### PR TITLE
example: use native `<a>` element

### DIFF
--- a/examples/with-tailwindcss/src/routes/[...404].tsx
+++ b/examples/with-tailwindcss/src/routes/[...404].tsx
@@ -6,9 +6,9 @@ export default function NotFound() {
       <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">Not Found</h1>
       <p class="mt-8">
         Visit{" "}
-        <A href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
-        </A>{" "}
+        </a>{" "}
         to learn how to build Solid apps.
       </p>
       <p class="my-4">


### PR DESCRIPTION
In the Tailwind example, an `<A>` component is used for an external link. Changed that to a native `<a>` element.