### PR TITLE
add ErrorBoundary and Suspense wrappers to tailwind and vitest examples

### DIFF
--- a/examples/with-tailwindcss/src/root.tsx
+++ b/examples/with-tailwindcss/src/root.tsx
@@ -1,5 +1,7 @@
 // @refresh reload
 import { Links, Meta, Routes, Scripts } from "solid-start/root";
+import { ErrorBoundary } from "solid-start/error-boundary";
+import { Suspense } from "solid-js";
 import "./index.css";
 
 export default function Root() {
@@ -12,7 +14,11 @@ export default function Root() {
         <Links />
       </head>
       <body class="antialiased">
-        <Routes />
+        <ErrorBoundary>
+          <Suspense>
+            <Routes />
+          </Suspense>
+        </ErrorBoundary>
         <Scripts />
       </body>
     </html>

--- a/examples/with-vitest/src/root.tsx
+++ b/examples/with-vitest/src/root.tsx
@@ -1,5 +1,7 @@
 // @refresh reload
 import { Links, Meta, Routes, Scripts } from "solid-start/root";
+import { ErrorBoundary } from "solid-start/error-boundary";
+import { Suspense } from "solid-js";
 
 export default function Root() {
   return (
@@ -11,7 +13,11 @@ export default function Root() {
         <Links />
       </head>
       <body>
-        <Routes />
+        <ErrorBoundary>
+          <Suspense>
+            <Routes />
+          </Suspense>
+        </ErrorBoundary>
         <Scripts />
       </body>
     </html>


### PR DESCRIPTION
As per [Discord discussion](https://discordapp.com/channels/722131463138705510/910635844119982080/971093152570175488), this adds ErrorBoundary and Suspense to the tailwind and vitest examples and therefore makes these examples consistent with the changes in 67eaa63cfbcb0e94d04617e76eeed354cab017ed.