### PR TITLE
Root option added to plugin and config option added to CLI

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -12,10 +12,11 @@ prog
   .describe("Start a development server")
   .option("-o, --open", "Open a browser tab", false)
   .option("-r --root", "Root directory")
+  .option("-c, --config", "Vite config file")
   .option("-p, --port", "Port to start server on", 3000)
-  .action(async ({ open, port, root }) => {
+  .action(async ({ config, open, port, root }) => {
     if (open) setTimeout(() => launch(port), 1000);
-    (await import("./runtime/devServer.js")).start({ port, root });
+    (await import("./runtime/devServer.js")).start({ config, port, root });
   });
 
 prog

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -4,7 +4,13 @@ import path from "path";
 
 export default function StartPlugin(options) {
   options = Object.assign(
-    { adapter: "solid-start-node", ssr: true, preferStreaming: true, prerenderRoutes: [] },
+    {
+      adapter: "solid-start-node",
+      root: process.cwd(),
+      ssr: true,
+      preferStreaming: true,
+      prerenderRoutes: []
+    },
     options
   );
   return [
@@ -19,7 +25,7 @@ export default function StartPlugin(options) {
             alias: [
               {
                 find: "~",
-                replacement: path.join(process.cwd(), "src")
+                replacement: path.join(root, "src")
               }
             ]
           },
@@ -35,7 +41,7 @@ export default function StartPlugin(options) {
                   publicPath: "/",
                   routes: file => {
                     file = file
-                      .replace(path.join(process.cwd(), "src"), "")
+                      .replace(path.join(root, "src"), "")
                       .replace(/(index)?\.[tj]sx?$/, "");
                     if (!file.includes("/pages/")) return "*"; // commons
                     return "/" + file.replace("/pages/", "").toLowerCase();

--- a/packages/start/runtime/devServer.js
+++ b/packages/start/runtime/devServer.js
@@ -6,11 +6,12 @@ import serverScripts from "./serverScripts.js";
 import { getBody } from "./utils.js";
 import vite from "vite";
 
-async function createServer(root = process.cwd()) {
+async function createServer(root = process.cwd(), configFile) {
   const resolve = p => path.resolve(root, p);
 
   const server = await vite.createServer({
     root,
+    configFile,
     logLevel: "info",
     server: {
       middlewareMode: true
@@ -71,7 +72,7 @@ async function createServer(root = process.cwd()) {
 }
 
 export function start(options) {
-  createServer(options.root).then(({ app }) =>
+  createServer(options.root, options.config).then(({ app }) =>
     app.listen(options.port, () => {
       console.log(`http://localhost:${options.port}`);
     })


### PR DESCRIPTION
The plugin always resolves the paths in the root of the project. When the root option is added to the CLI, the plug-in keeps trying to resolve the files in the main folder.

In a multi-folder project, the need for multiple configuration files is common.