### PR TITLE
fix entry-client url on Windows

### DIFF
--- a/packages/start/root/Scripts.tsx
+++ b/packages/start/root/Scripts.tsx
@@ -32,7 +32,7 @@ export default function Scripts() {
               <script
                 type="module"
                 async
-                src={import.meta.env.START_ENTRY_CLIENT}
+                src={"/@fs/" + import.meta.env.START_ENTRY_CLIENT}
                 $ServerOnly
               ></script>
             </>


### PR DESCRIPTION
Since on windows the URL was starting with `C:\` the browser was treating it as a local file request.

This PR simply adds `/@fs/` in front of the absolute file path.

This will create URLs like the following:

Windows
`/@fs/C:\...\examples\bare\src\entry-client.tsx`

Linux
`/@fs//home/.../examples/bare/src/entry-client.tsx`

The vite dev server seems to handle the extra slash in the Linux URL just fine and the browser seems to take care of converting the backslashes to slashes.

I tested this on Windows and WSL Ubuntu, with an entry-client and without.