### PR TITLE
Fix/vite middleware name

### DIFF
--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -697,7 +697,8 @@ function remove_html_middlewares(server) {
   const html_middlewares = [
     "viteIndexHtmlMiddleware",
     "vite404Middleware",
-    "viteSpaFallbackMiddleware"
+    "viteSpaFallbackMiddleware",
+    "viteHtmlFallbackMiddleware"
   ];
   for (let i = server.stack.length - 1; i > 0; i--) {
     // @ts-ignore


### PR DESCRIPTION
`viteSpaFallbackMiddleware` was renamed to `viteHtmlFallbackMiddleware` in vite 3.2.0 (https://github.com/vitejs/vite/pull/10336)