### PR TITLE
docs: Fix start command in example READMEs

### DIFF
--- a/examples/bare/README.md
+++ b/examples/bare/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/durable-objects-websocket/README.md
+++ b/examples/durable-objects-websocket/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -23,4 +23,4 @@ npm run dev -- --open
 
 SolidStart apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm run start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/with-solid-styled/README.md
+++ b/examples/with-solid-styled/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.

--- a/test/template/README.md
+++ b/test/template/README.md
@@ -27,4 +27,4 @@ npm run dev -- --open
 
 Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `node build`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.
+By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `vite.config.js`.


### PR DESCRIPTION
I noticed all but one of the example README's had the command `node build` written where it should be `npm start` instead.

I also modified the one instance of `npm run start` to just `npm start` since you don't need to include `run` when using `start`. As far as I can tell there's [no real difference between the two](https://stackoverflow.com/questions/51358235/difference-between-npm-start-and-npm-run-start) so the more concise option seems preferable to me.