### PR TITLE
StartContext: generic types of manifest & context match entryServer.ts

### DIFF
--- a/packages/start/components/StartContext.tsx
+++ b/packages/start/components/StartContext.tsx
@@ -1,6 +1,9 @@
 import { createContext } from "solid-js";
 
-export const StartContext = createContext<{ manifest?: {}; context?: {} }>({});
+export const StartContext = createContext<{
+  manifest?: Record<string, any>;
+  context?: Record<string, any>;
+}>({});
 
 export function StartProvider(props) {
   return <StartContext.Provider value={props}>{props.children}</StartContext.Provider>;


### PR DESCRIPTION
```ts
export const StartContext = createContext<{
  manifest?: Record<string, any>;
  context?: Record<string, any>;
}>({});
```
now matches manifest & context types in:

https://github.com/solidjs/solid-start/blob/main/examples/basic-ts/src/entry-server.tsx

Fixes https://github.com/solidjs/solid-start/issues/52