### PR TITLE
fix: run build in sequence

### DIFF
--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -36,32 +36,30 @@ export default function () {
     },
     async build(config) {
       const appRoot = config.solidOptions.appRoot;
-      await Promise.all([
-        vite.build({
-          build: {
-            outDir: "./dist/",
-            minify: "terser",
-            rollupOptions: {
-              input: resolve(join(config.root, appRoot, `entry-client`)),
-              output: {
-                manualChunks: undefined
-              }
+      await vite.build({
+        build: {
+          outDir: "./dist/",
+          minify: "terser",
+          rollupOptions: {
+            input: resolve(join(config.root, appRoot, `entry-client`)),
+            output: {
+              manualChunks: undefined
             }
           }
-        }),
-        vite.build({
-          build: {
-            ssr: true,
-            outDir: "./.solid/server",
-            rollupOptions: {
-              input: resolve(join(config.root, appRoot, `entry-server`)),
-              output: {
-                format: "esm"
-              }
+        }
+      });
+      await vite.build({
+        build: {
+          ssr: true,
+          outDir: "./.solid/server",
+          rollupOptions: {
+            input: resolve(join(config.root, appRoot, `entry-server`)),
+            output: {
+              format: "esm"
             }
           }
-        })
-      ]);
+        }
+      });
       copyFileSync(
         join(config.root, ".solid", "server", `entry-server.js`),
         join(config.root, ".solid", "server", "app.js")


### PR DESCRIPTION
Running the build tasks in parallel fails when the vite.config is a `.ts` file. This avoids the missing config file error when generating the output.

Vite generates a `vite.config.ts.js` when the project has `"type": "module"` set in the `package.json` which seems to fail when multiple build tasks are running:
https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L728