### PR TITLE
chore: remove invalid Next.js references

### DIFF
--- a/packages/create-solid/README.md
+++ b/packages/create-solid/README.md
@@ -4,7 +4,7 @@ description: Create Solid apps in one command with create-solid.
 
 # Create Solid
 
-The easiest way to get started with Solid is by using `create-solid`. This CLI tool enables you to quickly start building a new Solid application, with everything set up for you. You can create a new app using the default Next.js template, or by using one of the [official Next.js examples](https://github.com/solidjs/solid-start/tree/main/examples). To get started, use the following command:
+The easiest way to get started with Solid is by using `create-solid`. This CLI tool enables you to quickly start building a new Solid application, with everything set up for you. You can create a new app using the default Solid template, or by using one of the [official Solid examples](https://github.com/solidjs/solid-start/tree/main/examples). To get started, use the following command:
 
 ```bash
 #or
@@ -14,15 +14,7 @@ npm init solid@next ./my-solid-app
 yarn create solid@next ./my-solid-app
 ```
 
-### Options
-
-`create-next-app` comes with the following options:
-
-- **--ts, --typescript** - Initialize as a TypeScript project.
-- **-e, --example [name]|[github-url]** - An example to bootstrap the app with. You can use an example name from the [Next.js repo](https://github.com/vercel/next.js/tree/canary/examples) or a GitHub URL. The URL can use any branch and/or subdirectory.
-- **--example-path [path-to-example]** - In a rare case, your GitHub URL might contain a branch name with a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar). In this case, you must specify the path to the example separately: `--example-path foo/bar`
-
-### Why use Create Next App?
+### Why use Create Solid?
 
 `create-solid` allows you to create a new Solid app within seconds. It is officially maintained by the creators of Solid, and includes a number of benefits:
 


### PR DESCRIPTION
### tl;dr

- [x] Removes references to Next.js

### Description

It looks like the README had some copy pasta issues as the README referred to Next.js in many locations.