### PR TITLE
close router file watcher before server restarts

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -88,6 +88,9 @@ function solidStartFileSystemRouter(options) {
   let listener = function handleFileChange(file) {
     timerState = "restart";
     schedule(() => {
+      if (router.watcher) {
+        router.watcher.close();
+      }
       touch(configFile);
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
IS:
Changing files with routeData do trigger full server restarts. The old router file watcher is not closed during the restart.

https://user-images.githubusercontent.com/4012401/167722661-44bb561d-aa9d-4ef3-a8ed-2d2e9e180faf.mp4

SHOULD:
A server restart should close the old router file watcher since a new one is created.

https://user-images.githubusercontent.com/4012401/167722694-3a00cef5-53f4-44a7-b3f6-aa1c38ddc413.mp4


