### PR TITLE
infra: split vite plugin to separate parts including dev server

### DIFF
--- a/examples/basic-ts/vite.config.ts
+++ b/examples/basic-ts/vite.config.ts
@@ -3,5 +3,5 @@ import solid from "solid-start";
 import inspect from "vite-plugin-inspect";
 
 export default defineConfig({
-  plugins: [solid(), inspect()]
+  plugins: [solid()]
 });

--- a/examples/with-mdx-ts/vite.config.ts
+++ b/examples/with-mdx-ts/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 import solid from "solid-start";
-import inspect from "vite-plugin-inspect";
 
 export default defineConfig({
   plugins: [
@@ -14,7 +13,6 @@ export default defineConfig({
     },
     solid({
       extensions: [".mdx"]
-    }),
-    inspect()
+    })
   ]
 });

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-const { exec } = require("child_process");
+const { exec, spawn } = require("child_process");
 const sade = require("sade");
 const vite = require("vite");
 
@@ -16,7 +16,10 @@ prog
   .option("-p, --port", "Port to start server on", 3000)
   .action(async ({ config, open, port, root }) => {
     if (open) setTimeout(() => launch(port), 1000);
-    (await import("./runtime/devServer.js")).start({ config, port, root });
+    spawn("vite", ["dev"], {
+      stdio: "inherit"
+    });
+    // (await import("./runtime/devServer.js")).start({ config, port, root });
   });
 
 prog

--- a/packages/start/index.d.ts
+++ b/packages/start/index.d.ts
@@ -1,6 +1,0 @@
-import { Plugin } from "vite";
-import { Options } from "vite-plugin-solid";
-
-declare const startPlugin: (options?: Partial<Options>) => Plugin;
-
-export default startPlugin;

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -7,14 +7,14 @@
   "bin": "./bin.cjs",
   "main": "./plugin.js",
   "type": "module",
-  "types": "index.d.ts",
+  "types": "plugin.d.ts",
   "files": [
     "bin.cjs",
     "plugin.js",
     "routes.js",
     "actions.ts",
     "types.d.ts",
-    "index.d.ts",
+    "plugin.d.ts",
     "components",
     "runtime"
   ],
@@ -23,10 +23,12 @@
     "esbuild": "^0.14.11",
     "fast-glob": "^3.2.10",
     "node-fetch": "^2.6.1",
+    "picocolors": "^1.0.0",
     "rollup": "^2.0.0",
     "rollup-route-manifest": "^1.0.0",
     "sade": "^1.8.0",
     "solid-ssr": "^1.3.0",
+    "vite-plugin-inspect": "^0.3.13",
     "vite-plugin-solid": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/start/plugin.d.ts
+++ b/packages/start/plugin.d.ts
@@ -1,0 +1,13 @@
+export type Options = {
+  adapter: string;
+  appRoot: string;
+  routesDir: string;
+  ssr: boolean;
+  preferStreaming: boolean;
+  prerenderRoutes: any[];
+  inspect: boolean;
+} & import("vite-plugin-solid").Options;
+import { Plugin } from "vite";
+
+export const start: (options?: Partial<Options>) => Plugin[];
+export default start;

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -1,89 +1,178 @@
 import path from "path";
 import manifest from "rollup-route-manifest";
 import solid from "vite-plugin-solid";
-import fs from "fs";
+import inspect from "vite-plugin-inspect";
 import { getRoutes, stringifyRoutes } from "./routes.js";
