### PR TITLE
chore: use solid-start-node@next & solid-start@next fix #85

### DIFF
--- a/packages/start-cloudflare-workers/package.json
+++ b/packages/start-cloudflare-workers/package.json
@@ -15,7 +15,7 @@
     "vite": "^2.8.6"
   },
   "peerDependencies": {
-    "solid-start": "*",
+    "solid-start": "next",
     "vite": "*"
   }
 }

--- a/packages/start-netlify/package.json
+++ b/packages/start-netlify/package.json
@@ -18,6 +18,6 @@
     "solid-start": "^0.1.0-alpha.63"
   },
   "peerDependencies": {
-    "solid-start": "*"
+    "solid-start": "next"
   }
 }

--- a/packages/start-node/package.json
+++ b/packages/start-node/package.json
@@ -18,7 +18,7 @@
     "vite": "^2.8.6"
   },
   "peerDependencies": {
-    "solid-start": "*",
+    "solid-start": "next",
     "undici": "^4.12.2",
     "vite": "*"
   }

--- a/packages/start-static/package.json
+++ b/packages/start-static/package.json
@@ -11,7 +11,7 @@
     "undici": "^4.12.2"
   },
   "peerDependencies": {
-    "solid-start": "*",
+    "solid-start": "next",
     "undici": "^4.12.2"
   }
 }

--- a/packages/start-vercel/package.json
+++ b/packages/start-vercel/package.json
@@ -13,6 +13,6 @@
     "solid-start": "^0.1.0-alpha.63"
   },
   "peerDependencies": {
-    "solid-start": "*"
+    "solid-start": "next"
   }
 }

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -56,6 +56,6 @@
     "vite": "^2.8.6"
   },
   "optionalDependencies": {
-    "solid-start-node": "*"
+    "solid-start-node": "next"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,7 +305,7 @@ importers:
       solid-js: ^1.3.5
       solid-meta: ^0.27.3
       solid-ssr: ^1.3.3
-      solid-start-node: '*'
+      solid-start-node: next
       undici: ^4.12.2
       vite: ^2.8.6
       vite-plugin-inspect: ^0.3.13


### PR DESCRIPTION
Use the `next` tag instead of `*` to correctly resolve the latest version and avoid multiple versions of solid-start-node and solid-start.