### PR TITLE
Add baseUrl to tsconfig.json

### DIFF
--- a/packages/create-solid/templates/app-ts/tsconfig.json
+++ b/packages/create-solid/templates/app-ts/tsconfig.json
@@ -8,6 +8,7 @@
     "jsxImportSource": "solid-js",
     "jsx": "preserve",
     "types": ["vite/client"],
+    "baseUrl": "./",
     "paths": {
       "~/*": ["./src/*"]
     }


### PR DESCRIPTION
`baseUrl` is a required field if you use `paths`. I am sure a lot of tools will just assume the `tsconfig.json`'s current directory if it's missing, but it's technically required [as part of the spec](https://www.typescriptlang.org/tsconfig#paths) if you use `paths`. IntelliJ for one strictly conforms to this, and it won't work correctly without the `baseUrl`.

I won't be offended if you change `./` to `.`. Most people don't like to put on trailing slashes, but I like to always be explicit when I'm defining a directory!