-export default function StartPlugin(options) {
-  options = Object.assign(
-    {
-      adapter: "solid-start-node",
-      ssr: true,
-      preferStreaming: true,
-      prerenderRoutes: []
-    },
-    options
-  );
+import { createDevHandler } from "./runtime/devServer.js";
+import c from "picocolors";
 
-  return [
-    solid(options),
-    {
-      name: "solid-start",
-      mode: "pre",
-      async load(id) {
-        if (id.endsWith("components/Outlet.tsx")) {
+/**
+ * @returns {import('vite').Plugin}
+ */
+function solidStartRouter(options) {
+  return {
+    name: "solid-start-router",
+    enforce: "pre",
+    async transform(code, id) {
+      if (code.includes("const routes = $ROUTES;")) {
+        const routes = await getRoutes({
+          pageExtensions: [
+            "tsx",
+            "jsx",
+            "js",
+            "ts",
+            ...(options.extensions?.map(s => (Array.isArray(s) ? s[0] : s)).map(s => s.slice(1)) ??
+              [])
+          ]
+        });
+
+        return { code: code.replace("const routes = $ROUTES;", stringifyRoutes(routes)) };
+      }
+    }
+  };
+}
+
+function solidStartBuild(options) {
+  return {
+    name: "solid-start-build",
+    config(conf) {
+      const regex = new RegExp(
+        `(index)?(.(${[
+          "tsx",
+          "ts",
+          "jsx",
+          "js",
+          ...(options.extensions?.map(e => e.slice(1)) ?? [])
+        ].join("|")}))$`
+      );
+
+      const root = conf.root || process.cwd();
+      return {
+        build: {
+          target: "esnext",
+          manifest: true,
+          rollupOptions: {
+            plugins: [
+              manifest({
+                inline: false,
+                merge: false,
+                publicPath: "/",
+                routes: file => {
+                  file = file.replace(path.join(root, options.appRoot), "").replace(regex, "");
+                  if (!file.includes(`/${options.routesDir}/`)) return "*"; // commons
+                  return "/" + file.replace(`/${options.routesDir}/`, "");
+                }
+              })
+            ]
+          }
+        }
+      };
+    }
+  };
+}
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+function solidStartServer(options) {
+  let config;
+  return {
+    name: "solid-start-dev",
+    configureServer(vite) {
+      return () => {
+        remove_html_middlewares(vite.middlewares);
+        vite.middlewares.use(createDevHandler(vite));
+
+        // logging routes on server start
+        vite.httpServer?.once("listening", async () => {
+          const protocol = config.server.https ? "https" : "http";
+          const port = config.server.port;
           const routes = await getRoutes({
             pageExtensions: [
               "tsx",
               "jsx",
               "js",
               "ts",
-              ...(options.extensions?.map(s => s.slice(1)) ?? [])
+              ...(options.extensions
+                ?.map(s => (Array.isArray(s) ? s[0] : s))
+                .map(s => s.slice(1)) ?? [])
             ]
           });
-
-          return fs
-            .readFileSync(id, {
-              encoding: "utf-8"
-            })
-            .replace("const routes = $ROUTES;", stringifyRoutes(routes));
-        }
-      },
-      config(conf) {
-        const regex = new RegExp(
-          `(index)?(.(${[
-            "tsx",
-            "ts",
-            "jsx",
-            "js",
-            ...(options.extensions?.map(e => e.slice(1)) ?? [])
-          ].join("|")}))$`
-        );
-
-        const root = conf.root || process.cwd();
-        return {
-          resolve: {
-            conditions: ["solid"],
-            alias: [
-              {
-                find: "~",
-                replacement: path.join(root, "src")
-              }
-            ]
-          },
-          ssr: {
-            noExternal: ["solid-app-router", "solid-meta", "solid-start"]
-          },
-          build: {
-            target: "esnext",
-            manifest: true,
-            rollupOptions: {
-              plugins: [
-                manifest({
-                  inline: false,
-                  merge: false,
-                  publicPath: "/",
-                  routes: file => {
-                    file = file.replace(path.join(root, "src"), "").replace(regex, "");
-                    if (!file.includes("/pages/")) return "*"; // commons
-                    return "/" + file.replace("/pages/", "");
-                  }
-                })
-              ]
+          const label = `  > Routes: `;
+          setTimeout(() => {
+            // eslint-disable-next-line no-console
+            console.log(
+              `${label}\n${routes.pageRoutes
+                .flatMap(r => (r.children ? r.children : [r]))
+                .map(r => `     ${c.blue(`${protocol}://localhost:${port}${r.path}`)}`)
+                .join("\n")}`
+            );
+          }, 0);
+        });
+      };
+    },
+    configResolved: conf => {
+      config = conf;
+    },
+    config(conf) {
+      const root = conf.root || process.cwd();
+      return {
+        resolve: {
+          conditions: ["solid"],
+          alias: [
+            {
+              find: "~",
+              replacement: path.join(root, options.appRoot)
             }
-          },
-          solidOptions: options
-        };
-      }
+          ]
+        },
+        ssr: {
+          noExternal: ["solid-app-router", "solid-meta", "solid-start"]
+        },
+        solidOptions: options
+      };
     }
+  };
+}
+
+/**
+ * @returns {import('vite').Plugin[]}
+ */
+export default function solidStart(options) {
+  options = Object.assign(
+    {
+      adapter: "solid-start-node",
+      appRoot: "src",
+      routesDir: "pages",
+      ssr: true,
+      preferStreaming: true,
+      prerenderRoutes: [],
+      inspect: true
+    },
+    options ?? {}
+  );
+
+  return [
+    options.inspect ? inspect() : undefined,
+    solid(options),
+    solidStartRouter(options),
+    solidStartServer(options),
+    solidStartBuild(options)
+  ].filter(Boolean);
+}
+
+/**
+ * @param {import('vite').ViteDevServer['middlewares']} server
+ */
+function remove_html_middlewares(server) {
+  const html_middlewares = [
+    "viteIndexHtmlMiddleware",
+    "vite404Middleware",
+    "viteSpaFallbackMiddleware"
   ];
+  for (let i = server.stack.length - 1; i > 0; i--) {
+    if (html_middlewares.includes(server.stack[i].handle.name)) {
+      server.stack.splice(i, 1);
+    }
+  }
 }

--- a/packages/start/runtime/devServer.js
+++ b/packages/start/runtime/devServer.js
@@ -7,7 +7,39 @@ import fetch from "node-fetch";
 
 globalThis.fetch || (globalThis.fetch = fetch);
 
-async function createServer(root = process.cwd(), configFile) {
+export function createDevHandler(viteServer) {
+  return async (req, res) => {
+    try {
+      if (req.url === "/favicon.ico") return;
+
+      const { render, renderActions } = await viteServer.ssrLoadModule(
+        path.join(path.dirname(fileURLToPath(import.meta.url)), "entries", "devServer.tsx")
+      );
+
+      if (req.method === "POST") {
+        let e;
+        const body = await getBody(req);
+        if ((e = await renderActions(req.url, body))) {
+          res.statusCode = e.status;
+          res.write(e.body);
+          res.end();
+          return;
+        }
+      }
+
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/html");
+      render({ url: req.url, writable: res });
+    } catch (e) {
+      viteServer && viteServer.ssrFixStacktrace(e);
+      console.log(e.stack);
+      res.statusCode = 500;
+      res.end(e.stack);
+    }
+  };
+}
+
+async function createDevServer(root = process.cwd(), configFile) {
   const server = await vite.createServer({
     root,
     configFile,
@@ -18,42 +50,14 @@ async function createServer(root = process.cwd(), configFile) {
   });
 
   const app = http.createServer((req, res) => {
-    server.middlewares(req, res, async () => {
-      try {
-        if (req.url === "/favicon.ico") return;
-
-        const { render, renderActions } = await server.ssrLoadModule(
-          path.join(path.dirname(fileURLToPath(import.meta.url)), "entries", "devServer.tsx")
-        );
-
-        if (req.method === "POST") {
-          let e;
-          const body = await getBody(req);
-          if ((e = await renderActions(req.url, body))) {
-            res.statusCode = e.status;
-            res.write(e.body);
-            res.end();
-            return;
-          }
-        }
-
-        res.statusCode = 200;
-        res.setHeader("content-type", "text/html");
-        render({ url: req.url, writable: res });
-      } catch (e) {
-        server && server.ssrFixStacktrace(e);
-        console.log(e.stack);
-        res.statusCode = 500;
-        res.end(e.stack);
-      }
-    });
+    server.middlewares(req, res, createDevHandler(server));
   });
 
   return { app, server };
 }
 
 export function start(options) {
-  createServer(options.root, options.config).then(({ app }) =>
+  createDevServer(options.root, options.config).then(({ app }) =>
     app.listen(options.port, () => {
       console.log(`http://localhost:${options.port}`);
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,7 @@ importers:
       esbuild: ^0.14.11
       fast-glob: ^3.2.10
       node-fetch: ^2.6.1
+      picocolors: ^1.0.0
       rollup: ^2.0.0
       rollup-route-manifest: ^1.0.0
       sade: ^1.8.0
@@ -135,16 +136,19 @@ importers:
       solid-ssr: ^1.3.0
       solid-start-node: '*'
       vite: ^2.7.10
+      vite-plugin-inspect: ^0.3.13
       vite-plugin-solid: ^2.2.1
     dependencies:
       es-module-lexer: 0.9.3
       esbuild: 0.14.11
       fast-glob: 3.2.10
       node-fetch: 2.6.6
+      picocolors: 1.0.0
       rollup: 2.63.0
       rollup-route-manifest: 1.0.0_rollup@2.63.0
       sade: 1.8.1
       solid-ssr: 1.3.1
+      vite-plugin-inspect: 0.3.13_vite@2.7.10
       vite-plugin-solid: 2.2.1
     optionalDependencies:
       solid-start-node: link:../start-node
@@ -1489,7 +1493,6 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: true
 
   /@sindresorhus/is/4.2.1:
     resolution: {integrity: sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==}
@@ -3889,7 +3892,6 @@ packages:
 
   /kolorist/1.5.1:
     resolution: {integrity: sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==}
-    dev: true
 
   /lcov-parse/1.0.0:
     resolution: {integrity: sha1-6w1GtUER68VhrLTECO+TY73I9+A=}
@@ -5761,7 +5763,6 @@ packages:
       '@polka/url': 1.0.0-next.21
       mrmime: 1.0.0
       totalist: 2.0.0
-    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -6262,7 +6263,6 @@ packages:
   /totalist/2.0.0:
     resolution: {integrity: sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /tough-cookie/2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
@@ -6364,7 +6364,6 @@ packages:
 
   /ufo/0.7.9:
     resolution: {integrity: sha512-6t9LrLk3FhqTS+GW3IqlITtfRB5JAVr5MMNjpBECfK827W+Vh5Ilw/LhTcHWrt6b3hkeBvcbjx4Ti7QVFzmcww==}
-    dev: true
 
   /uglify-js/3.14.5:
     resolution: {integrity: sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==}
@@ -6586,7 +6585,6 @@ packages:
       vite: 2.7.10
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /vite-plugin-solid/1.9.0:
     resolution: {integrity: sha512-GN6lm/FkMBuZZyVEXSLf2lJzw+uhyFpBUPZ1d7p9PbgH6ScpTny5waa8smur4dx/JRuXDpHq+kWoRV3kCP4YjQ==}


### PR DESCRIPTION
The vite plugin currently handles all the parts of the dev and build functionality.. This splits that into smaller modular plugins and overall becomes a preset made of those plugins. We shift the server from an external dev server to just using the vite dev server with our handler. This allows tools like vite-plugin-inspect to work well. 

Adds some additional routes output to the vite URLs when starting a dev server