### PR TITLE
types: wrap ServerFn return type in promise

### DIFF
--- a/packages/start/server/server-functions/types.ts
+++ b/packages/start/server/server-functions/types.ts
@@ -8,7 +8,7 @@ export type InlineServer<E extends any[], T extends (...args: [...E]) => void> =
 
 export type ServerFn = (<E extends any[], T extends (...args: E) => void>(
   fn: T
-) => T & { url: string; action: T }) & {
+) => (...p: Parameters<T>) => Promise<Awaited<ReturnType<T>>> & { url: string; action: T }) & {
   getHandler: (route: string) => any;
   createHandler: (fn: any, hash: string) => any;
   registerHandler: (route: string, handler: any) => any;


### PR DESCRIPTION
Currently the `ServerFn` type does not reflect the fact that the function returned by it returns a `Promise`.

The user may or may not use an async function with `server`.

```typescript
server(async () => {
  return 33
})()
```

```typescript
server(() => {
  return 33
})()
```

Simply wrapping the return type in `Promise` could result in a nested Promise type like `Promise<Promise<number>>`.

`Awaited` is used to erase the `Promise` (whether there is one or not) and then the result is wrapped in `Promise` to reflect that the function returned by  `server` returns a `Promise`.