### PR TITLE
Added auto detection for adapters

### DIFF
--- a/packages/start-cloudflare-workers/package.json
+++ b/packages/start-cloudflare-workers/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha.73",
   "main": "./index.js",
   "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.1",
     "@rollup/plugin-commonjs": "^21.0.1",

--- a/packages/start-netlify/package.json
+++ b/packages/start-netlify/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha.73",
   "main": "./index.js",
   "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
   "dependencies": {
     "@babel/core": "^7.16.12",
     "@babel/preset-env": "^7.16.11",

--- a/packages/start-node/package.json
+++ b/packages/start-node/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha.73",
   "main": "./index.js",
   "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
   "dependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/start-static/package.json
+++ b/packages/start-static/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha.73",
   "main": "./index.js",
   "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
   "dependencies": {
     "sirv-cli": "1.0.12",
     "solid-ssr": "^1.3.11"

--- a/packages/start-vercel/package.json
+++ b/packages/start-vercel/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha.73",
   "main": "./index.js",
   "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
   "dependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -300,7 +300,12 @@ function detectAdapter() {
   let adapters = [];
   fs.readdirSync(nodeModulesPath).forEach((dir) => {
     if (dir.startsWith("solid-start-")) {
-      adapters.push(dir);
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(nodeModulesPath, dir, "package.json"))
+      );
+      if (pkg.solid && pkg.solid.type === "adapter") {
+        adapters.push(dir);
+      }
     }
   });
 

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -1,3 +1,4 @@
+import fs from "path";
 import path from "path";
 import { normalizePath } from "vite";
 import manifest from "rollup-route-manifest";
@@ -285,6 +286,30 @@ function solidStartConfig(options) {
   };
 }
 
+function find(locate, cwd) {
+  cwd = cwd || process.cwd();
+  if (cwd.split(path.sep).length < 2) return undefined;
+  const match = fs.readdirSync(cwd).find((f) => f === locate);
+  if (match) return match;
+  return find(locate, path.join(cwd, ".."));
+}
+
+function detectAdapter() {
+  const nodeModulesPath = find("node_modules");
+
+  let adapters = [];
+  fs.readdirSync(nodeModulesPath).forEach((dir) => {
+    if (dir.startsWith("solid-start-")) {
+      adapters.push(dir);
+    }
+  });
+
+  // Ignore the default adapter.
+  adapters = adapters.filter((adapter) => adapter !== "solid-start-node");
+
+  return adapters.length > 0 ? adapters[0] : "solid-start-node";
+}
+
 /**
  * @returns {import('vite').Plugin[]}
  */
@@ -294,7 +319,7 @@ export default function solidStart(options) {
       adapter:
         options && options.ssr !== undefined && !options.srr
           ? solidStartClientAdpater()
-          : "solid-start-node",
+          : detectAdapter(),
       appRoot: "src",
       routesDir: "routes",
       ssr: true,


### PR DESCRIPTION
Added zero-configuration detection for adapters.

Now the only thing needed to get started with solid is to drop off `solid()` and install the adapter you need. 🚀

## Implementation
By looking through the current directory for node_modules, then if it's not found, keep looking up the path for the directory. When node_modules are found, look for any directory starting with "solid-start-", ignore the default "solid-start-node"; Then, in case a package is found, apply that name and default to "solid-start-node".