### PR TITLE
fix prisma esm __dirname

### DIFF
--- a/packages/start-node/server.js
+++ b/packages/start-node/server.js
@@ -2,11 +2,14 @@ import compression from "compression";
 import { once } from "events";
 import fs from "fs";
 import { readFile } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import polka from "polka";
 import sirv from "sirv";
 import { createRequest } from "solid-start/node/fetch.js";
 import { Readable } from "stream";
+
+global.__dirname = dirname(fileURLToPath(import.meta.url));
 
 global.onunhandledrejection = (err, promise) => {
   console.error(err);


### PR DESCRIPTION
Prisma internally uses __dirname which breaks the solid-start start command with solid-start-node

```
dist/server.js => import_path.default.join(__dirname, "../query-engine-darwin");

ReferenceError: __dirname is not defined in ES module scope
```