### PR TITLE
Handle empty matches

### DIFF
--- a/packages/start/components/Links.tsx
+++ b/packages/start/components/Links.tsx
@@ -4,7 +4,7 @@ import { StartContext } from "./StartContext";
 
 function getAssetsFromManifest(manifest, context) {
   let path = mapRouteToFile(context.matches[0]);
-  const match = manifest[path];
+  const match = manifest[path] || [];
   return Object.values(
     match.reduce((r, src) => {
       r[src.href] =


### PR DESCRIPTION
I'm not sure what situation causes this but I've noticed when I have more than 1 page, this function fails because `match` is empty.  Wanted to propose this as a starting point to fix this issue