### PR TITLE
feat: using our custom route walker using fast-glob

### DIFF
--- a/examples/basic-ts/package.json
+++ b/examples/basic-ts/package.json
@@ -7,11 +7,12 @@
   },
   "type": "module",
   "devDependencies": {
+    "node-fetch": "^3.1.0",
     "solid-app-router": "^0.2.0",
     "solid-js": "^1.3.0",
     "solid-meta": "^0.27.3",
-    "solid-start": "next",
-    "solid-start-node": "next",
+    "solid-start": "workspace:^0.1.0-alpha.51",
+    "solid-start-node": "workspace:^0.1.0-alpha.51",
     "typescript": "^4.4.3",
     "vite": "^2.7.10",
     "vite-plugin-inspect": "^0.3.13"

--- a/examples/with-mdx-ts/package.json
+++ b/examples/with-mdx-ts/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "devDependencies": {
     "@mdx-js/rollup": "^2.0.0-rc.1",
+    "node-fetch": "^3.1.0",
     "solid-app-router": "^0.2.0",
     "solid-js": "^1.3.0",
     "solid-mdx": "^0.0.5",

--- a/examples/with-mdx-ts/package.json
+++ b/examples/with-mdx-ts/package.json
@@ -12,8 +12,8 @@
     "solid-js": "^1.3.0",
     "solid-mdx": "^0.0.5",
     "solid-meta": "^0.27.3",
-    "solid-start": "next",
-    "solid-start-node": "next",
+    "solid-start": "workspace:^0.1.0-alpha.51",
+    "solid-start-node": "workspace:^0.1.0-alpha.51",
     "typescript": "^4.4.3",
     "vite": "^2.7.10",
     "vite-plugin-inspect": "^0.3.13"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "solid-start",
+  "name": "solid-start-monorepo",
   "description": "Official starter for SolidJS",
   "version": "0.1.0",
   "author": "Ryan Carniato",

--- a/packages/start-node/index.js
+++ b/packages/start-node/index.js
@@ -15,29 +15,27 @@ export default function () {
     async build(config) {
       const { preferStreaming } = config.solidOptions;
       const __dirname = dirname(fileURLToPath(import.meta.url));
-      await Promise.all([
-        vite.build({
-          build: {
-            outDir: "./dist/",
-            minify: "terser",
-            rollupOptions: {
-              input: `node_modules/solid-start/runtime/entries/client.tsx`
+      await vite.build({
+        build: {
+          outDir: "./dist/",
+          minify: "terser",
+          rollupOptions: {
+            input: `node_modules/solid-start/runtime/entries/client.tsx`
+          }
+        }
+      });
+      await vite.build({
+        build: {
+          ssr: true,
+          outDir: "./.solid/server",
+          rollupOptions: {
+            input: `node_modules/solid-start/runtime/entries/server.tsx`,
+            output: {
+              format: "esm"
             }
           }
-        }),
-        vite.build({
-          build: {
-            ssr: true,
-            outDir: "./.solid/server",
-            rollupOptions: {
-              input: `node_modules/solid-start/runtime/entries/server.tsx`,
-              output: {
-                format: "esm"
-              }
-            }
-          }
-        })
-      ]);
+        }
+      });
       copyFileSync(
         join(config.root, ".solid", "server", `server.js`),
         join(config.root, ".solid", "server", "app.js")

--- a/packages/start-node/package.json
+++ b/packages/start-node/package.json
@@ -14,9 +14,11 @@
     "sirv": "^1.0.12"
   },
   "devDependencies": {
-    "solid-start": "^0.1.0-alpha.51"
+    "solid-start": "^0.1.0-alpha.51",
+    "vite": "^2.7.10"
   },
   "peerDependencies": {
-    "solid-start": "*"
+    "solid-start": "*",
+    "vite": "*"
   }
 }

--- a/packages/start/components/Outlet.tsx
+++ b/packages/start/components/Outlet.tsx
@@ -1,5 +1,7 @@
 /// <reference path="../types.d.ts" />
 
 import { useRoutes } from "solid-app-router";
-import routes from "virtual:solid-start/routes";
+// @ts-expect-error
+const routes = $ROUTES;
+console.log(routes);
 export default useRoutes(routes);

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -33,6 +33,7 @@
     "solid-app-router": "^0.2.0",
     "solid-js": "^1.3.1",
     "solid-meta": "^0.27.3",
+    "solid-start-node": "workspace:^0.1.0-alpha.51",
     "vite": "^2.7.10"
   },
   "peerDependencies": {
@@ -40,5 +41,8 @@
     "solid-js": "^1.3.0",
     "solid-meta": "^0.27.2",
     "vite": "^2.7.1"
+  },
+  "optionalDependencies": {
+    "solid-start-node": "*"
   }
 }

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -19,6 +19,9 @@
     "runtime"
   ],
   "dependencies": {
+    "es-module-lexer": "^0.9.3",
+    "esbuild": "^0.14.11",
+    "fast-glob": "^3.2.10",
     "node-fetch": "^2.6.6",
     "rollup": "^2.0.0",
     "rollup-route-manifest": "^1.0.0",

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -2,11 +2,7 @@ import path from "path";
 import manifest from "rollup-route-manifest";
 import solid from "vite-plugin-solid";
 import fs from "fs";
-
-const SOLID_START_DATA_MODULE_ID = "virtual:solid-start/data";
-const SOLID_START_PAGES_MODULE_ID = "virtual:solid-start/pages";
-const SOLID_START_ROUTES_MODULE_ID = "virtual:solid-start/routes";
-
+import { getRoutes, stringifyRoutes } from "./routes.js";
 export default function StartPlugin(options) {
   options = Object.assign(
     {
@@ -17,40 +13,29 @@ export default function StartPlugin(options) {
     },
     options
   );
+
   return [
     solid(options),
     {
       name: "solid-start",
       mode: "pre",
-      resolveId(id, referrer) {
-        if (id === SOLID_START_DATA_MODULE_ID) {
-          return id;
-        } else if (id === SOLID_START_PAGES_MODULE_ID) {
-          return id;
-        } else if (id === SOLID_START_ROUTES_MODULE_ID) {
-          return id;
-        }
-      },
-      load(id) {
-        if (id === SOLID_START_DATA_MODULE_ID) {
-          return `export default import.meta.globEager("/src/pages/**/*.data.(js|ts)");`;
-        } else if (id === SOLID_START_PAGES_MODULE_ID) {
-          return `export default import.meta.glob("/src/pages/**/*.(${[
-            "jsx",
-            "tsx",
-            ...(options?.extensions ?? []).map(e => (Array.isArray(e) ? e[0].slice(1) : e.slice(1)))
-          ].join("|")})");`;
-        } else if (id === SOLID_START_ROUTES_MODULE_ID) {
+      async load(id) {
+        if (id.endsWith("components/Outlet.tsx")) {
+          const routes = await getRoutes({
+            pageExtensions: [
+              "tsx",
+              "jsx",
+              "js",
+              "ts",
+              ...(options.extensions?.map(s => s.slice(1)) ?? [])
+            ]
+          });
+
           return fs
-            .readFileSync(new URL("./routes.js", import.meta.url), "utf8")
-            .replaceAll(
-              "$EXTENSIONS",
-              [
-                ".jsx",
-                ".tsx",
-                ...(options?.extensions ?? []).map(e => (Array.isArray(e) ? e[0] : e))
-              ].join("|")
-            );
+            .readFileSync(id, {
+              encoding: "utf-8"
+            })
+            .replace("const routes = $ROUTES;", stringifyRoutes(routes));
         }
       },
       config(conf) {

--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -1,48 +1,135 @@
-// This file is used a virtual module to load the data and pages using glob imports,
-// then processing them into a format that is compatible with the solid-app-router
-// useRoutes hook
-import { lazy } from "solid-js";
+import fg from "fast-glob";
+import fs from "fs";
+import { init, parse } from "es-module-lexer";
+import esbuild from "esbuild";
 
-import dataModules from "virtual:solid-start/data";
-import pages from "virtual:solid-start/pages";
+export async function getRoutes({
+  baseDir = "src/pages",
+  pageExtensions = ["jsx", "tsx", "js", "ts"],
+  cwd = process.cwd()
+} = {}) {
+  await init;
+  const pageRoutes = fg.sync(
+    [`${baseDir}/**/*.(${pageExtensions.join("|")})`, `!${baseDir}/**/*.data.(ts|js)`],
+    {
+      cwd
+    }
+  );
 
-function toIdentifier(source) {
-  // $EXTENSIONS will be replaced by the extensions list
-  // by the solid-start vite plugin
-  return source.slice(10).replace(/(index)?($EXTENSIONS|.data.js|.data.ts)/, "");
+  const dataRoutes = fg.sync(`${baseDir}/**/*.data.(ts|js)`, { cwd });
+
+  const regex = new RegExp(`(index)?(.(${pageExtensions.join("|")})|.data.js|.data.ts)`);
+
+  function toIdentifier(source) {
+    return source.slice(baseDir.length).replace(regex, "");
+  }
+
+  function toPath(id) {
+    return id.replace(/\[(.+)\]/, (_, m) => (m.startsWith("...") ? `*${m.slice(3)}` : `:${m}`));
+  }
+
+  const data = dataRoutes.reduce((memo, file) => {
+    memo[toIdentifier(file)] = file;
+    return memo;
+  }, {});
+
+  // processRoute populates the routesList with the given route.
+  // if checks if a parent route exists and if it does, it adds the route to the parent's children.
+  // it also checks that if a file is a javascript/typescript file, it must have a default export to be
+  // considered a route
+  function processRoute(routesList, src, id, full) {
+    let parentRoute = routesList.find(o => o._id && o._id !== "/" && id.startsWith(o._id + "/"));
+
+    if (/\.(js|ts)x?$/.test(src)) {
+      let [imports, exports] = parse(
+        esbuild.transformSync(fs.readFileSync(process.cwd() + "/" + src).toString(), {
+          jsx: "transform",
+          format: "esm",
+          loader: "tsx"
+        }).code
+      );
+      if (!exports.includes("default")) {
+        return;
+      }
+    }
+
+    if (!parentRoute) {
+      routesList.push({
+        src: src,
+        _id: id,
+        path: toPath(id) || "/",
+        componentSrc: src,
+        type: "PAGE"
+        // dataSrc: data[full] ? data[full] : exports.includes("data") ? src + "?data" : undefined
+        // methods: ["GET", ...(exports.includes("action") ? ["POST", "PATCH", "DELETE"] : [])]
+        // actionSrc: exports.includes("action") ? src + "?action" : undefined,
+        // loaderSrc: exports.includes("loader") ? src + "?loader" : undefined
+      });
+    } else {
+      processRoute(
+        parentRoute.children || (parentRoute.children = []),
+        src,
+        id.slice(parentRoute._id.length),
+        full
+      );
+    }
+  }
+
+  const routes = pageRoutes.reduce((r, file) => {
+    let id = toIdentifier(file);
+    processRoute(r, file, id, id);
+    return r;
+  }, []);
+
+  return {
+    pageRoutes: routes
+  };
 }
 
-function toPath(id) {
-  return id.replace(/\[(.+)\]/, (_, m) => (m.startsWith("...") ? `*${m.slice(3)}` : `:${m}`));
-}
+export function stringifyRoutes(routes) {
+  let imports = new Map();
+  let vars = 0;
 
-const data = Object.entries(dataModules).reduce((memo, [key, value]) => {
-  memo[toIdentifier(key)] = value;
-  return memo;
-}, {});
-
-function findNestedPath(list, id, full, component) {
-  let temp = list.find(o => o._id && o._id !== "/" && id.startsWith(o._id + "/"));
-  if (!temp)
-    list.push({
-      _id: id,
-      path: toPath(id) || "/",
-      component,
-      data: data[full] ? data[full].default : undefined
+  function addImport(p) {
+    let d = "data" + vars++;
+    imports.set(p, {
+      default: d
     });
-  else
-    findNestedPath(
-      temp.children || (temp.children = []),
-      id.slice(temp._id.length),
-      full,
-      component
+    return d;
+  }
+
+  function _stringifyRoutes(r) {
+    return (
+      `[\n` +
+      r
+        .map(
+          i =>
+            `{ ${[
+              i.dataSrc?.endsWith(".data.js")
+                ? `data: ${addImport(process.cwd() + "/" + i.dataSrc)}`
+                : undefined,
+              `component: lazy(() => import('${process.cwd() + "/" + i.componentSrc}'))`,
+              ...Object.keys(i)
+                .filter(k => i[k] !== undefined)
+                .map(
+                  k => `${k}: ${k === "children" ? _stringifyRoutes(i[k]) : JSON.stringify(i[k])}`
+                )
+            ]
+              .filter(Boolean)
+              .join(", ")} }`
+        )
+        .join(",") +
+      `\n]`
     );
+  }
+
+  let r = _stringifyRoutes(routes.pageRoutes);
+  console.log(
+    [...imports.keys()].map(i => `import ${imports.get(i).default} from '${i}';`).join("\n")
+  );
+  const text = `
+  import { lazy } from 'solid-js';
+  ${[...imports.keys()].map(i => `import ${imports.get(i).default} from '${i}';`).join("\n")}
+  const routes = ${r};`;
+  return text;
 }
-
-const routes = Object.entries(pages).reduce((r, [key, fn]) => {
-  let id = toIdentifier(key);
-  findNestedPath(r, id, id, lazy(fn));
-  return r;
-}, []);
-
-export default routes;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,15 +24,17 @@ importers:
 
   examples/basic-ts:
     specifiers:
+      node-fetch: ^3.1.0
       solid-app-router: ^0.2.0
       solid-js: ^1.3.0
       solid-meta: ^0.27.3
-      solid-start: next
-      solid-start-node: next
+      solid-start: workspace:^0.1.0-alpha.51
+      solid-start-node: workspace:^0.1.0-alpha.51
       typescript: ^4.4.3
       vite: ^2.7.10
       vite-plugin-inspect: ^0.3.13
     devDependencies:
+      node-fetch: 3.1.0
       solid-app-router: 0.2.0_solid-js@1.3.1
       solid-js: 1.3.1
       solid-meta: 0.27.3_solid-js@1.3.1
@@ -2320,6 +2322,11 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
+  /data-uri-to-buffer/4.0.0:
+    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
+    engines: {node: '>= 12'}
+    dev: true
+
   /dateformat/3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
     dev: true
@@ -3000,6 +3007,13 @@ packages:
     dependencies:
       reusify: 1.0.4
 
+  /fetch-blob/3.1.3:
+    resolution: {integrity: sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      web-streams-polyfill: 3.2.0
+    dev: true
+
   /figures/3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -3049,6 +3063,13 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.34
+    dev: true
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.1.3
     dev: true
 
   /fs-extra/9.1.0:
@@ -4719,6 +4740,15 @@ packages:
     engines: {node: 4.x || >=6.0.0}
     dependencies:
       whatwg-url: 5.0.0
+
+  /node-fetch/3.1.0:
+    resolution: {integrity: sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.0
+      fetch-blob: 3.1.3
+      formdata-polyfill: 4.0.10
+    dev: true
 
   /node-gyp/5.1.1:
     resolution: {integrity: sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==}
@@ -6619,6 +6649,11 @@ packages:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
     dependencies:
       defaults: 1.0.3
+    dev: true
+
+  /web-streams-polyfill/3.2.0:
+    resolution: {integrity: sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /webidl-conversions/3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
       solid-js: ^1.3.0
       solid-mdx: ^0.0.5
       solid-meta: ^0.27.3
-      solid-start: next
-      solid-start-node: next
+      solid-start: workspace:^0.1.0-alpha.51
+      solid-start-node: workspace:^0.1.0-alpha.51
       typescript: ^4.4.3
       vite: ^2.7.10
       vite-plugin-inspect: ^0.3.13
@@ -110,6 +110,9 @@ importers:
 
   packages/start:
     specifiers:
+      es-module-lexer: ^0.9.3
+      esbuild: ^0.14.11
+      fast-glob: ^3.2.10
       node-fetch: ^2.6.6
       rollup: ^2.0.0
       rollup-route-manifest: ^1.0.0
@@ -118,15 +121,21 @@ importers:
       solid-js: ^1.3.1
       solid-meta: ^0.27.3
       solid-ssr: ^1.3.0
+      solid-start-node: '*'
       vite: ^2.7.10
       vite-plugin-solid: ^2.2.1
     dependencies:
+      es-module-lexer: 0.9.3
+      esbuild: 0.14.11
+      fast-glob: 3.2.10
       node-fetch: 2.6.6
       rollup: 2.63.0
       rollup-route-manifest: 1.0.0_rollup@2.63.0
       sade: 1.8.1
       solid-ssr: 1.3.1
       vite-plugin-solid: 2.2.1
+    optionalDependencies:
+      solid-start-node: link:../start-node
     devDependencies:
       solid-app-router: 0.2.0_solid-js@1.3.1
       solid-js: 1.3.1
@@ -140,7 +149,7 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^13.0.2
       rollup: ^2.53.3
-      solid-start: ^0.1.0-alpha.50
+      solid-start: ^0.1.0-alpha.51
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.63.0
@@ -148,7 +157,7 @@ importers:
       '@rollup/plugin-node-resolve': 13.1.3_rollup@2.63.0
       rollup: 2.63.0
     devDependencies:
-      solid-start: link:../..
+      solid-start: 0.1.0-y.0_rollup@2.63.0
 
   packages/start-netlify:
     specifiers:
@@ -158,7 +167,7 @@ importers:
       encoding: ^0.1.13
       node-fetch: ^2.6.1
       rollup: ^2.53.3
-      solid-start: ^0.1.0-alpha.50
+      solid-start: ^0.1.0-alpha.51
     dependencies:
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.63.0
       '@rollup/plugin-json': 4.1.0_rollup@2.63.0
@@ -167,7 +176,7 @@ importers:
       node-fetch: 2.6.6
       rollup: 2.63.0
     devDependencies:
-      solid-start: link:../..
+      solid-start: 0.1.0-y.0_rollup@2.63.0
 
   packages/start-node:
     specifiers:
@@ -179,7 +188,8 @@ importers:
       polka: ^1.0.0-next.13
       rollup: ^2.53.3
       sirv: ^1.0.12
-      solid-start: ^0.1.0-alpha.50
+      solid-start: ^0.1.0-alpha.51
+      vite: ^2.7.10
     dependencies:
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.63.0
       '@rollup/plugin-json': 4.1.0_rollup@2.63.0
@@ -190,18 +200,19 @@ importers:
       rollup: 2.63.0
       sirv: 1.0.19
     devDependencies:
-      solid-start: link:../..
+      solid-start: 0.1.0-y.0_rollup@2.63.0+vite@2.7.10
+      vite: 2.7.10
 
   packages/start-static:
     specifiers:
       node-fetch: ^2.6.1
       sirv-cli: 1.0.12
-      solid-start: ^0.1.0-alpha.50
+      solid-start: ^0.1.0-alpha.51
     dependencies:
       node-fetch: 2.6.6
       sirv-cli: 1.0.12
     devDependencies:
-      solid-start: link:../..
+      solid-start: 0.1.0-y.0_rollup@2.63.0
 
   packages/start-vercel:
     specifiers:
@@ -209,14 +220,14 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^13.0.2
       rollup: ^2.53.3
-      solid-start: ^0.1.0-alpha.50
+      solid-start: ^0.1.0-alpha.51
     dependencies:
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.63.0
       '@rollup/plugin-json': 4.1.0_rollup@2.63.0
       '@rollup/plugin-node-resolve': 13.1.3_rollup@2.63.0
       rollup: 2.63.0
     devDependencies:
-      solid-start: link:../..
+      solid-start: 0.1.0-y.0_rollup@2.63.0
 
 packages:
 
@@ -229,7 +240,6 @@ packages:
   /@babel/compat-data/7.16.4:
     resolution: {integrity: sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/core/7.16.7:
     resolution: {integrity: sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==}
@@ -252,7 +262,6 @@ packages:
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/generator/7.16.7:
     resolution: {integrity: sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==}
@@ -261,14 +270,12 @@ packages:
       '@babel/types': 7.16.7
       jsesc: 2.5.2
       source-map: 0.5.7
-    dev: false
 
   /@babel/helper-annotate-as-pure/7.16.7:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-compilation-targets/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==}
@@ -281,7 +288,6 @@ packages:
       '@babel/helper-validator-option': 7.16.7
       browserslist: 4.19.1
       semver: 6.3.0
-    dev: false
 
   /@babel/helper-create-class-features-plugin/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==}
@@ -299,14 +305,12 @@ packages:
       '@babel/helper-split-export-declaration': 7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-environment-visitor/7.16.7:
     resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-function-name/7.16.7:
     resolution: {integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==}
@@ -315,28 +319,24 @@ packages:
       '@babel/helper-get-function-arity': 7.16.7
       '@babel/template': 7.16.7
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-get-function-arity/7.16.7:
     resolution: {integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-hoist-variables/7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-member-expression-to-functions/7.16.7:
     resolution: {integrity: sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-module-imports/7.16.0:
     resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
@@ -350,7 +350,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-module-transforms/7.16.7:
     resolution: {integrity: sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==}
@@ -366,19 +365,16 @@ packages:
       '@babel/types': 7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-optimise-call-expression/7.16.7:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-plugin-utils/7.16.7:
     resolution: {integrity: sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-replace-supers/7.16.7:
     resolution: {integrity: sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==}
@@ -391,21 +387,18 @@ packages:
       '@babel/types': 7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-simple-access/7.16.7:
     resolution: {integrity: sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-split-export-declaration/7.16.7:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/helper-validator-identifier/7.16.7:
     resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
@@ -414,7 +407,6 @@ packages:
   /@babel/helper-validator-option/7.16.7:
     resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helpers/7.16.7:
     resolution: {integrity: sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==}
@@ -425,7 +417,6 @@ packages:
       '@babel/types': 7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/highlight/7.16.7:
     resolution: {integrity: sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==}
@@ -439,7 +430,6 @@ packages:
     resolution: {integrity: sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dev: false
 
   /@babel/plugin-syntax-jsx/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==}
@@ -449,7 +439,6 @@ packages:
     dependencies:
       '@babel/core': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-typescript/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==}
@@ -459,7 +448,6 @@ packages:
     dependencies:
       '@babel/core': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-transform-typescript/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-Hzx1lvBtOCWuCEwMmYOfpQpO7joFeXLgoPuzZZBtTxXqSqUGUubvFGZv2ygo1tB5Bp9q6PXV3H0E/kf7KM0RLA==}
@@ -473,7 +461,6 @@ packages:
       '@babel/plugin-syntax-typescript': 7.16.7_@babel+core@7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-typescript/7.16.7_@babel+core@7.16.7:
     resolution: {integrity: sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==}
@@ -487,7 +474,6 @@ packages:
       '@babel/plugin-transform-typescript': 7.16.7_@babel+core@7.16.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/template/7.16.7:
     resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
@@ -496,7 +482,6 @@ packages:
       '@babel/code-frame': 7.16.7
       '@babel/parser': 7.16.7
       '@babel/types': 7.16.7
-    dev: false
 
   /@babel/traverse/7.16.7:
     resolution: {integrity: sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==}
@@ -514,7 +499,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/types/7.16.7:
     resolution: {integrity: sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==}
@@ -522,7 +506,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
-    dev: false
 
   /@cloudflare/kv-asset-handler/0.1.3:
     resolution: {integrity: sha512-FNcunDuTmEfQTLRLtA6zz+buIXUHj1soPvSWzzQFBC+n2lsy+CGf/NIrR3SEPCmsVNQj70/Jx2lViCpq+09YpQ==}
@@ -1263,12 +1246,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
   /@nodelib/fs.stat/2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
   /@nodelib/fs.walk/1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -1276,7 +1257,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
-    dev: true
 
   /@npmcli/ci-detect/1.4.0:
     resolution: {integrity: sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==}
@@ -1810,6 +1790,16 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
+  /babel-plugin-jsx-dom-expressions/0.26.3_@babel+core@7.16.7:
+    resolution: {integrity: sha512-TtcqjKrCzP9m8eMKBTxwdqTK5PlySn6+mYt6vJTbgQ7cCNtnurLUqPFN+ObG1dY60D2ZgUGc86/7O6plXDjsXg==}
+    dependencies:
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/plugin-syntax-jsx': 7.16.7_@babel+core@7.16.7
+      '@babel/types': 7.16.7
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: true
+
   /babel-plugin-jsx-dom-expressions/0.31.5_@babel+core@7.16.7:
     resolution: {integrity: sha512-Rg+tUQmuBe74l6+GUKyVsBjAQbmBKultSLA6Py7lANp8oWRdmipegzgL4QhFxjvmmvw+w5z2JRD3xQomyl5Sww==}
     dependencies:
@@ -1820,6 +1810,14 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
     dev: false
+
+  /babel-preset-solid/0.26.5_@babel+core@7.16.7:
+    resolution: {integrity: sha512-SXMSmp3iL3FTbcy2QB4poHSbsPMrNSHOk8vIgQSMI/8UwxbxjjAG1iDDcqjsgWw6DqndxM6Z6nID9+94aT8NCQ==}
+    dependencies:
+      babel-plugin-jsx-dom-expressions: 0.26.3_@babel+core@7.16.7
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: true
 
   /babel-preset-solid/1.3.1_@babel+core@7.16.7:
     resolution: {integrity: sha512-72mgWT7FR8siIUV4xALXKQzKbJDPo2b4bUZqQhzPXbN5XoTVQfKrRRgGgQFKtf3ClWW8/HYnFzjRe49QTnusWA==}
@@ -1864,7 +1862,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /browserslist/4.19.1:
     resolution: {integrity: sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==}
@@ -1876,7 +1873,6 @@ packages:
       escalade: 3.1.1
       node-releases: 2.0.1
       picocolors: 1.0.0
-    dev: false
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1975,7 +1971,6 @@ packages:
 
   /caniuse-lite/1.0.30001297:
     resolution: {integrity: sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==}
-    dev: false
 
   /caseless/0.12.0:
     resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
@@ -2272,7 +2267,6 @@ packages:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: false
 
   /core-util-is/1.0.2:
     resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
@@ -2497,7 +2491,6 @@ packages:
 
   /electron-to-chromium/1.4.38:
     resolution: {integrity: sha512-WhHt3sZazKj0KK/UpgsbGQnUUoFeAHVishzHFExMxagpZgjiGYSC9S0ZlbhCfSH2L2i+2A1yyqOIliTctMx7KQ==}
-    dev: false
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2562,6 +2555,10 @@ packages:
       unbox-primitive: 1.0.1
     dev: true
 
+  /es-module-lexer/0.9.3:
+    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+    dev: false
+
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
@@ -2578,11 +2575,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-android-arm64/0.14.11:
+    resolution: {integrity: sha512-6iHjgvMnC/SzDH8TefL+/3lgCjYWwAd1LixYfmz/TBPbDQlxcuSkX0yiQgcJB9k+ibZ54yjVXziIwGdlc+6WNw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-darwin-64/0.13.15:
     resolution: {integrity: sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /esbuild-darwin-64/0.14.11:
+    resolution: {integrity: sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.13.15:
@@ -2592,11 +2605,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-darwin-arm64/0.14.11:
+    resolution: {integrity: sha512-Jj0ieWLREPBYr/TZJrb2GFH8PVzDqiQWavo1pOFFShrcmHWDBDrlDxPzEZ67NF/Un3t6sNNmeI1TUS/fe1xARg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-freebsd-64/0.13.15:
     resolution: {integrity: sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /esbuild-freebsd-64/0.14.11:
+    resolution: {integrity: sha512-C5sT3/XIztxxz/zwDjPRHyzj/NJFOnakAanXuyfLDwhwupKPd76/PPHHyJx6Po6NI6PomgVp/zi6GRB8PfrOTA==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.13.15:
@@ -2606,11 +2635,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-freebsd-arm64/0.14.11:
+    resolution: {integrity: sha512-y3Llu4wbs0bk4cwjsdAtVOesXb6JkdfZDLKMt+v1U3tOEPBdSu6w8796VTksJgPfqvpX22JmPLClls0h5p+L9w==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-32/0.13.15:
     resolution: {integrity: sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-32/0.14.11:
+    resolution: {integrity: sha512-Cg3nVsxArjyLke9EuwictFF3Sva+UlDTwHIuIyx8qpxRYAOUTmxr2LzYrhHyTcGOleLGXUXYsnUVwKqnKAgkcg==}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-64/0.13.15:
@@ -2620,11 +2665,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-64/0.14.11:
+    resolution: {integrity: sha512-oeR6dIrrojr8DKVrxtH3xl4eencmjsgI6kPkDCRIIFwv4p+K7ySviM85K66BN01oLjzthpUMvBVfWSJkBLeRbg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-arm/0.13.15:
     resolution: {integrity: sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-arm/0.14.11:
+    resolution: {integrity: sha512-vcwskfD9g0tojux/ZaTJptJQU3a7YgTYsptK1y6LQ/rJmw7U5QJvboNawqM98Ca3ToYEucfCRGbl66OTNtp6KQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.13.15:
@@ -2634,11 +2695,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-arm64/0.14.11:
+    resolution: {integrity: sha512-+e6ZCgTFQYZlmg2OqLkg1jHLYtkNDksxWDBWNtI4XG4WxuOCUErLqfEt9qWjvzK3XBcCzHImrajkUjO+rRkbMg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-mips64le/0.13.15:
     resolution: {integrity: sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.11:
+    resolution: {integrity: sha512-Rrs99L+p54vepmXIb87xTG6ukrQv+CzrM8eoeR+r/OFL2Rg8RlyEtCeshXJ2+Q66MXZOgPJaokXJZb9snq28bw==}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.13.15:
@@ -2648,11 +2725,35 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-ppc64le/0.14.11:
+    resolution: {integrity: sha512-JyzziGAI0D30Vyzt0HDihp4s1IUtJ3ssV2zx9O/c+U/dhUHVP2TmlYjzCfCr2Q6mwXTeloDcLS4qkyvJtYptdQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-s390x/0.14.11:
+    resolution: {integrity: sha512-DoThrkzunZ1nfRGoDN6REwmo8ZZWHd2ztniPVIR5RMw/Il9wiWEYBahb8jnMzQaSOxBsGp0PbyJeVLTUatnlcw==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-netbsd-64/0.13.15:
     resolution: {integrity: sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.11:
+    resolution: {integrity: sha512-12luoRQz+6eihKYh1zjrw0CBa2aw3twIiHV/FAfjh2NEBDgJQOY4WCEUEN+Rgon7xmLh4XUxCQjnwrvf8zhACw==}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.13.15:
@@ -2662,11 +2763,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-openbsd-64/0.14.11:
+    resolution: {integrity: sha512-l18TZDjmvwW6cDeR4fmizNoxndyDHamGOOAenwI4SOJbzlJmwfr0jUgjbaXCUuYVOA964siw+Ix+A+bhALWg8Q==}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-sunos-64/0.13.15:
     resolution: {integrity: sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    optional: true
+
+  /esbuild-sunos-64/0.14.11:
+    resolution: {integrity: sha512-bmYzDtwASBB8c+0/HVOAiE9diR7+8zLm/i3kEojUH2z0aIs6x/S4KiTuT5/0VKJ4zk69kXel1cNWlHBMkmavQg==}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-32/0.13.15:
@@ -2676,6 +2793,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-windows-32/0.14.11:
+    resolution: {integrity: sha512-J1Ys5hMid8QgdY00OBvIolXgCQn1ARhYtxPnG6ESWNTty3ashtc4+As5nTrsErnv8ZGUcWZe4WzTP/DmEVX1UQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-64/0.13.15:
     resolution: {integrity: sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==}
     cpu: [x64]
@@ -2683,11 +2808,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-windows-64/0.14.11:
+    resolution: {integrity: sha512-h9FmMskMuGeN/9G9+LlHPAoiQk9jlKDUn9yA0MpiGzwLa82E7r1b1u+h2a+InprbSnSLxDq/7p5YGtYVO85Mlg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-arm64/0.13.15:
     resolution: {integrity: sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.11:
+    resolution: {integrity: sha512-dZp7Krv13KpwKklt9/1vBFBMqxEQIO6ri7Azf8C+ob4zOegpJmha2XY9VVWP/OyQ0OWk6cEeIzMJwInRZrzBUQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild/0.13.15:
@@ -2712,6 +2853,31 @@ packages:
       esbuild-windows-32: 0.13.15
       esbuild-windows-64: 0.13.15
       esbuild-windows-arm64: 0.13.15
+
+  /esbuild/0.14.11:
+    resolution: {integrity: sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-arm64: 0.14.11
+      esbuild-darwin-64: 0.14.11
+      esbuild-darwin-arm64: 0.14.11
+      esbuild-freebsd-64: 0.14.11
+      esbuild-freebsd-arm64: 0.14.11
+      esbuild-linux-32: 0.14.11
+      esbuild-linux-64: 0.14.11
+      esbuild-linux-arm: 0.14.11
+      esbuild-linux-arm64: 0.14.11
+      esbuild-linux-mips64le: 0.14.11
+      esbuild-linux-ppc64le: 0.14.11
+      esbuild-linux-s390x: 0.14.11
+      esbuild-netbsd-64: 0.14.11
+      esbuild-openbsd-64: 0.14.11
+      esbuild-sunos-64: 0.14.11
+      esbuild-windows-32: 0.14.11
+      esbuild-windows-64: 0.14.11
+      esbuild-windows-arm64: 0.14.11
+    dev: false
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -2803,6 +2969,17 @@ packages:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
 
+  /fast-glob/3.2.10:
+    resolution: {integrity: sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.4
+    dev: false
+
   /fast-glob/3.2.9:
     resolution: {integrity: sha512-MBwILhhD92sziIrMQwpqcuGERF+BH99ei2a3XsGJuqEKcSycAL+w0HWokFenZXona+kjFr82Lf71eTxNRC06XQ==}
     engines: {node: '>=8.6.0'}
@@ -2822,7 +2999,6 @@ packages:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
       reusify: 1.0.4
-    dev: true
 
   /figures/3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2841,7 +3017,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /filter-obj/1.1.0:
     resolution: {integrity: sha1-mzERErxsYSehbgFsbF1/GeCAXFs=}
@@ -2928,7 +3103,6 @@ packages:
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3048,7 +3222,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob/7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -3063,7 +3236,6 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: false
 
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
@@ -3448,7 +3620,6 @@ packages:
   /is-extglob/2.1.1:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-fullwidth-code-point/1.0.0:
     resolution: {integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=}
@@ -3467,7 +3638,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-hexadecimal/2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -3495,7 +3665,6 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-obj/2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
@@ -3596,7 +3765,6 @@ packages:
 
   /is-what/3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
-    dev: false
 
   /isarray/1.0.0:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
@@ -3634,7 +3802,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3666,7 +3833,6 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.5
-    dev: false
 
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -4068,7 +4234,6 @@ packages:
     dependencies:
       is-what: 3.14.1
       ts-toolbelt: 9.6.0
-    dev: false
 
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4077,7 +4242,6 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: true
 
   /micromark-core-commonmark/1.0.6:
     resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
@@ -4343,7 +4507,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /mime-db/1.51.0:
     resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
@@ -4594,7 +4757,6 @@ packages:
 
   /node-releases/2.0.1:
     resolution: {integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==}
-    dev: false
 
   /nopt/4.0.3:
     resolution: {integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==}
@@ -5175,7 +5337,6 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
 
   /quick-lru/4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -5434,7 +5595,6 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
 
   /rimraf/2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -5458,7 +5618,6 @@ packages:
     dependencies:
       rollup: 2.63.0
       route-sort: 1.0.0
-    dev: false
 
   /rollup/2.63.0:
     resolution: {integrity: sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==}
@@ -5470,7 +5629,6 @@ packages:
   /route-sort/1.0.0:
     resolution: {integrity: sha512-SFgmvjoIhp5S4iBEDW3XnbT+7PRuZ55oRuNjY+CDB1SGZkyCG9bqQ3/dhaZTctTBYMAvDxd2Uy9dStuaUfgJqQ==}
     engines: {node: '>= 6'}
-    dev: false
 
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -5481,7 +5639,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
   /rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -5652,6 +5809,10 @@ packages:
       solid-js: 1.3.1
     dev: true
 
+  /solid-js/0.26.5:
+    resolution: {integrity: sha512-cMjxcVoyRBgnfSpwYxXPM5WF800guR+x/01RDBFQjAAkqU7X28GbRkTNKcyQ1KHcFOnzEsG18J+JJ9/PvqyNmw==}
+    dev: true
+
   /solid-js/1.3.1:
     resolution: {integrity: sha512-umBPwS/d7K5+NxojUok/t8xgXdMbIOkFLs/sk4DliFTsl3nbguHgkcAt3KWE6XhA8Xr1xKx5P+g75B8+VP0CzQ==}
 
@@ -5677,6 +5838,14 @@ packages:
       solid-js: 1.3.1
     dev: true
 
+  /solid-refresh/0.1.2_solid-js@0.26.5:
+    resolution: {integrity: sha512-irpGTZcn9xtzTQZhHslIEB4D1zYpWizT6GZ15GXyQE/gFBn6bKo53umQGmhq3NqRFqPXXavFDhiEQnyC08gzNg==}
+    peerDependencies:
+      solid-js: '*'
+    dependencies:
+      solid-js: 0.26.5
+    dev: true
+
   /solid-refresh/0.4.0_solid-js@1.3.1:
     resolution: {integrity: sha512-5XCUz845n/sHPzKK2i2G2EeV61tAmzv6SqzqhXcPaYhrgzVy7nKTQaBpKK8InKrriq9Z2JFF/mguIU00t/73xw==}
     peerDependencies:
@@ -5691,6 +5860,47 @@ packages:
   /solid-ssr/1.3.1:
     resolution: {integrity: sha512-/mCEXzyUDWt/Rd5kqN06b7SiYjgqEzF5mPA7aun6s/NPxOrHUAxCG4af4KkXHqdk7IaJsMt4hAwBqk2Uni1+BQ==}
     dev: false
+
+  /solid-start/0.1.0-y.0_rollup@2.63.0:
+    resolution: {integrity: sha512-8m6fLpxCJE5nyiyZt1ZLEk36deiYsQiKfBXrvdDeKybHhKjw2tmT9v8XCjLGO2Y8yJu64OcY8qjDOErofzLvvQ==}
+    hasBin: true
+    peerDependencies:
+      solid-app-router: '*'
+      solid-js: '*'
+      vite: '*'
+    dependencies:
+      node-fetch: 2.6.6
+      rollup-route-manifest: 1.0.0_rollup@2.63.0
+      sade: 1.8.1
+      vite-plugin-solid: 1.9.0
+    transitivePeerDependencies:
+      - less
+      - rollup
+      - sass
+      - stylus
+      - supports-color
+    dev: true
+
+  /solid-start/0.1.0-y.0_rollup@2.63.0+vite@2.7.10:
+    resolution: {integrity: sha512-8m6fLpxCJE5nyiyZt1ZLEk36deiYsQiKfBXrvdDeKybHhKjw2tmT9v8XCjLGO2Y8yJu64OcY8qjDOErofzLvvQ==}
+    hasBin: true
+    peerDependencies:
+      solid-app-router: '*'
+      solid-js: '*'
+      vite: '*'
+    dependencies:
+      node-fetch: 2.6.6
+      rollup-route-manifest: 1.0.0_rollup@2.63.0
+      sade: 1.8.1
+      vite: 2.7.10
+      vite-plugin-solid: 1.9.0
+    transitivePeerDependencies:
+      - less
+      - rollup
+      - sass
+      - stylus
+      - supports-color
+    dev: true
 
   /sort-keys/2.0.0:
     resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
@@ -5713,7 +5923,6 @@ packages:
   /source-map/0.5.7:
     resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -6008,14 +6217,12 @@ packages:
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
     engines: {node: '>=4'}
-    dev: false
 
   /to-regex-range/5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
@@ -6063,7 +6270,6 @@ packages:
 
   /ts-toolbelt/9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-    dev: false
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -6349,6 +6555,23 @@ packages:
       ufo: 0.7.9
       vite: 2.7.10
     transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /vite-plugin-solid/1.9.0:
+    resolution: {integrity: sha512-GN6lm/FkMBuZZyVEXSLf2lJzw+uhyFpBUPZ1d7p9PbgH6ScpTny5waa8smur4dx/JRuXDpHq+kWoRV3kCP4YjQ==}
+    dependencies:
+      '@babel/core': 7.16.7
+      '@babel/preset-typescript': 7.16.7_@babel+core@7.16.7
+      babel-preset-solid: 0.26.5_@babel+core@7.16.7
+      merge-anything: 4.0.2
+      solid-js: 0.26.5
+      solid-refresh: 0.1.2_solid-js@0.26.5
+      vite: 2.7.10
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
       - supports-color
     dev: true
 


### PR DESCRIPTION
uses fast-glob (same as vite) to do the route parsing
from the file system. we remove the virtual module for the routes
since it was giving SSR trouble. no API breaking changes, just changes
the internals for how the routes are parsed and loaded