### PR TITLE
fix plugin order and simplify hmr logic

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -219,19 +219,19 @@ function solidStartFileSystemRouter(options) {
         return babelSolidCompiler(code, id.replace("?data", ""), (source, id) => ({
           plugins: [
             [
+              routeData,
+              { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
+            ],
+            !ssr &&
+              process.env.NODE_ENV !== "production" && [routeDataHmr, { ssr, root: process.cwd() }],
+            [
               routeResource,
               { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
             ],
             options.ssr && [
               babelServerModule,
               { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
-            ],
-            [
-              routeData,
-              { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
-            ],
-            !ssr &&
-              process.env.NODE_ENV !== "production" && [routeDataHmr, { ssr, root: process.cwd() }]
+            ]
           ].filter(Boolean)
         }));
       } else if (id.includes("routes")) {

--- a/packages/start/server/routeDataHmr.js
+++ b/packages/start/server/routeDataHmr.js
@@ -12,10 +12,8 @@ export default function routeDataHmr() {
         const statements = template.default.ast(`
         export const ${modHash} = "${hash}";
         if (import.meta.hot) {
-          import.meta.hot.data.modHash = ${modHash};
           import.meta.hot.accept(newMod => {
-            import.meta.hot.data.modHash = ${modHash};
-            if (import.meta.hot.data.modHash !== newMod.${modHash}) {
+            if (${modHash} !== newMod.${modHash}) {
               import.meta.hot.invalidate();
             }
           });


### PR DESCRIPTION
Follow up to #143 

I noticed that the page wasn't reloading if I modified a `routeData` function using server functions.

The server transforms happening in the plugins before were hiding the change and causing the hash to be the same even though the code changed.

Changing the plugin order so that the `routeData` separation and `routeDataHmr` happens first fixes that.

I also realized that `import.meta.hot.data` wasn't behaving how I thought it would and it ended up being useless so I got rid of it.