### PR TITLE
Add cache control header for immutable static assets

### DIFF
--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -2,12 +2,13 @@ import common from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import { spawn } from "child_process";
-import { copyFileSync } from "fs";
+import { copyFileSync, writeFileSync } from "fs";
 import { Miniflare } from "miniflare";
 import { dirname, join } from "path";
 import { rollup } from "rollup";
 import { fileURLToPath } from "url";
 import { createServer } from "./dev-server.js";
+
 export default function (miniflareOptions) {
   return {
     name: "cloudflare-pages",
@@ -132,6 +133,8 @@ export default function (miniflareOptions) {
         await builder.server(join(config.root, ".solid", "server"));
       }
 
+      writeFileSync(join(config.root, "dist", "public", "_headers"), getHeadersFile(), "utf8");
+
       copyFileSync(
         join(config.root, ".solid", "server", `entry-server.js`),
         join(config.root, ".solid", "server", "handler.js")
@@ -161,3 +164,13 @@ export default function (miniflareOptions) {
     }
   };
 }
+
+/**
+ * @see https://developers.cloudflare.com/pages/platform/headers/
+ */
+// prettier-ignore
+const getHeadersFile = () =>
+`
+/assets/*
+  Cache-Control: public, immutable, max-age=31536000
+`.trim();

--- a/packages/start-cloudflare-workers/entry.js
+++ b/packages/start-cloudflare-workers/entry.js
@@ -3,12 +3,31 @@ import manifestJSON from "__STATIC_CONTENT_MANIFEST";
 import manifest from "../../dist/public/route-manifest.json";
 import handler from "./handler";
 
+/**
+ * @example
+ * ```json
+ * {
+ *   "assets/Counter.e8357007.js": "assets/Counter.e8357007.8f31e4baa4.js",
+ *   "assets/_...404_.68cf6c56.js": "assets/_...404_.68cf6c56.baba7f4d98.js",
+ *   "assets/about.f03466fc.js": "assets/about.f03466fc.390e8a8920.js",
+ *   "assets/entry-client.a6d191bb.js": "assets/entry-client.a6d191bb.530bd80ed6.js",
+ *   "assets/entry-client.b4a47d5a.css": "assets/entry-client.b4a47d5a.5df049b686.css",
+ *   "assets/index.d3e176d7.js": "assets/index.d3e176d7.e02e4320da.js",
+ *   "favicon.ico": "favicon.d2db245add.ico",
+ *   "manifest.json": "manifest.10eaf89c07.json",
+ *   "route-manifest.json": "route-manifest.4ff2febcfe.json",
+ *   "ssr-manifest.json": "ssr-manifest.63eaf33625.json"
+ * }
+ * ```
+ */
 const assetManifest = JSON.parse(manifestJSON);
 
 export default {
   async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+
     if (request.headers.get("Upgrade") === "websocket") {
-      const url = new URL(request.url);
       const durableObjectId = env.DO_WEBSOCKET.idFromName(url.pathname + url.search);
       const durableObjectStub = env.DO_WEBSOCKET.get(durableObjectId);
       const response = await durableObjectStub.fetch(request);
@@ -17,7 +36,7 @@ export default {
 
     env.manifest = manifest;
     env.getStaticAsset = async request => {
-      return await getAssetFromKV(
+      const response = await getAssetFromKV(
         {
           request,
           waitUntil(promise) {
@@ -29,6 +48,17 @@ export default {
           ASSET_MANIFEST: assetManifest
         }
       );
+
+      // This path comes from Vite at `build.assetsDir`
+      // or `build.rollupOptions.{entryFileNames,chunkFileNames,assetFileNames}`
+      // https://github.com/vitejs/vite/blob/07d3fbd21e6b63a12997d201a2deb5b2f2129882/packages/vite/src/node/build.ts#L552
+      const isAsset = pathname.startsWith("/assets/");
+
+      if (isAsset) {
+        response.headers.set("cache-control", "public, immutable, max-age=31536000");
+      }
+
+      return response;
     };
 
     env.getStaticHTML = async path => {

--- a/packages/start-deno/entry.js
+++ b/packages/start-deno/entry.js
@@ -16,10 +16,17 @@ serve(
 
     try {
       const file = await Deno.readFile(`./public${pathname}`);
+      const isAsset = pathname.startsWith("/assets/");
+
       // Respond to the request with the style.css file.
       return new Response(file, {
         headers: {
-          "content-type": lookup(pathname)
+          "content-type": lookup(pathname),
+          ...(isAsset
+            ? {
+                "cache-control": "public, immutable, max-age=31536000"
+              }
+            : {})
         }
       });
     } catch (e) {}

--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -57,6 +57,8 @@ export default function ({ edge } = {}) {
       // closes the bundle
       await bundle.close();
 
+      await promises.writeFile(join(config.root, "netlify", "_headers"), getHeadersFile(), "utf-8");
+
       if (edge) {
         const dir = join(config.root, ".netlify", "edge-functions");
         if (!existsSync(dir)) {
@@ -85,3 +87,13 @@ export default function ({ edge } = {}) {
     }
   };
 }
+
+/**
+ * @see https://docs.netlify.com/routing/headers/
+ */
+// prettier-ignore
+const getHeadersFile = () =>
+`
+/assets/*
+  Cache-Control: public, immutable, max-age=31536000
+`.trim();

--- a/packages/start-node/server.js
+++ b/packages/start-node/server.js
@@ -22,8 +22,12 @@ export function createServer({ handler, paths, env }) {
   });
   const assets_handler = fs.existsSync(paths.assets)
     ? sirv(paths.assets, {
-        maxAge: 31536000,
-        immutable: true
+        setHeaders: (res, pathname) => {
+          const isAsset = pathname.startsWith("/assets/");
+          if (isAsset) {
+            res.setHeader("cache-control", "public, immutable, max-age=31536000");
+          }
+        }
       })
     : (_req, _res, next) => next();
 

--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -81,6 +81,13 @@ export default function ({ edge } = {}) {
       const outputConfig = {
         version: 3,
         routes: [
+          // https://vercel.com/docs/project-configuration#project-configuration/headers
+          // https://vercel.com/docs/build-output-api/v3#build-output-configuration/supported-properties/routes/source-route
+          {
+            src: "/assets/(.*)",
+            headers: { "Cache-Control": "public, max-age=31556952, immutable" },
+            continue: true
+          },
           // Serve any matching static assets first
           { handle: "filesystem" },
           // Invoke the SSR function if not a static asset


### PR DESCRIPTION
Files in the [`/assets` dir](https://vitejs.dev/config/build-options.html#build-assetsdir) get a [content hash from Vite/Rollup](https://github.com/vitejs/vite/blob/07d3fbd21e6b63a12997d201a2deb5b2f2129882/packages/vite/src/node/build.ts#L552) by default. Because they have a content hash, the deploy adapters can give these files a `Cache-Control` header of `public, immutable, max-age=31536000` which will allow browsers to cache the files without needing to ping the server again.

This can speed up repeating loadings of the site deployment and also cut down on HTTP requests, which could help stretch the free quota or reduce costs for various serverless site providers.

I would like to have this feature in the Cloudflare Workers adapter, which I am currently using, so I tested this feature out there first.

But I figure it would be good to have in all the adapters so I tried to adjust all them. However, I have not fully tested them yet. If you have a chance, could you please take a look and let me know if I am on the right track with this PR?

Also, if I understood correctly, the Node.js adapter is currently giving an "immutable" cache header to all files in the public folder. This is not ideal, because there may be files in this folder that do *not* have a content hash and may occasionally update, such as `favicon.ico`, Web app manifest of PWAs, `apple-touch-icon.png`, etc. I updated the code to only use the immutable cache header for files in the `/public/assets/` folder.

Reference:

- Next.js documentation: https://nextjs.org/docs/going-to-production#caching
- Sveltekit adapters, eg: https://github.com/sveltejs/kit/blob/b4c268091b246befb1cb028875781285c9ff4aa5/packages/adapter-cloudflare/index.js#L98

Future considerations:

- I think the adapters should support a customizable `build.assetsDir` and [base url](https://vitejs.dev/config/shared-options.html#base) instead of hardcoding `/assets/`, but this is more complicated, we would need to pass these settings on to the adapters, perhaps via a generated manifest file.