### PR TITLE
fix URL to file path conversion on windows in plugin.js

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -42,7 +42,7 @@ export default function StartPlugin(options) {
           ].join("|")})");`;
         } else if (id === SOLID_START_ROUTES_MODULE_ID) {
           return fs
-            .readFileSync(path.dirname(new URL(import.meta.url).pathname) + "/routes.js", "utf8")
+            .readFileSync(new URL("./routes.js", import.meta.url), "utf8")
             .replaceAll(
               "$EXTENSIONS",
               [


### PR DESCRIPTION
on windows, `fileUrl.pathname` for absolute file URLs produces a pathname with leading `/` before the drive letter, like

```
 /C:/Users/me/src/solid-next/node_modules/solid-start/plugin.js
```

which is invalid path on windows, see the discussion about this in https://github.com/nodejs/node/issues/23026

Fortunately, `readFileSync` accepts file URLs as well, so there's no need for URL -> path conversion