### PR TITLE
fix: solid-start merge babel options

### DIFF
--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -437,13 +437,13 @@ export default function solidStart(options) {
 
         if (options.ssr) {
           // NOTE push or shift?
-          baseOptions.push([
+          processedOptions.push([
             babelServerModule,
             { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
           ])
         }
         
-        return baseOptions;
+        return processedOptions;
       },
     }),
     options.ssr && solidStartSSR(options),

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -429,16 +429,22 @@ export default function solidStart(options) {
     options.ssr && solidStartInlineServerModules(options),
     solid({
       ...(options ?? {}),
-      babel: (source, id, ssr) => ({
-        plugins: options.ssr
-          ? [
-              [
-                babelServerModule,
-                { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
-              ]
-            ]
-          : []
-      })
+      babel: (source, id, ssr) => {
+        const baseOptions = options?.babel ?? [];
+        const processedOptions = typeof baseOptions === 'function'
+          ? baseOptions(source, id, ssr)
+          : baseOptions;
+
+        if (options.ssr) {
+          // NOTE push or shift?
+          baseOptions.push([
+            babelServerModule,
+            { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
+          ])
+        }
+        
+        return baseOptions;
+      },
     }),
     options.ssr && solidStartSSR(options),
     solidsStartRouteManifest(options)

--- a/packages/start/plugin.js
+++ b/packages/start/plugin.js
@@ -430,14 +430,17 @@ export default function solidStart(options) {
     solid({
       ...(options ?? {}),
       babel: (source, id, ssr) => {
-        const baseOptions = options?.babel ?? [];
+        const baseOptions = options?.babel ?? {};
         const processedOptions = typeof baseOptions === 'function'
           ? baseOptions(source, id, ssr)
           : baseOptions;
 
         if (options.ssr) {
+          if (!processedOptions.plugins) {
+            processedOptions.plugins = [];
+          }
           // NOTE push or shift?
-          processedOptions.push([
+          processedOptions.plugins.push([
             babelServerModule,
             { ssr, root: process.cwd(), minify: process.env.NODE_ENV === "production" }
           ])


### PR DESCRIPTION
Probably an oversight. `solid-start`'s vite plugin completely omits the `babel` option for `vite-plugin-solid`.

As for the server transform, I'm not sure where to put it, but for now I'll just use `push`.