### PR TITLE
ssr and spa becomes a one flip switch

### DIFF
--- a/examples/bare/src/entry-client.tsx
+++ b/examples/bare/src/entry-client.tsx
@@ -1,4 +1,3 @@
-import { hydrate } from "solid-js/web";
-import { StartClient } from "solid-start/entry-client";
+import { mount, StartClient } from "solid-start/entry-client";
 
-hydrate(() => <StartClient />, document);
+mount(() => <StartClient />, document.body);

--- a/examples/bare/src/entry-client.tsx
+++ b/examples/bare/src/entry-client.tsx
@@ -1,3 +1,3 @@
 import { mount, StartClient } from "solid-start/entry-client";
 
-mount(() => <StartClient />, document.body);
+mount(() => <StartClient />, document);

--- a/examples/bare/src/root.tsx
+++ b/examples/bare/src/root.tsx
@@ -1,28 +1,29 @@
 // @refresh reload
-import { Links, Meta, FileRoutes, Scripts } from "solid-start/root";
-import { ErrorBoundary } from "solid-start/error-boundary";
-import { Suspense } from "solid-js";
 import { Routes } from "solid-app-router";
+import { Suspense } from "solid-js";
+import { Meta } from "solid-meta";
+import { ErrorBoundary } from "solid-start/error-boundary";
+import { Body, FileRoutes, Head, Html, Scripts } from "solid-start/root";
 
 export default function Root() {
   return (
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <ErrorBoundary>
-          <Suspense>
+    <Html lang="en">
+      <Head>
+        <Meta charset="utf-8" />
+        <Meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Body>
+        <Suspense>
+          <ErrorBoundary>
+            <a href="/">Home</a>
+            <a href="/random">Random</a>
             <Routes>
               <FileRoutes />
             </Routes>
-          </Suspense>
-        </ErrorBoundary>
+          </ErrorBoundary>
+        </Suspense>
         <Scripts />
-      </body>
-    </html>
+      </Body>
+    </Html>
   );
 }

