### PR TITLE
fix windows path handling

### DIFF
--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -52,24 +52,25 @@ export class Router {
     }
     this.watcher = chokidar.watch("src/routes/**/*", { cwd: this.cwd, ignoreInitial: true });
 
-    this.watcher.on("all", (event, path) => {
+    this.watcher.on("all", (event, filePath) => {
+      const posixPath = filePath.split(path.sep).join(path.posix.sep);
       switch (event) {
         case "add": {
-          this.processFile(path);
-          this.rawFiles[path] = true;
+          this.processFile(posixPath);
+          this.rawFiles[posixPath] = true;
           break;
         }
         case "change":
-          this.processFile(path);
+          this.processFile(posixPath);
           break;
         case "unlink":
           this.routes = Object.fromEntries(
             Object.entries(this.routes).filter(
-              ([k, v]) => v.componentPath !== path && v.dataPath !== path
+              ([k, v]) => v.componentPath !== posixPath && v.dataPath !== posixPath
             )
           );
-          this.notify(path);
-          delete this.rawFiles[path];
+          this.notify(posixPath);
+          delete this.rawFiles[posixPath];
           break;
       }
     });


### PR DESCRIPTION
I noticed that the vite server was restarting every time I edited a file. I tracked it down to the chokidar file watcher inside `routes.js` giving back a windows style path containing backslashes, while the existing path inside the `routes` object are url/posix style paths only containing forward slashes.

This is a simple fix that converts the file path to a posix file path.