### PR TITLE
example: enable type support for tailwind config

### DIFF
--- a/examples/with-tailwindcss/tailwind.config.cjs
+++ b/examples/with-tailwindcss/tailwind.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{html,js,jsx,ts,tsx}"],
   theme: {


### PR DESCRIPTION
Adds type annotation to `tailwind.config.js`, see [here](https://tailwindcss.com/docs/configuration#type-script-types).