### PR TITLE
Fix typo in api-routes page

### DIFF
--- a/docs/core-concepts/api-routes.md
+++ b/docs/core-concepts/api-routes.md
@@ -104,7 +104,7 @@ export async function GET({ params }: APIEvent) {
 ```
 
 
-## Session managmment
+## Session management
 
 As HTTP is a stateless protocol, for awesome dynamic experiences, you want to know the state of the session on the client. For example, you want to know who the user is. The secure way of doing this is to use HTTP-only cookies. You can store session data in them and they are persisted by the browser that your user is using. 
 


### PR DESCRIPTION
Before
<img width="484" alt="image" src="https://user-images.githubusercontent.com/73651621/196062126-622f5bbd-3dfa-486f-afa5-76513b6d2447.png">

After
<img width="597" alt="image" src="https://user-images.githubusercontent.com/73651621/196062116-89609b79-eb12-49b8-a7fa-2a6828ac1a07.png">
