### PR TITLE
`server$.fetch` forward headers during SSR

### DIFF
--- a/packages/start/api/internalFetch.ts
+++ b/packages/start/api/internalFetch.ts
@@ -1,3 +1,4 @@
+import { useServerContext } from "../server/ServerContext";
 import { FETCH_EVENT } from "../server/types";
 import { getRouteMatches } from "./router";
 import type { APIEvent, Method } from "./types";
@@ -8,16 +9,31 @@ export const registerApiRoutes = routes => {
   apiRoutes = routes;
 };
 
-export async function internalFetch(route: string, init: RequestInit) {
+const FORWARDED_HEADERS = ["cookie"];
+
+export async function internalFetch(route: string, init: RequestInit = {}) {
   if (route.startsWith("http")) {
     return await fetch(route, init);
   }
 
-  let url = new URL(route, "http://internal");
-  const request = new Request(url.href, init);
+  const headers = new Headers(init.headers);
+  const requestHeaders = useServerContext().request?.headers;
+  if (requestHeaders) {
+    for (const header of FORWARDED_HEADERS) {
+      if (requestHeaders.has(header)) {
+        headers.set(header, requestHeaders.get(header));
+      }
+    }
+  }
+
+  const url = new URL(route, "http://internal");
+  const request = new Request(url.href, {
+    ...init,
+    headers
+  });
   const handler = getRouteMatches(apiRoutes, url.pathname, request.method.toUpperCase() as Method);
 
-  let apiEvent: APIEvent = Object.freeze({
+  const apiEvent: APIEvent = Object.freeze({
     request,
     params: handler.params,
     env: {},

--- a/test/api-routes-test.ts
+++ b/test/api-routes-test.ts
@@ -35,6 +35,7 @@ test.describe("api routes", () => {
                 <a href="/redirect" rel="external">Redirect</a>
                 <a href="/server-data-fetch">Server data fetch</a>
                 <a href="/server-fetch">Server Fetch</a>
+                <a href="/server-fetch-cookie">Server Fetch Cookie</a>
                 <form action="/redirect-to" method="post">
                   <input name="destination" value="/redirect-destination" />
                   <button type="submit">Redirect</button>
@@ -132,10 +133,11 @@ test.describe("api routes", () => {
             }
           `,
           "src/routes/server-fetch-cookie.jsx": js`
-            import server$, { createServerData$ } from "solid-start/server";
+            import server$ from "solid-start/server";
+            import { createResource } from 'solid-js';
 
             export default function Page() {
-              const data = createServerData$(() => server$.fetch('/api/server-fetch-cookie').then(res => res.text()));
+              const [data] = createResource(() => server$.fetch('/api/server-fetch-cookie').then(res => res.text()));
 
               return <Show when={data()}><div data-testid="data">{data()}</div></Show>;
             }
@@ -203,9 +205,8 @@ test.describe("api routes", () => {
       page,
       context
     }) => {
-      await context.addCookies([{ name: "secret", value: "pass", url: page.url() }]);
-
-      let app = new PlaywrightFixture(appFixture, page);
+      const app = new PlaywrightFixture(appFixture, page);
+      await context.addCookies([{ name: "secret", value: "pass", url: appFixture.serverUrl }]);
       await app.goto("/server-fetch-cookie");
       let dataEl = await page.waitForSelector("[data-testid='data']");
       expect(await dataEl!.innerText()).toBe("pass");


### PR DESCRIPTION
Forward the cookie header from the original page request to the API route.

We could consider forwarding more headers or even letting the user configure which header to forward.

Sidenote:
I was not able to get the tests to run locally, going to test using the CI.