### PR TITLE
fix ENOENT when spawning vite and imports path resolution on windows

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -17,6 +17,7 @@ prog
   .action(async ({ config, open, port, root }) => {
     if (open) setTimeout(() => launch(port), 1000);
     spawn("vite", ["dev"], {
+      shell: true,
       stdio: "inherit"
     });
     // (await import("./runtime/devServer.js")).start({ config, port, root });

--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -1,5 +1,6 @@
 import fg from "fast-glob";
 import fs from "fs";
+import path from "path";
 import { init, parse } from "es-module-lexer";
 import esbuild from "esbuild";
 
@@ -108,9 +109,9 @@ export function stringifyRoutes(routes) {
           i =>
             `{\n${[
               /.data.(js|ts)$/.test(i.dataSrc ?? "")
-                ? `data: ${addImport(process.cwd() + "/" + i.dataSrc)}`
+                ? `data: ${addImport(path.posix.resolve(i.dataSrc))}`
                 : undefined,
-              `component: lazy(() => import('${process.cwd() + "/" + i.componentSrc}'))`,
+              `component: lazy(() => import('${path.posix.resolve(i.componentSrc)}'))`,
               ...Object.keys(i)
                 .filter(k => ROUTE_KEYS.indexOf(k) > -1 && i[k] !== undefined)
                 .map(


### PR DESCRIPTION
1. On windows, node binaries are usually started using cmd or powershell scripts, which can't be spawned without `shell: true`

2. In routes.js, the intent is to import file using its absolute path. Technically correct way for this is to use file URLs, but vite resolver does not support `file:///` URLs. Also, vite does not seem to recognize absolute paths in windows format. Using absolute posix paths is the only way I could find to get this to work. 
 