### PR TITLE
Fixed refresh bug as it would never match response 304 Not Modified

### DIFF
--- a/packages/start-cloudflare-pages/entry.js
+++ b/packages/start-cloudflare-pages/entry.js
@@ -5,7 +5,7 @@ export const onRequestGet = async ({ request, next, env }) => {
   // Handle static assets
   if (/\.\w+$/.test(request.url)) {
     let resp = await next(request);
-    if (resp.status === 200) {
+    if (resp.status === 200 || 304) {
       return resp;
     }
   }
@@ -25,7 +25,7 @@ export const onRequestHead = async ({ request, next, env }) => {
   // Handle static assets
   if (/\.\w+$/.test(request.url)) {
     let resp = await next(request);
-    if (resp.status === 200) {
+    if (resp.status === 200 || 304) {
       return resp;
     }
   }


### PR DESCRIPTION
### Cloudflare Pages Adapter

- When refreshing the page currently `entry.js` does not match response 304 and will fail to load assets until a subsequent refresh.

- I've now added `(resp.status === 200 || 304)` so if nothing has changed on the page it will now return assets on page reload.