--- a/examples/bare/src/root.tsx
+++ b/examples/bare/src/root.tsx
@@ -15,8 +15,8 @@ export default function Root() {
       <Body>
         <Suspense>
           <ErrorBoundary>
-            <a href="/">Home</a>
-            <a href="/random">Random</a>
+            <a href="/about">About</a>
+            <a href="/">Index</a>
             <Routes>
               <FileRoutes />
             </Routes>

--- a/examples/bare/src/routes/index.tsx
+++ b/examples/bare/src/routes/index.tsx
@@ -1,18 +1,22 @@
+import { Stylesheet } from "solid-meta";
 import Counter from "~/components/Counter";
-import "./index.css";
+import css from "./index.css?url";
 
 export default function Home() {
   return (
-    <main>
-      <h1>Hello world!</h1>
-      <Counter />
-      <p>
-        Visit{" "}
-        <a href="https://solidjs.com" target="_blank">
-          solidjs.com
-        </a>{" "}
-        to learn how to build Solid apps.
-      </p>
-    </main>
+    <>
+      <Stylesheet href={css} />
+      <main>
+        <h1>Hello world!</h1>
+        <Counter />
+        <p>
+          Visit{" "}
+          <a href="https://solidjs.com" target="_blank">
+            solidjs.com
+          </a>{" "}
+          to learn how to build Solid apps.
+        </p>
+      </main>
+    </>
   );
 }

--- a/examples/bare/vite.config.ts
+++ b/examples/bare/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import solid from "solid-start";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [solid()]

--- a/packages/start-node/index.js
+++ b/packages/start-node/index.js
@@ -30,6 +30,7 @@ export default function () {
           `'${join(config.root, "dist", "public", "index.html").replace(/\\/g, "\\\\")}'`
         );
         writeFileSync(join(config.root, ".solid", "server", "entry-server.js"), text);
+        builder.debug(`created ${join(config.root, ".solid", "server", "entry-server.js")}`);
       } else {
         await builder.client(join(config.root, "dist", "public"));
 
@@ -55,6 +56,9 @@ export default function () {
       let text = readFileSync(join(__dirname, "entry.js")).toString();
 
       writeFileSync(join(config.root, ".solid", "server", "server.js"), text);
+
+      builder.debug(`bundling server with rollup`);
+
       const bundle = await rollup({
         input: join(config.root, ".solid", "server", "server.js"),
         plugins: [
@@ -72,6 +76,8 @@ export default function () {
 
       // closes the bundle
       await bundle.close();
+
+      builder.debug(`bundling server done`);
     }
   };
 }

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -115,7 +115,7 @@ prog
         await vite.build({
           build: {
             outDir: path,
-            minify: "terser",
+            minify: false,
             ssrManifest: true,
             rollupOptions: {
               input: indexHtml,

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -53,7 +53,7 @@ prog
           build: {
             outDir: path,
             ssrManifest: true,
-            minify: process.env.START_MINIFY === 'false' ?  false :"terser",
+            minify: process.env.START_MINIFY === "false" ? false : "terser",
             rollupOptions: {
               input: resolve(join(config.root, config.solidOptions.appRoot, `entry-client`)),
               output: {
@@ -91,7 +91,7 @@ prog
             process.exit();
           });
           await waitOn({
-            resources: ["http://127.0.0.1:8989/"],
+            resources: ["http://localhost:8989/"],
             verbose: isDebug
           });
 
@@ -99,7 +99,7 @@ prog
 
           writeFileSync(
             join(config.root, ".solid", "index.html"),
-            await (await import("./dev/create-index-html.js")).createHTML("http://127.0.0.1:8989/")
+            await (await import("./dev/create-index-html.js")).createHTML("http://localhost:8989/")
           );
 
           indexHtml = join(config.root, ".solid", "index.html");
@@ -111,6 +111,7 @@ prog
 
         debug("building client bundle");
 
+        process.env.START_SPA_CLIENT = "true";
         await vite.build({
           build: {
             outDir: path,
@@ -124,6 +125,7 @@ prog
             }
           }
         });
+        process.env.START_SPA_CLIENT = "false";
 
         if (indexHtml === join(config.root, ".solid", "index.html")) {
           renameSync(join(path, ".solid", "index.html"), join(path, "index.html"));

--- a/packages/start/dev/create-index-html.js
+++ b/packages/start/dev/create-index-html.js
@@ -1,0 +1,5 @@
+import "../node/globals.js";
+
+export async function createHTML(url) {
+  return await (await fetch(new Request(url))).text();
+}

--- a/packages/start/entry-client/index.tsx
+++ b/packages/start/entry-client/index.tsx
@@ -1,1 +1,2 @@
+export { default as mount } from "./mount";
 export { default as StartClient } from "./StartClient";

--- a/packages/start/entry-client/mount.ts
+++ b/packages/start/entry-client/mount.ts
@@ -1,10 +1,10 @@
 import { JSX } from "solid-js";
-import { hydrate, MountableElement, render } from "solid-js/web";
+import { hydrate, render } from "solid-js/web";
 
-export default function mount(code: () => JSX.Element, element: MountableElement) {
+export default function mount(code: () => JSX.Element, element: Document) {
   if (import.meta.env.START_SSR) {
     hydrate(code, element);
   } else {
-    render(code, element);
+    render(code, element.body);
   }
 }

--- a/packages/start/entry-client/mount.ts
+++ b/packages/start/entry-client/mount.ts
@@ -1,0 +1,10 @@
+import { JSX } from "solid-js";
+import { hydrate, MountableElement, render } from "solid-js/web";
+
+export default function mount(code: () => JSX.Element, element: MountableElement) {
+  if (import.meta.env.START_SSR) {
+    hydrate(code, element);
+  } else {
+    render(code, element);
+  }
+}

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -86,9 +86,12 @@
     "sirv": "^1.0.19",
     "undici": "^5.5.1",
     "vite-plugin-inspect": "^0.3.13",
-    "vite-plugin-solid": "^2.2.6"
+    "vite-plugin-solid": "^2.2.6",
+    "wait-on": "^6.0.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/wait-on": "^5.3.1",
     "solid-app-router": "0.4.1",
     "solid-js": "1.4.7",
     "solid-meta": "0.27.5",

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -398,7 +398,7 @@ export default function solidStart(options) {
     options.ssr && solidStartInlineServerModules(options),
     solid({
       ...(options ?? {}),
-      ssr: true,
+      ssr: process.env.START_SPA_CLIENT === "true" ? false : true,
       babel: (source, id, ssr) => ({
         plugins: options.ssr
           ? [

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -314,7 +314,9 @@ function solidStartConfig(options) {
           "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
           "import.meta.env.START_SSR": JSON.stringify(options.ssr ? true : false),
           "import.meta.env.START_ADAPTER": JSON.stringify(
-            typeof options.adapter === "string" ? options.adapter : options.adapter.name
+            typeof options.adapter === "string"
+              ? options.adapter
+              : options.adapter && options.adapter.name
           )
         },
         solidOptions: options
@@ -358,7 +360,7 @@ function detectAdapter() {
 export default function solidStart(options) {
   options = Object.assign(
     {
-      adapter: process.env.START_ADAPTER ?? detectAdapter(),
+      adapter: process.env.START_ADAPTER ? process.env.START_ADAPTER : detectAdapter(),
       appRoot: "src",
       routesDir: "routes",
       ssr: process.env.START_SSR === "false" ? false : true,
@@ -368,6 +370,7 @@ export default function solidStart(options) {
     },
     options ?? {}
   );
+  console.log(options);
 
   options.pageExtensions = [
     "tsx",

--- a/packages/start/root/Document.tsx
+++ b/packages/start/root/Document.tsx
@@ -1,0 +1,47 @@
+import { children } from "solid-js";
+import { isServer, resolveSSRNode } from "solid-js/web";
+import Links from "./Links";
+import Meta from "./Meta";
+import Scripts from "./Scripts";
+
+export function Html(props) {
+  if (isServer) {
+    return `<html>
+        ${resolveSSRNode(children(() => props.children))}
+      </html>
+    `;
+  }
+
+  return <>{props.children}</>;
+}
+
+export function Head(props) {
+  if (isServer) {
+    return `<head>
+        ${resolveSSRNode(
+          children(() => (
+            <>
+              {props.children}
+              <Meta />
+              <Links />
+            </>
+          ))
+        )}
+      </head>
+    `;
+  }
+  return <>{props.children}</>;
+}
+
+export function Body(props) {
+  if (isServer) {
+    console.log(import.meta.env.START_SSR, import.meta.env.SSR);
+    return `<body>${
+      import.meta.env.START_SSR
+        ? resolveSSRNode(children(() => props.children))
+        : resolveSSRNode(<Scripts />)
+    }</body>`;
+  }
+
+  return <>{children(() => props.children)}</>;
+}

--- a/packages/start/root/Document.tsx
+++ b/packages/start/root/Document.tsx
@@ -1,22 +1,30 @@
-import { children } from "solid-js";
-import { isServer, resolveSSRNode } from "solid-js/web";
+import { children, createRenderEffect } from "solid-js";
+import { insert, resolveSSRNode } from "solid-js/web";
 import Links from "./Links";
 import Meta from "./Meta";
 import Scripts from "./Scripts";
 
 export function Html(props) {
-  if (isServer) {
+  if (import.meta.env.SSR) {
     return `<html>
         ${resolveSSRNode(children(() => props.children))}
       </html>
     `;
-  }
+  } else {
+    if (import.meta.env.START_SSR) {
+      createRenderEffect(() => {
+        children(() => props.children);
+      });
 
-  return <>{props.children}</>;
+      return document;
+    }
+
+    return <>{props.children}</>;
+  }
 }
 
 export function Head(props) {
-  if (isServer) {
+  if (import.meta.env.SSR) {
     return `<head>
         ${resolveSSRNode(
           children(() => (
@@ -29,19 +37,55 @@ export function Head(props) {
         )}
       </head>
     `;
+  } else {
+    if (import.meta.env.START_SSR) {
+      createRenderEffect(() => {
+        children(() => props.children);
+      });
+
+      return document.head;
+    }
+
+    return <>{props.children}</>;
   }
-  return <>{props.children}</>;
 }
 
 export function Body(props) {
-  if (isServer) {
+  if (import.meta.env.SSR) {
     console.log(import.meta.env.START_SSR, import.meta.env.SSR);
     return `<body>${
       import.meta.env.START_SSR
         ? resolveSSRNode(children(() => props.children))
         : resolveSSRNode(<Scripts />)
     }</body>`;
-  }
+  } else {
+    if (import.meta.env.START_SSR) {
+      let child = children(() => props.children);
+      insert(
+        document.body,
+        () => {
+          let childNodes = child();
+          if (childNodes) {
+            if (Array.isArray(childNodes)) {
+              let els = childNodes.filter(n => Boolean(n));
 
-  return <>{children(() => props.children)}</>;
+              if (!els.length) {
+                return null;
+              }
+
+              return els;
+            }
+            return childNodes;
+          }
+          return null;
+        },
+        null,
+        [...document.body.childNodes]
+      );
+
+      return document.body;
+    } else {
+      return <>{props.children}</>;
+    }
+  }
 }

--- a/packages/start/root/FileRoutes.tsx
+++ b/packages/start/root/FileRoutes.tsx
@@ -4,7 +4,9 @@
 var routesConfig = $ROUTES_CONFIG;
 
 export const fileRoutes = routesConfig.routes;
-export const routeLayouts = routesConfig.routeLayouts;
+export const routeLayouts = routesConfig.routeLayouts as {
+  [key: string]: { layouts: string[]; id: string };
+};
 
 /**
  * Routes are the file system based routes, used by Solid App Router to show the current page according to the URL.

--- a/packages/start/root/InlineStyles.tsx
+++ b/packages/start/root/InlineStyles.tsx
@@ -36,9 +36,18 @@ export function InlineStyles() {
     return null;
   }
 
-  const [resource] = createResource(() => getInlineStyles(context.env, context.routerContext), {
-    deferStream: true
-  });
+  const [resource] = createResource(
+    async () => {
+      if (import.meta.env.SSR) {
+        return await getInlineStyles(context.env, context.routerContext);
+      } else {
+        return {};
+      }
+    },
+    {
+      deferStream: true
+    }
+  );
 
   // We need a space here to prevent the server from collapsing the space between the style tags
   // and making it invalid

--- a/packages/start/root/InlineStyles.tsx
+++ b/packages/start/root/InlineStyles.tsx
@@ -4,11 +4,8 @@ import type { PageEvent } from "../server";
 import { ServerContext } from "../server/ServerContext";
 import { routeLayouts } from "./FileRoutes";
 
-export async function getInlineStyles(
-  env: PageEvent["env"],
-  routerContext: PageEvent["routerContext"]
-) {
-  const match = routerContext.matches.reduce((memo, m) => {
+async function getInlineStyles(env: PageEvent["env"], routerContext: PageEvent["routerContext"]) {
+  const match = routerContext.matches.reduce((memo: string[], m) => {
     if (m.length) {
       const fullPath = m.reduce((previous, match) => previous + match.originalPath, "");
       if (env.devManifest.find(entry => entry.path === fullPath)) {
@@ -35,7 +32,7 @@ export async function getInlineStyles(
 export function InlineStyles() {
   const isDev = import.meta.env.MODE === "development";
   const context = useContext(ServerContext);
-  if (!isDev) {
+  if (!isDev || !import.meta.env.START_SSR) {
     return null;
   }
 
@@ -43,6 +40,8 @@ export function InlineStyles() {
     deferStream: true
   });
 
+  // We need a space here to prevent the server from collapsing the space between the style tags
+  // and making it invalid
   return (
     <Suspense>
       <Show when={resource()}>

--- a/packages/start/root/Scripts.tsx
+++ b/packages/start/root/Scripts.tsx
@@ -14,7 +14,7 @@ export default function Scripts() {
   const context = useContext(ServerContext);
   return (
     <>
-      <HydrationScript />
+      {import.meta.env.START_SSR && <HydrationScript />}
       <NoHydration>
         {isServer &&
           (isDev ? (
@@ -22,8 +22,10 @@ export default function Scripts() {
               <script type="module" src="/@vite/client" $ServerOnly></script>
               <script type="module" async src="/src/entry-client" $ServerOnly></script>
             </>
-          ) : (
+          ) : import.meta.env.START_SSR ? (
             getEntryClient(context.env.manifest)
+          ) : (
+            <script type="module" async src="/src/entry-client" $ServerOnly></script>
           ))}
       </NoHydration>
       {isDev && <InlineStyles />}

--- a/packages/start/root/index.tsx
+++ b/packages/start/root/index.tsx
@@ -1,4 +1,5 @@
 // isomorphic exports
+export { Body, Head, Html } from "./Document";
 export { default as FileRoutes } from "./FileRoutes";
 export { default as Links } from "./Links";
 export { default as Meta } from "./Meta";

--- a/packages/start/server/types.tsx
+++ b/packages/start/server/types.tsx
@@ -27,7 +27,7 @@ export interface FetchEvent {
   env: {
     manifest?: Record<string, ManifestEntry[]>;
     collectStyles?: (matches: string[]) => Promise<Record<string, string>>;
-    devManifest: ManifestEntry[];
+    devManifest: [{ path: string; componentPath: string; id: string }];
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,8 @@ importers:
       '@babel/preset-typescript': ^7.16.7
       '@babel/template': ^7.16.7
       '@types/cookie': ^0.5.1
+      '@types/debug': ^4.1.7
+      '@types/wait-on': ^5.3.1
       chokidar: ^3.5.3
       compression: ^1.7.4
       connect: ^3.7.0
@@ -316,6 +318,7 @@ importers:
       vite: ^2.8.6
       vite-plugin-inspect: ^0.3.13
       vite-plugin-solid: ^2.2.6
+      wait-on: ^6.0.1
     dependencies:
       '@babel/core': 7.18.6
       '@babel/generator': 7.18.7
@@ -341,7 +344,10 @@ importers:
       undici: 5.6.0
       vite-plugin-inspect: 0.3.15_vite@2.9.13
       vite-plugin-solid: 2.2.6
+      wait-on: 6.0.1_debug@4.3.4
     devDependencies:
+      '@types/debug': 4.1.7
+      '@types/wait-on': 5.3.1
       solid-app-router: 0.4.1_solid-js@1.4.7
       solid-js: 1.4.7
       solid-meta: 0.27.5_solid-js@1.4.7
@@ -3268,6 +3274,12 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
+  /@types/wait-on/5.3.1:
+    resolution: {integrity: sha512-2FFOKCF/YydrMUaqg+fkk49qf0e5rDgwt6aQsMzFQzbS419h2gNOXyiwp/o2yYy27bi/C1z+HgfncryjGzlvgQ==}
+    dependencies:
+      '@types/node': 18.0.1
+    dev: true
+
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: true
@@ -3606,6 +3618,14 @@ packages:
     dev: true
 
   /axios/0.25.0:
+    resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
+    dependencies:
+      follow-redirects: 1.15.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios/0.25.0_debug@4.3.4:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
       follow-redirects: 1.15.1
@@ -10432,6 +10452,20 @@ packages:
     hasBin: true
     dependencies:
       axios: 0.25.0
+      joi: 17.6.0
+      lodash: 4.17.21
+      minimist: 1.2.6
+      rxjs: 7.5.6
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /wait-on/6.0.1_debug@4.3.4:
+    resolution: {integrity: sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      axios: 0.25.0_debug@4.3.4
       joi: 17.6.0
       lodash: 4.17.21
       minimist: 1.2.6

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -12,47 +12,6 @@ test.describe("actions", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
       files: {
-        // "src/entry-client.tsx": js`
-        //   import { render } from "solid-js/web";
-        //   import { StartClient } from "solid-start/entry-client";
-
-        //   render(() => <StartClient />, document.body);
-        // `,
-        // "vite.config.ts": js`
-        //   import { defineConfig } from "vite";
-        //   import solid from "solid-start";
-
-        //   export default defineConfig({
-        //     plugins: [solid({ ssr: false })]
-        //   });
-        // `,
-        // "src/root.tsx": js`
-        //   import { Links, Meta, FileRoutes, Scripts } from "solid-start/root";
-        //   import { Routes } from "solid-app-router";
-        //   import { Suspense } from "solid-js";
-
-        //   export default function Root() {
-        //     return (
-        //       <>
-        //         <div id="content">
-        //           <h1>Root</h1>
-        //           <Routes><FileRoutes /></Routes>
-        //         </div>
-        //       </>
-        //     );
-        //   }
-        // `,
-        // "index.html": js`
-        //   <!DOCTYPE html>
-        //   <html lang="en">
-        //     <head>
-        //       <meta charset="utf-8" />
-        //       <meta name="viewport" content="width=device-width, initial-scale=1" />
-        //       <script type="module" src="./src/entry-client.tsx"></script>
-        //     </head>
-        //     <body></body>
-        //   </html>
-        // `,
         "src/routes/client-action.tsx": js`
           import { createRouteAction } from 'solid-start/data';
 
@@ -124,6 +83,7 @@ test.describe("actions", () => {
             );
           }
         `,
+        // TODO: check the bug related to Document hydration for the `< when={action.value}>`
         "src/routes/server-action-in-component.tsx": js`
           import { Action } from '~/components/Action';
           export default function Route() {
@@ -147,7 +107,7 @@ test.describe("actions", () => {
                 <button onClick={e => action.submit({ hello: "world" })} id="submit-earth">Earth</button>
                 <button onClick={e => action.submit({ hello: "mars" })} id="submit-mars">Mars</button>
                 <button onClick={e => action.reset()} id="reset">Reset</button>
-                <Show when={action.value}><p id="result">{action.value}</p></Show>
+                <Show when={() => action.value}><p id="result">{action.value}</p></Show>
                 <Show when={action.state === "pending"}><p id="pending">Pending</p></Show>
               </>
             );

--- a/test/spa-test.ts
+++ b/test/spa-test.ts
@@ -12,10 +12,9 @@ test.describe("spa rendering", () => {
     fixture = await createFixture({
       files: {
         "src/entry-client.tsx": js`
-          import { render } from "solid-js/web";
-          import { StartClient } from "solid-start/entry-client";
+          import { mount, StartClient } from "solid-start/entry-client";
           
-          render(() => <StartClient />, document.body);
+          mount(() => <StartClient />, document.body);
         `,
         "vite.config.ts": js`
           import { defineConfig } from "vite";
@@ -84,7 +83,7 @@ test.describe("spa rendering", () => {
     let res = await fixture.requestDocument("/");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")?.includes("text/html")).toBe(true);
-    expect(async () => selectHtml(await res.text(), "#content")).rejects.toThrow();
+    expect((async () => selectHtml(await res.text(), "#content"))()).rejects.toThrow();
   });
 
   test("client side rendering", async ({ page }) => {
@@ -94,7 +93,9 @@ test.describe("spa rendering", () => {
       prettyHtml(`
       <div id="content">
         <h1>Root</h1>
+        <!--#-->
         <h2>Index</h2>
+        <!--/-->
       </div>`)
     );
 
@@ -103,7 +104,9 @@ test.describe("spa rendering", () => {
       prettyHtml(`
       <div id="content">
         <h1>Root</h1>
+        <!--#-->
         <h2>About</h2>
+        <!--/-->
       </div>`)
     );
   });

--- a/test/spa-test.ts
+++ b/test/spa-test.ts
@@ -8,106 +8,148 @@ test.describe("spa rendering", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
-  test.beforeAll(async () => {
-    fixture = await createFixture({
-      files: {
-        "src/entry-client.tsx": js`
-          import { mount, StartClient } from "solid-start/entry-client";
-          
-          mount(() => <StartClient />, document.body);
-        `,
-        "vite.config.ts": js`
-          import { defineConfig } from "vite";
-          import solid from "solid-start";
+  const files = {
+    "src/entry-client.tsx": js`
+      import { mount, StartClient } from "solid-start/entry-client";
+      
+      mount(() => <StartClient />, document.body);
+    `,
+    "vite.config.ts": js`
+      import { defineConfig } from "vite";
+      import solid from "solid-start";
 
-          export default defineConfig({
-            plugins: [solid({ ssr: false, adapter: process.env.ADAPTER })]
-          });
-        `,
-        "src/root.tsx": js`
-          import { Links, Meta, FileRoutes, Scripts } from "solid-start/root";
-          import { Routes } from "solid-app-router";
-          import { Suspense } from "solid-js";
-
-          export default function Root() {
-            return (
-              <>
-                <div id="content">
-                  <h1>Root</h1>
-                  <Routes><FileRoutes /></Routes>
-                </div>
-              </>
-            );
-          }
-        `,
-        "index.html": js`
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <meta name="viewport" content="width=device-width, initial-scale=1" />
-              <script type="module" src="./src/entry-client.tsx"></script>
-            </head>
-            <body></body>
-          </html>
-        `,
-        "src/routes/index.tsx": js`
-          export default function Index() {
-            return <h2>Index</h2>;
-          }
-        `,
-        "src/routes/about.tsx": js`
-          export default function About() {
-            return <h2>About</h2>;
-          }
-        `
+      export default defineConfig({
+        plugins: [solid({ ssr: false, adapter: process.env.ADAPTER })]
+      });
+    `,
+    "src/routes/index.tsx": js`
+      export default function Index() {
+        return <h2>Index</h2>;
       }
+    `,
+    "src/routes/about.tsx": js`
+      export default function About() {
+        return <h2>About</h2>;
+      }
+    `
+  };
+  test.describe("with index.html", () => {
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        files: {
+          ...files,
+          "src/root.tsx": js`
+            import { Links, Meta, FileRoutes, Scripts } from "solid-start/root";
+            import { Routes } from "solid-app-router";
+            import { Suspense } from "solid-js";
+
+            export default function Root() {
+              return (
+                <>
+                  <div id="content">
+                    <h1>Root</h1>
+                    <Routes><FileRoutes /></Routes>
+                  </div>
+                </>
+              );
+            }
+          `,
+          "index.html": js`
+            <!DOCTYPE html>
+            <html lang="en">
+              <head>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <script type="module" src="./src/entry-client.tsx"></script>
+              </head>
+              <body></body>
+            </html>
+          `
+        }
+      });
+
+      appFixture = await fixture.createServer();
     });
 
-    appFixture = await fixture.createServer();
-  });
-
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
-
-  let logs: string[] = [];
-
-  test.beforeEach(({ page }) => {
-    page.on("console", msg => {
-      logs.push(msg.text());
+    test.afterAll(async () => {
+      await appFixture.close();
     });
+
+    runTests();
   });
 
-  test("server rendering doesn't include content", async () => {
-    let res = await fixture.requestDocument("/");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")?.includes("text/html")).toBe(true);
-    expect((async () => selectHtml(await res.text(), "#content"))()).rejects.toThrow();
+  test.describe("with root.tsx", () => {
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        files: {
+          ...files,
+          "src/root.tsx": js`
+            import { FileRoutes, Scripts } from "solid-start/root";
+            import { Routes } from "solid-app-router";
+            import { Suspense } from "solid-js";
+            import { Html, Head, Body } from "solid-start/root";
+            import { Meta } from 'solid-meta'
+
+            export default function Root() {
+              return (
+                <Html lang="en">
+                  <Head>
+                    <Meta charset="utf-8" />
+                    <Meta name="viewport" content="width=device-width, initial-scale=1" />
+                  </Head>
+                  <Body>
+                    <div id="content">
+                      <h1>Root</h1>
+                      <Routes>
+                        <FileRoutes />
+                      </Routes>
+                    </div>
+                    <Scripts />
+                  </Body>
+                </Html>
+              );
+            }
+          `
+        }
+      });
+
+      appFixture = await fixture.createServer();
+    });
+
+    test.afterAll(async () => {
+      await appFixture.close();
+    });
+
+    runTests();
   });
 
-  test("client side rendering", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/", true);
-    expect(await app.getHtml("#content")).toBe(
-      prettyHtml(`
+  function runTests() {
+    test("server rendering doesn't include content", async () => {
+      let res = await fixture.requestDocument("/");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")?.includes("text/html")).toBe(true);
+      expect((async () => selectHtml(await res.text(), "#content"))()).rejects.toThrow();
+    });
+
+    test("client side rendering", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+      expect(await app.getHtml("#content")).toBe(
+        prettyHtml(`
       <div id="content">
         <h1>Root</h1>
-        <!--#-->
         <h2>Index</h2>
-        <!--/-->
       </div>`)
-    );
+      );
 
-    await app.goto("/about", true);
-    expect(await app.getHtml("#content")).toBe(
-      prettyHtml(`
+      await app.goto("/about", true);
+      expect(await app.getHtml("#content")).toBe(
+        prettyHtml(`
       <div id="content">
         <h1>Root</h1>
-        <!--#-->
         <h2>About</h2>
-        <!--/-->
       </div>`)
-    );
-  });
+      );
+    });
+  }
 });

--- a/test/spa-test.ts
+++ b/test/spa-test.ts
@@ -9,11 +9,6 @@ test.describe("spa rendering", () => {
   let appFixture: AppFixture;
 
   const files = {
-    "src/entry-client.tsx": js`
-      import { mount, StartClient } from "solid-start/entry-client";
-      
-      mount(() => <StartClient />, document.body);
-    `,
     "vite.config.ts": js`
       import { defineConfig } from "vite";
       import solid from "solid-start";

--- a/test/template/src/entry-client.tsx
+++ b/test/template/src/entry-client.tsx
@@ -1,4 +1,3 @@
-import { hydrate } from "solid-js/web";
-import { StartClient } from "solid-start/entry-client";
+import { mount, StartClient } from "solid-start/entry-client";
 
-hydrate(() => <StartClient />, document);
+mount(() => <StartClient />, document);

--- a/test/template/src/root.tsx
+++ b/test/template/src/root.tsx
@@ -1,28 +1,27 @@
 // @refresh reload
 import { Routes } from "solid-app-router";
 import { Suspense } from "solid-js";
+import { Meta } from "solid-meta";
 import { ErrorBoundary } from "solid-start/error-boundary";
-import { FileRoutes, Links, Meta, Scripts } from "solid-start/root";
+import { Body, FileRoutes, Head, Html, Scripts } from "solid-start/root";
 
 export default function Root() {
   return (
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <ErrorBoundary>
-          <Suspense>
+    <Html lang="en">
+      <Head>
+        <Meta charset="utf-8" />
+        <Meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Body>
+        <Suspense>
+          <ErrorBoundary>
             <Routes>
               <FileRoutes />
             </Routes>
-          </Suspense>
-        </ErrorBoundary>
+          </ErrorBoundary>
+        </Suspense>
         <Scripts />
-      </body>
-    </html>
+      </Body>
+    </Html>
   );
 }


### PR DESCRIPTION
1. We can use the setup we have with SSR by using the same root and entry-client, we ignore the entry-server in prod.. but we use it at build time to construct a shell for the SPA. The shell will include all the content upto the file routes such that it can include api calls that could be cached at build time (if desired, of course we will need a way to disable this feature so everything is SPA, including index.html)