### PR TITLE
Missed dependency in solid-start module

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "node-fetch": "^2.6.6",
+    "rollup": "^2.0.0",
     "rollup-route-manifest": "^1.0.0",
     "sade": "^1.7.4",
     "solid-ssr": "^1.2.6",


### PR DESCRIPTION
solid-start using rollup-route-manifest without rollup

![image](https://user-images.githubusercontent.com/17812651/148087321-e81970a7-3a05-4c4d-8108-5fe8319e0dbb.png)