### PR TITLE
fix link tags for nested routes

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -1,14 +1,14 @@
 import fs from "fs";
 import path from "path";
-import { normalizePath } from "vite";
-import manifest from "rollup-route-manifest";
-import solid from "vite-plugin-solid";
-import inspect from "vite-plugin-inspect";
-import { stringifyApiRoutes, stringifyPageRoutes, Router } from "./routes.js";
 import c from "picocolors";
-import babelServerModule from "./server/server-functions/babel.js";
+import manifest from "rollup-route-manifest";
+import { normalizePath } from "vite";
+import inspect from "vite-plugin-inspect";
+import solid from "vite-plugin-solid";
+import { Router, stringifyApiRoutes, stringifyPageRoutes } from "./routes.js";
 import routeData from "./server/routeData.js";
 import routeDataHmr from "./server/routeDataHmr.js";
+import babelServerModule from "./server/server-functions/babel.js";
 import routeResource from "./server/serverResource.js";
 
 /**
@@ -301,7 +301,7 @@ function solidsStartRouteManifest(options) {
     name: "solid-start-route-manifest",
     config(conf) {
       const regex = new RegExp(
-        `(index)?(.(${[
+        `(/index)?(.(${[
           "tsx",
           "ts",
           "jsx",
@@ -324,7 +324,7 @@ function solidsStartRouteManifest(options) {
                 routes: file => {
                   file = file
                     .replace(path.posix.join(root, options.appRoot), "")
-                    .replace(regex, "");
+                    .replace(regex, (_, index) => (index ? "/" : ""));
                   if (!file.includes(`/${options.routesDir}/`)) return "*"; // commons
                   return "/" + file.replace(`/${options.routesDir}/`, "");
                 }

--- a/packages/start/root/Links.tsx
+++ b/packages/start/root/Links.tsx
@@ -7,8 +7,6 @@ function getAssetsFromManifest(
   manifest: PageEvent["env"]["manifest"],
   routerContext: PageEvent["routerContext"]
 ) {
-  console.log(manifest);
-
   const match = routerContext.matches.reduce<ManifestEntry[]>((memo, m) => {
     const manifestEntries = routesToManifestKeys(m).flatMap(
       manifestKey => manifest[manifestKey] || []

--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -1,11 +1,11 @@
-import fg from "fast-glob";
-import fs from "fs";
-import path, { join } from "path";
-import { init, parse } from "es-module-lexer";
-import esbuild from "esbuild";
 import chokidar from "chokidar";
 import debug from "debug";
 import { dequal } from "dequal";
+import { init, parse } from "es-module-lexer";
+import esbuild from "esbuild";
+import fg from "fast-glob";
+import fs from "fs";
+import path, { join } from "path";
 
 const log = debug("solid-start");
 const ROUTE_KEYS = ["component", "path", "data", "children"];
@@ -110,7 +110,9 @@ export class Router {
     if (path.match(new RegExp(`\\.data\\.(${["ts", "js"].join("|")})$`))) {
       let id = path
         .slice(this.baseDir.length)
-        .replace(new RegExp(`(index)?\\.data\\.(${["ts", "js"].join("|")})$`), "");
+        .replace(new RegExp(`(/index)?\\.data\\.(${["ts", "js"].join("|")})$`), (_, index) =>
+          index ? "/" : ""
+        );
       this.setRouteData(id, path);
       return;
     }
@@ -120,7 +122,9 @@ export class Router {
       log("processing", path);
       let id = path
         .slice(this.baseDir.length)
-        .replace(new RegExp(`(index)?\\.(${this.pageExtensions.join("|")})$`), "");
+        .replace(new RegExp(`(/index)?\\.(${this.pageExtensions.join("|")})$`), (_, index) =>
+          index ? "/" : ""
+        );
 
       let routeConfig = {};
 

--- a/test/link-test.ts
+++ b/test/link-test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+import type { AppFixture, Fixture } from "./helpers/create-fixture.js";
+import { createAppFixture, createFixture, css, js } from "./helpers/create-fixture.js";
+import { getElement } from "./helpers/playwright-fixture.js";
+
+test.describe("CSS link tags", () => {
+  let fixture: Fixture;
+  let appFixture: AppFixture;
+
+  test.describe("without streaming", () => {
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        files: {
+          "src/routes/index.css": css`
+            h1 {
+              color: brown;
+            }
+          `,
+          "src/routes/index.tsx": js`
+            import { Outlet } from "solid-app-router";
+            import "./index.css";
+            export default function Index() {
+              return <>
+                <h1>Index</h1>
+                <Outlet/>
+              </>;
+            }
+          `,
+          "src/routes/index/index-index.css": css`
+            p {
+              background-color: red;
+            }
+          `,
+          "src/routes/index/index.tsx": js`
+            import "./index-index.css";
+            export default function IndexIndex() {
+              return <p>Index Index</p>;
+            }
+          `,
+          "src/routes/index/index-non-index.css": css`
+            span {
+              padding-left: 5px;
+            }
+          `,
+          "src/routes/index/non-index.tsx": js`
+            import "./index-non-index.css";
+            export default function IndexNonIndex() {
+              return <span>Index Non-Index</span>;
+            }
+          `,
+          "src/routes/nested-route.css": css`
+            h2 {
+              color: blue;
+            }
+          `,
+          "src/routes/nested-route.tsx": js`
+            import { Outlet } from "solid-app-router";
+            import "./nested-route.css";
+            export default function NestedRoute() {
+              return <>
+                <h2>Nested Route</h2>
+                <Outlet/>
+              </>;
+            }
+          `,
+          "src/routes/nested-route/nested-route-index.css": css`
+            p {
+              background-color: pink;
+            }
+          `,
+          "src/routes/nested-route/index.tsx": js`
+            import "./nested-route-index.css";
+            export default function NestedRouteIndex() {
+              return <p>Nested Route Index</p>;
+            }
+          `,
+          "src/routes/nested-route/nested-route-non-index.css": css`
+            span {
+              padding-right: 5px;
+            }
+          `,
+          "src/routes/nested-route/non-index.tsx": js`
+            import "./nested-route-non-index.css";
+            export default function NestedRouteNonIndex() {
+              return <span>Nested Route Non-Index</span>;
+            }
+          `
+        }
+      });
+
+      appFixture = await createAppFixture(fixture);
+    });
+
+    test.afterAll(async () => {
+      await appFixture.close();
+    });
+
+    runTests();
+  });
+
+  function runTests() {
+    test("Index of index nested route", async () => {
+      const res = await fixture.requestDocument("/");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/html");
+      const html = await res.text();
+      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index."]')).toBeTruthy();
+      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index-index."]')).toBeTruthy();
+    });
+
+    test("Non-index of index nested route", async () => {
+      const res = await fixture.requestDocument("/");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/html");
+      const html = await res.text();
+      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index."]')).toBeTruthy();
+      expect(
+        getElement(html, 'link[rel="stylesheet"][href^="/assets/index-non-index."]')
+      ).toBeTruthy();
+    });
+
+    test("Index of nested route", async () => {
+      const res = await fixture.requestDocument("/");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/html");
+      const html = await res.text();
+      expect(
+        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route."]')
+      ).toBeTruthy();
+      expect(
+        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route-index."]')
+      ).toBeTruthy();
+    });
+
+    test("Non-index of nested route", async () => {
+      const res = await fixture.requestDocument("/");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/html");
+      const html = await res.text();
+      expect(
+        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route."]')
+      ).toBeTruthy();
+      expect(
+        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route-non-index."]')
+      ).toBeTruthy();
+    });
+  }
+});

--- a/test/link-test.ts
+++ b/test/link-test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import cheerio from "cheerio";
 import type { AppFixture, Fixture } from "./helpers/create-fixture.js";
 import { createAppFixture, createFixture, css, js } from "./helpers/create-fixture.js";
 import { getElement } from "./helpers/playwright-fixture.js";
@@ -10,83 +11,101 @@ test.describe("CSS link tags", () => {
 
   test.describe("without streaming", () => {
     test.beforeAll(async () => {
-      fixture = await createFixture({
-        files: {
-          "src/routes/index.css": css`
-            h1 {
-              color: brown;
+      const files = {};
+
+      const camelize = name => name.replace(/-./g, x => x[1].toUpperCase());
+      const pascalize = name => {
+        const cc = camelize(name);
+        return cc[0].toUpperCase() + cc.slice(1);
+      };
+
+      function createNestedRoute(path: string, children = ["index", "non-index"]) {
+        const name = path.split("/").pop()!;
+        const pascalCaseName = pascalize(name);
+
+        const createChildRoute = childName => {
+          const childPascalCaseName = pascalize(childName);
+          files[`src/routes/${path}/${childName}.css`] = css`
+            p::before {
+              content: "${path}-${childName}";
             }
-          `,
-          "src/routes/index.tsx": js`
-            import { Outlet } from "solid-app-router";
-            import "./index.css";
-            export default function Index() {
-              return <>
-                <h1>Index</h1>
-                <Outlet/>
-              </>;
+          `;
+          files[`src/routes/${path}/${childName}.tsx`] = js`
+            import "./${childName}.css";
+            export default function ${pascalCaseName}${childPascalCaseName}() {
+              return <p>${pascalCaseName} ${childPascalCaseName}</p>;
             }
-          `,
-          "src/routes/index/index-index.css": css`
-            p {
-              background-color: red;
-            }
-          `,
-          "src/routes/index/index.tsx": js`
-            import "./index-index.css";
-            export default function IndexIndex() {
-              return <p>Index Index</p>;
-            }
-          `,
-          "src/routes/index/index-non-index.css": css`
-            span {
-              padding-left: 5px;
-            }
-          `,
-          "src/routes/index/non-index.tsx": js`
-            import "./index-non-index.css";
-            export default function IndexNonIndex() {
-              return <span>Index Non-Index</span>;
-            }
-          `,
-          "src/routes/nested-route.css": css`
-            h2 {
-              color: blue;
-            }
-          `,
-          "src/routes/nested-route.tsx": js`
-            import { Outlet } from "solid-app-router";
-            import "./nested-route.css";
-            export default function NestedRoute() {
-              return <>
-                <h2>Nested Route</h2>
-                <Outlet/>
-              </>;
-            }
-          `,
-          "src/routes/nested-route/nested-route-index.css": css`
-            p {
-              background-color: pink;
-            }
-          `,
-          "src/routes/nested-route/index.tsx": js`
-            import "./nested-route-index.css";
-            export default function NestedRouteIndex() {
-              return <p>Nested Route Index</p>;
-            }
-          `,
-          "src/routes/nested-route/nested-route-non-index.css": css`
-            span {
-              padding-right: 5px;
-            }
-          `,
-          "src/routes/nested-route/non-index.tsx": js`
-            import "./nested-route-non-index.css";
-            export default function NestedRouteNonIndex() {
-              return <span>Nested Route Non-Index</span>;
-            }
-          `
+          `;
+        };
+
+        files[`src/routes/${path}.css`] = css`
+          h1::before {
+            content: "${path}";
+          }
+        `;
+        files[`src/routes/${path}.tsx`] = js`
+          import { Outlet } from "solid-app-router";
+          import "./${name}.css";
+          export default function ${pascalCaseName}() {
+            return <>
+              <h1>${pascalCaseName}</h1>
+              <Outlet/>
+            </>;
+          }
+        `;
+
+        children.forEach(childName => {
+          createChildRoute(childName);
+        });
+      }
+
+      files["src/root.css"] = css`
+        body::before {
+          content: "root";
         }
+      `;
+
+      files["src/root.tsx"] = js`
+        // @refresh reload
+        import { Links, Meta, FileRoutes, Scripts } from "solid-start/root";
+        import { ErrorBoundary } from "solid-start/error-boundary";
+        import { Suspense } from "solid-js";
+        import { Routes } from "solid-app-router";
+
+        import "./root.css";
+
+        export default function Root() {
+          return (
+            <html lang="en">
+              <head>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <Meta />
+                <Links />
+              </head>
+              <body>
+                <ErrorBoundary>
+                  <Suspense>
+                    <Routes>
+                      <FileRoutes />
+                    </Routes>
+                  </Suspense>
+                </ErrorBoundary>
+                <Scripts />
+              </body>
+            </html>
+          );
+        }
+      `;
+
+      createNestedRoute("index");
+      createNestedRoute("index/double-nested");
+      createNestedRoute("nested");
+      createNestedRoute("nested/double-nested");
+      createNestedRoute("nested/double-nested/triple-nested");
+
+      fixture = await createFixture({
+        files
       });
 
       appFixture = await createAppFixture(fixture);
@@ -99,51 +118,91 @@ test.describe("CSS link tags", () => {
     runTests();
   });
 
+  async function getStylesheetUrlsForRoute(route: string, expectedNumberOfStylesheets: number) {
+    const res = await fixture.requestDocument(route);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html");
+    const html = await res.text();
+    const cssLinkTags = getElement(html, 'link[rel="stylesheet"]');
+    const cssUrls = cssLinkTags
+      .map((_, el) => {
+        return cheerio(el).attr("href");
+      })
+      .toArray();
+
+    expectNumberOfUrlsToMatch(cssUrls, "entry-client", 1);
+    expect(cssUrls).toHaveLength(expectedNumberOfStylesheets);
+
+    return [...new Set(cssUrls)];
+  }
+
+  function matchHashedCssFile(name: string) {
+    return (x: string) => new RegExp(`^/assets/${name}\\.[a-f0-9]+\.css$`).test(x);
+  }
+
+  function expectNumberOfUrlsToMatch(urls: string[], matchName: string, expectedNumber: number) {
+    return expect(urls.filter(matchHashedCssFile(matchName))).toHaveLength(expectedNumber);
+  }
+
   function runTests() {
     test("Index of index nested route", async () => {
-      const res = await fixture.requestDocument("/");
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("text/html");
-      const html = await res.text();
-      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index."]')).toBeTruthy();
-      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index-index."]')).toBeTruthy();
+      const cssUrls = await getStylesheetUrlsForRoute("/", 3);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 2);
     });
-
     test("Non-index of index nested route", async () => {
-      const res = await fixture.requestDocument("/");
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("text/html");
-      const html = await res.text();
-      expect(getElement(html, 'link[rel="stylesheet"][href^="/assets/index."]')).toBeTruthy();
-      expect(
-        getElement(html, 'link[rel="stylesheet"][href^="/assets/index-non-index."]')
-      ).toBeTruthy();
+      const cssUrls = await getStylesheetUrlsForRoute("/non-index", 3);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "non-index", 1);
     });
-
+    test("Index of double index nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute("/double-nested", 4);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 2);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+    });
+    test("Non-index of double index nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute("/double-nested/non-index", 4);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "non-index", 1);
+    });
     test("Index of nested route", async () => {
-      const res = await fixture.requestDocument("/");
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("text/html");
-      const html = await res.text();
-      expect(
-        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route."]')
-      ).toBeTruthy();
-      expect(
-        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route-index."]')
-      ).toBeTruthy();
+      const cssUrls = await getStylesheetUrlsForRoute("/nested", 3);
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 1);
     });
-
     test("Non-index of nested route", async () => {
-      const res = await fixture.requestDocument("/");
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("text/html");
-      const html = await res.text();
-      expect(
-        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route."]')
-      ).toBeTruthy();
-      expect(
-        getElement(html, 'link[rel="stylesheet"][href^="/assets/nested-route-non-index."]')
-      ).toBeTruthy();
+      const cssUrls = await getStylesheetUrlsForRoute("/nested/non-index", 3);
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "non-index", 1);
+    });
+    test("Index of double nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute("/nested/double-nested", 4);
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 1);
+    });
+    test("Non-index of double nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute("/nested/double-nested/non-index", 4);
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "non-index", 1);
+    });
+    test("Index of triple nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute("/nested/double-nested/triple-nested", 5);
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "triple-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "index", 1);
+    });
+    test("Non-index of triple nested route", async () => {
+      const cssUrls = await getStylesheetUrlsForRoute(
+        "/nested/double-nested/triple-nested/non-index",
+        5
+      );
+      expectNumberOfUrlsToMatch(cssUrls, "nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "double-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "triple-nested", 1);
+      expectNumberOfUrlsToMatch(cssUrls, "non-index", 1);
     });
   }
 });


### PR DESCRIPTION
Fixes #171 

Previously only link tags for the topmost routes were being added to the document. Now all link tags for the ancestors routes will be added. This fixes a CSS flashing issue during prod SSR for nested routes.

A check for index nested routes was also added to correctly match the manifest key, this fixes an issue where the CSS was not getting loaded at all during prod SSR for index nested routes.
