### PR TITLE
Fix HMR issue caused by the collection of styles during dev

### DIFF
--- a/packages/start/dev/server.js
+++ b/packages/start/dev/server.js
@@ -28,9 +28,8 @@ export function createDevHandler(viteServer, config, options) {
             const styles = {};
             const deps = new Set();
             for (const file of match) {
-              const absolutePath = path.resolve(file);
-              await viteServer.ssrLoadModule(absolutePath);
-              const node = await viteServer.moduleGraph.getModuleByUrl(absolutePath);
+              const normalizedPath = path.resolve(file).replace(/\\/g, "/");
+              const node = await viteServer.moduleGraph.getModuleById(normalizedPath);
 
               await find_deps(viteServer, node, deps);
             }


### PR DESCRIPTION
The page would always reload after changing the JSX inside a page. This shouldn't happen because `vite-plugin-solid` injects `solid-refresh` in every component. 

This was caused by there being 2 different `ModuleNode` for the same module. This in turn caused the `isSelfAccepting` property to get set on the duplicate module instead of the original one.

This issue couldn't be replicated by directly running one of the example in the `solid-start` repo because `solid-refresh` doesn't apply to files with `node_modules` in their path but since the examples use `pnpm link` the files in the `solid-start` package had a path without `node_modules` in it and were getting `solid-refresh` applied to them like `FileRoutes` which is what imported the pages and prevented the reload from happening.

To solve the duplicate module issue the call to `ssrLoadModule` was removed as it seemed unnecessary and `getModuleByUrl` was changed to `getModuleById` as it seemed a bit more consistent (always has absolute paths while the former has a mix of relative and absolute paths).