### PR TITLE
fix hmr

### DIFF
--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -162,15 +162,14 @@ export class Router {
       if (this.routes[id]) {
         // get old config, we want to compare the oldConfig with the new one to
         // detect changes and restart the vite server
-        let { id: oldID, path: oldPath, dataPath, ...oldConfig } = this.routes[id];
+        let { id: oldID, path: oldPath, ...oldConfig } = this.routes[id];
         let newConfig = { ...routeConfig };
 
-        if (dataPath && !dataPath.endsWith("?data") && !newConfig.dataPath) {
-          newConfig.dataPath = dataPath;
+        if (oldConfig.dataPath && !oldConfig.dataPath.endsWith("?data") && !newConfig.dataPath) {
+          newConfig.dataPath = oldConfig.dataPath;
         }
 
-        if (!dequal({ dataPath, ...oldConfig }, newConfig)) {
-          console.log(newConfig, { dataPath, ...oldConfig });
+        if (!dequal(oldConfig, newConfig)) {
           this.routes[id] = { id, path: toPath(id) ?? "/", ...newConfig };
           this.notify(path);
         }
@@ -183,8 +182,10 @@ export class Router {
 
   getNestedPageRoutes() {
     function processRoute(routes, route, id, full) {
-      const parentRoute = Object.values(routes).find(
-        o => o.id && o.id === "/" ? (id.startsWith("/index/") && (id = id.slice("/index".length))) : id.startsWith(o.id + "/")
+      const parentRoute = Object.values(routes).find(o =>
+        o.id && o.id === "/"
+          ? id.startsWith("/index/") && (id = id.slice("/index".length))
+          : id.startsWith(o.id + "/")
       );
 
       if (!parentRoute) {


### PR DESCRIPTION
https://github.com/solidjs/solid-start/commit/a27a3a9f13e506f2a11b80b4f7ea2b91d5cffb76 broke hmr for routes without a dataPath. 

To simplify the issue imagine we have an empty config, we end up comparing `{dataPath: undefined}` vs `{}` which wasn't an issue previously because `JSON.stringify` doesn't support undefined. But the new check using `dequal` considers those 2 objects to be different.

I opted to change the code to not destructure `dataPath` out of the config, so if it is not present it won't create an object with `{dataPath: undefined}`
