### PR TITLE
Add root option to dev server

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -11,10 +11,11 @@ prog
   .command("dev")
   .describe("Start a development server")
   .option("-o, --open", "Open a browser tab", false)
+  .option("-r --root", "Root directory")
   .option("-p, --port", "Port to start server on", 3000)
-  .action(async ({ open, port }) => {
+  .action(async ({ open, port, root }) => {
     if (open) setTimeout(() => launch(port), 1000);
-    (await import("./runtime/devServer.js")).start({ port });
+    (await import("./runtime/devServer.js")).start({ port, root });
   });
 
 prog

--- a/packages/start/runtime/devServer.js
+++ b/packages/start/runtime/devServer.js
@@ -3,11 +3,11 @@ import http from "http";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import serverScripts from "./serverScripts.js";
-import { getBody } from "./utils.js"
+import { getBody } from "./utils.js";
 import vite from "vite";
 
 async function createServer(root = process.cwd()) {
-  const resolve = p => path.resolve(process.cwd(), p);
+  const resolve = p => path.resolve(root, p);
 
   const server = await vite.createServer({
     root,
@@ -71,7 +71,7 @@ async function createServer(root = process.cwd()) {
 }
 
 export function start(options) {
-  createServer().then(({ app }) =>
+  createServer(options.root).then(({ app }) =>
     app.listen(options.port, () => {
       console.log(`http://localhost:${options.port}`);
     })


### PR DESCRIPTION
The root parameter is defined in the createDevServer function, but it is not used in the CLI. The root option is necessary when working on multi-directory projects where the main folder is not necessarily the solidjs entry.