### PR TITLE
fix non-index routes containing the word index

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -1,14 +1,14 @@
 import fs from "fs";
 import path from "path";
-import { normalizePath } from "vite";
-import manifest from "rollup-route-manifest";
-import solid from "vite-plugin-solid";
-import inspect from "vite-plugin-inspect";
-import { stringifyApiRoutes, stringifyPageRoutes, Router } from "./routes.js";
 import c from "picocolors";
-import babelServerModule from "./server/server-functions/babel.js";
+import manifest from "rollup-route-manifest";
+import { normalizePath } from "vite";
+import inspect from "vite-plugin-inspect";
+import solid from "vite-plugin-solid";
+import { Router, stringifyApiRoutes, stringifyPageRoutes } from "./routes.js";
 import routeData from "./server/routeData.js";
 import routeDataHmr from "./server/routeDataHmr.js";
+import babelServerModule from "./server/server-functions/babel.js";
 import routeResource from "./server/serverResource.js";
 
 /**
@@ -301,7 +301,7 @@ function solidsStartRouteManifest(options) {
     name: "solid-start-route-manifest",
     config(conf) {
       const regex = new RegExp(
-        `(index)?(.(${[
+        `(/index)?(.(${[
           "tsx",
           "ts",
           "jsx",
@@ -324,7 +324,7 @@ function solidsStartRouteManifest(options) {
                 routes: file => {
                   file = file
                     .replace(path.posix.join(root, options.appRoot), "")
-                    .replace(regex, "");
+                    .replace(regex, (_, index) => (index ? "/" : ""));
                   if (!file.includes(`/${options.routesDir}/`)) return "*"; // commons
                   return "/" + file.replace(`/${options.routesDir}/`, "");
                 }

--- a/packages/start/routes.js
+++ b/packages/start/routes.js
@@ -1,11 +1,11 @@
-import fg from "fast-glob";
-import fs from "fs";
-import path, { join } from "path";
-import { init, parse } from "es-module-lexer";
-import esbuild from "esbuild";
 import chokidar from "chokidar";
 import debug from "debug";
 import { dequal } from "dequal";
+import { init, parse } from "es-module-lexer";
+import esbuild from "esbuild";
+import fg from "fast-glob";
+import fs from "fs";
+import path, { join } from "path";
 
 const log = debug("solid-start");
 const ROUTE_KEYS = ["component", "path", "data", "children"];
@@ -110,7 +110,9 @@ export class Router {
     if (path.match(new RegExp(`\\.data\\.(${["ts", "js"].join("|")})$`))) {
       let id = path
         .slice(this.baseDir.length)
-        .replace(new RegExp(`(index)?\\.data\\.(${["ts", "js"].join("|")})$`), "");
+        .replace(new RegExp(`(/index)?\\.data\\.(${["ts", "js"].join("|")})$`), (_, index) =>
+          index ? "/" : ""
+        );
       this.setRouteData(id, path);
       return;
     }
@@ -120,7 +122,9 @@ export class Router {
       log("processing", path);
       let id = path
         .slice(this.baseDir.length)
-        .replace(new RegExp(`(index)?\\.(${this.pageExtensions.join("|")})$`), "");
+        .replace(new RegExp(`(/index)?\\.(${this.pageExtensions.join("|")})$`), (_, index) =>
+          index ? "/" : ""
+        );
 
       let routeConfig = {};
 


### PR DESCRIPTION
Previously a route like the following `src/routes/non-index.tsx` would get converted into `/non-` instead of `/non-index`