### PR TITLE
fix: webcrypto global under Node 19 runtime

### DIFF
--- a/packages/start/node/globals.js
+++ b/packages/start/node/globals.js
@@ -7,5 +7,8 @@ Object.assign(globalThis, Streams, {
   Response,
   fetch,
   Headers,
-  crypto: crypto.webcrypto
 });
+
+if (globalThis.crypto != crypto.webcrypto) {
+  globalThis.crypto = crypto.webcrypto;
+}


### PR DESCRIPTION
Since Node 19, the [`crypto` global has been redefined to the WebCrypto object](https://nodejs.org/en/blog/announcements/v19-release-announce/#stable-webcrypto), and the [current globals.js](https://github.com/solidjs/solid-start/commit/fe6e4405c8d0205f95b1232f10c3290765cd159d) code errors as it can't assign to a key that's already a getter.

This PR checks if the `crypto` global is already the WebCrypto object first before redefining it. An alternative approach is to get `process.version` and verify the major version before assigning `globalThis.crypto`.