### PR TITLE
fix: use vite plugin extensions options in route manifest

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -39,6 +39,16 @@ export default function StartPlugin(options) {
         }
       },
       config(conf) {
+        const regex = new RegExp(
+          `(index)?(.(${[
+            "tsx",
+            "ts",
+            "jsx",
+            "js",
+            ...(options.extensions?.map(e => e.slice(1)) ?? [])
+          ].join("|")}))$`
+        );
+
         const root = conf.root || process.cwd();
         return {
           resolve: {
@@ -63,9 +73,7 @@ export default function StartPlugin(options) {
                   merge: false,
                   publicPath: "/",
                   routes: file => {
-                    file = file
-                      .replace(path.join(root, "src"), "")
-                      .replace(/(index)?\.[tj]sx?$/, "");
+                    file = file.replace(path.join(root, "src"), "").replace(regex, "");
                     if (!file.includes("/pages/")) return "*"; // commons
                     return "/" + file.replace("/pages/", "");
                   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ importers:
   examples/with-mdx-ts:
     specifiers:
       '@mdx-js/rollup': ^2.0.0-rc.1
+      node-fetch: ^3.1.0
       solid-app-router: ^0.2.0
       solid-js: ^1.3.0
       solid-mdx: ^0.0.5
@@ -58,6 +59,7 @@ importers:
       vite-plugin-inspect: ^0.3.13
     devDependencies:
       '@mdx-js/rollup': 2.0.0-rc.1_rollup@2.63.0
+      node-fetch: 3.1.0
       solid-app-router: 0.2.0_solid-js@1.3.1
       solid-js: 1.3.1
       solid-mdx: 0.0.5_solid-js@1.3.1+vite@2.7.10


### PR DESCRIPTION
the previous PR didnt not have the manifest.json produced correctly for the mdx example so this fixes that.