### PR TITLE
Missing resolve from path import

### DIFF
--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -1,5 +1,5 @@
 import { copyFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { rollup } from "rollup";
 import vite from "vite";


### PR DESCRIPTION
When trying to build using `solid-start-vercel`, it throws an error due to missing `resolve` import.

Error message:
```./node_modules/solid-start-vercel/index.js:26
            input: resolve(join(config.root, appRoot, `entry-client`)),
                   ^

ReferenceError: resolve is not defined
    at Object.build (./node_modules/solid-start-vercel/index.js:26:20)
    at ./node_modules/.pnpm/solid-start@0.1.0-alpha.69_dd0a6a10e5f7b16d27d7286030fa2e9f/node_modules/solid-start/bin.cjs:39:13
```

The build goes successfully when adding the missing resolve import.