### PR TITLE
Fixed path resolution when using windows

### DIFF
--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -18,6 +18,7 @@ function getAllFiles(dirPath, pageRoot, arrayOfFiles) {
       arrayOfFiles.push(
         join(dirPath, "/", file)
           .replace(pageRoot, "")
+          .replace(/\\/g, "/")
           .replace(/(\/index)?(.jsx|.tsx)/, "") || "/"
       );
     }


### PR DESCRIPTION
Fixed a problem in which backslashes were used in the path when using `solid-start-static` on windows and it did not build properly.
