### PR TITLE
fix hmr for pages with routeData

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -8,6 +8,7 @@ import { stringifyApiRoutes, stringifyPageRoutes, Router } from "./routes.js";
 import c from "picocolors";
 import babelServerModule from "./server/server-functions/babel.js";
 import routeData from "./server/routeData.js";
+import routeDataHmr from "./server/routeDataHmr.js";
 import routeResource from "./server/serverResource.js";
 import { solidStartClientAdpater } from "./client-adapter.js";
 
@@ -225,7 +226,12 @@ function solidStartFileSystemRouter(options) {
               babelServerModule,
               { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
             ],
-            [routeData, { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }]
+            [
+              routeData,
+              { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
+            ],
+            !ssr &&
+              process.env.NODE_ENV !== "production" && [routeDataHmr, { ssr, root: process.cwd() }]
           ].filter(Boolean)
         }));
       } else if (id.includes("routes")) {

--- a/packages/start/server/routeDataHmr.js
+++ b/packages/start/server/routeDataHmr.js
@@ -1,0 +1,28 @@
+import crypto from "crypto";
+import generate from "@babel/generator";
+import template from "@babel/template";
+
+export default function routeDataHmr() {
+  return {
+    visitor: {
+      Program(path) {
+        const result = generate.default(path.node);
+        const hash = crypto.createHash("sha256").update(result.code).digest("base64");
+        const modHash = path.scope.generateUidIdentifier("modHash").name;
+        const statements = template.default.ast(`
+        export const ${modHash} = "${hash}";
+        if (import.meta.hot) {
+          import.meta.hot.data.modHash = ${modHash};
+          import.meta.hot.accept(newMod => {
+            if (import.meta.hot.data.modHash !== newMod.${modHash}) {
+              import.meta.hot.invalidate();
+            }
+          });
+        }
+        `);
+
+        path.node.body.push(...statements);
+      }
+    }
+  };
+}


### PR DESCRIPTION
Currently if you have a page that exports a `routeData` function like this:

```javascript
export function routeData() {}

export default function Home() {
  return <div></div>;
}
```
the page will reload whenever you make a change to the component.

This PR fixes that by adding a new babel plugin for ?data modules. The plugin creates a hash of the whole source code of the module and then injects some HMR code into the module to compare the hashes, if the hashes don't match the page is reloaded.

I left the code in template form so it's easier to review and tweak for now, but it can be converted into babel-types function calls like the other plugins for some extra performance.