### PR TITLE
Remove `es-module-lexer`

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -41,7 +41,6 @@
     "cookie-signature": "^1.1.0",
     "debug": "^4.3.4",
     "dequal": "^2.0.2",
-    "es-module-lexer": "^0.9.3",
     "esbuild": "^0.14.11",
     "fast-glob": "^3.2.10",
     "parse-multipart-data": "^1.2.1",

--- a/packages/start/root/Routes.tsx
+++ b/packages/start/root/Routes.tsx
@@ -3,7 +3,6 @@
 import { useRoutes } from "solid-app-router";
 // @ts-expect-error
 var routes = $ROUTES;
-// console.log(routes);
 /**
  * Routes are the file system based routes, used by Solid App Router to show the current page according to the URL.
  */


### PR DESCRIPTION
I started having a dig into how this is all put together and realised that it was possible to re-use `esbuild` to minimise usage of file reading for feature detection in `routeData` generation. In this case it meant that we could remove the WASM startup cost of parsing and also remove the dependency from the tree.