### PR TITLE
fix port config for dev

### DIFF
--- a/packages/start/components/Scripts.tsx
+++ b/packages/start/components/Scripts.tsx
@@ -10,7 +10,7 @@ function getFromManifest(manifest) {
 
 export default function Scripts() {
   const isDev = import.meta.env.MODE === "development";
-  const { manifest } = useContext(StartContext);
+  const { manifest, port } = useContext(StartContext);
   return (
     <>
       <HydrationScript />
@@ -18,11 +18,11 @@ export default function Scripts() {
         {isServer &&
           (isDev ? (
             <>
-              <script type="module" src="http://localhost:3000/@vite/client" $ServerOnly></script>
+              <script type="module" src={`http://localhost:${port || 3000}/@vite/client`} $ServerOnly></script>
               <script
                 type="module"
                 async
-                src="http://localhost:3000/node_modules/solid-start/runtime/entries/client.jsx"
+                src={`http://localhost:${port || 3000}/node_modules/solid-start/runtime/entries/client.jsx`}
                 $ServerOnly
               ></script>
             </>

--- a/packages/start/components/StartContext.tsx
+++ b/packages/start/components/StartContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "solid-js";
 
-export const StartContext = createContext<{ manifest?: {}; context: {} }>({});
+export const StartContext = createContext<{ manifest?: {}; context: {}, port?: number }>({});
 
 export function StartProvider(props) {
   return <StartContext.Provider value={props}>{props.children}</StartContext.Provider>;

--- a/packages/start/runtime/devServer.js
+++ b/packages/start/runtime/devServer.js
@@ -7,7 +7,7 @@ import fetch from "node-fetch";
 
 globalThis.fetch || (globalThis.fetch = fetch);
 
-async function createServer(root = process.cwd(), configFile) {
+async function createServer(root = process.cwd(), configFile, port) {
   const server = await vite.createServer({
     root,
     configFile,
@@ -39,7 +39,7 @@ async function createServer(root = process.cwd(), configFile) {
 
         res.statusCode = 200;
         res.setHeader("content-type", "text/html");
-        render({ url: req.url, writable: res });
+        render({ url: req.url, writable: res, port: port });
       } catch (e) {
         server && server.ssrFixStacktrace(e);
         console.log(e.stack);
@@ -53,7 +53,7 @@ async function createServer(root = process.cwd(), configFile) {
 }
 
 export function start(options) {
-  createServer(options.root, options.config).then(({ app }) =>
+  createServer(options.root, options.config, options.port).then(({ app }) =>
     app.listen(options.port, () => {
       console.log(`http://localhost:${options.port}`);
     })

--- a/packages/start/runtime/entries/nodeStream.jsx
+++ b/packages/start/runtime/entries/nodeStream.jsx
@@ -5,10 +5,10 @@ import Root from "~/root";
 import { StartProvider } from "../../components";
 import renderActions from "../actionsServer";
 
-export function render({ url, writable, manifest }) {
+export function render({ url, writable, manifest, port }) {
   const context = { tags: [] };
   const Start = props => (
-    <StartProvider context={context} manifest={manifest}>
+    <StartProvider context={context} manifest={manifest} port={port}>
       <MetaProvider tags={context.tags}>
         <Router url={url} out={context}>
           {props.children}


### PR DESCRIPTION
Hi!
Noticed that `3000 port` was hardcoded for `solid-start dev` :(
Here is an option to pass a port from CLI params to Scripts area.

P.S.: This is just a suggestion for improvement, so I'm open for any comments. 