### PR TITLE
fix path regex for routes with more than 1 param

### DIFF
--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -10,7 +10,7 @@ const log = debug("solid-start");
 const ROUTE_KEYS = ["component", "path", "data", "children"];
 const API_METHODS = ["get", "post", "put", "delete", "patch"];
 function toPath(id) {
-  return id.replace(/\[(.+)\]/, (_, m) => (m.startsWith("...") ? `*${m.slice(3)}` : `:${m}`));
+  return id.replace(/\[([^\[]+)\]/g, (_, m) => (m.startsWith("...") ? `*${m.slice(3)}` : `:${m}`));
 }
 
 export class Router {


### PR DESCRIPTION
If you have the following path:
`[foo]/[bar].tsx`

Before:
`http://localhost:3000/:foo]/[bar`

After:
`http://localhost:3000/:foo/:bar `