### PR TITLE
fix unescaped periods in route toIdentifier regex

### DIFF
--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -20,7 +20,7 @@ export async function getRoutes({
 
   const dataRoutes = fg.sync(`${baseDir}/**/*.data.(ts|js)`, { cwd });
 
-  const regex = new RegExp(`(index)?(.(${pageExtensions.join("|")})|.data.js|.data.ts)`);
+  const regex = new RegExp(`(index)?(\\.(${pageExtensions.join("|")})|\\.data\\.js|\\.data\\.ts)`);
 
   function toIdentifier(source) {
     return source.slice(baseDir.length).replace(regex, "");


### PR DESCRIPTION
Escape periods in route toIdentifier regex, which leaves some routes incorrectly resolved.

Fixes #49 