### PR TITLE
fix path resolution for manifest on windows (fix #60)

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -1,4 +1,5 @@
 import path from "path";
+import { normalizePath } from "vite";
 import manifest from "rollup-route-manifest";
 import solid from "vite-plugin-solid";
 import inspect from "vite-plugin-inspect";
@@ -51,7 +52,7 @@ function solidStartBuild(options) {
         ].join("|")}))$`
       );
 
-      const root = conf.root || process.cwd();
+      const root = normalizePath(conf.root || process.cwd());
       return {
         build: {
           target: "esnext",
@@ -63,7 +64,7 @@ function solidStartBuild(options) {
                 merge: false,
                 publicPath: "/",
                 routes: file => {
-                  file = file.replace(path.join(root, options.appRoot), "").replace(regex, "");
+                  file = file.replace(path.posix.join(root, options.appRoot), "").replace(regex, "");
                   if (!file.includes(`/${options.routesDir}/`)) return "*"; // commons
                   return "/" + file.replace(`/${options.routesDir}/`, "");
                 }


### PR DESCRIPTION
this uses `normalizedPath` from vite to avoid mismatch with file paths which are normalized by vite.

it makes vite an actual runtime dependency, but I think it's ok
to leave it as it is - both dev an peer dependency