### PR TITLE
fix index nested routes

### DIFF
--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -184,7 +184,7 @@ export class Router {
   getNestedPageRoutes() {
     function processRoute(routes, route, id, full) {
       const parentRoute = Object.values(routes).find(
-        o => o.id && o.id === "/" ? (id === "/index/" && (id = "/")) : id.startsWith(o.id + "/")
+        o => o.id && o.id === "/" ? (id.startsWith("/index/") && (id = id.slice("/index".length))) : id.startsWith(o.id + "/")
       );
 
       if (!parentRoute) {


### PR DESCRIPTION
Fix #107 

An earlier commit by @ryansolid partially fixed the issue, but it only worked for the nested index (index/index.tsx) and not for any other pages e.g. (index/about.tsx)