### PR TITLE
Small css improvements

### DIFF
--- a/examples/movies/src/routes/layout.module.scss
+++ b/examples/movies/src/routes/layout.module.scss
@@ -54,7 +54,7 @@
   bottom: 0;
   left: 0;
   z-index: 5;
-  height: 4.5rem;
+  padding-block: 1.5rem;
   background-color: #000;
 
   @media (min-width: $breakpoint-large) {
@@ -68,6 +68,7 @@
   ul {
     display: flex;
     height: 100%;
+    align-items: center;
 
     @media (min-width: $breakpoint-large) {
       flex-direction: column;

--- a/examples/movies/src/routes/movie/[movieId]/layout.module.scss
+++ b/examples/movies/src/routes/movie/[movieId]/layout.module.scss
@@ -3,7 +3,7 @@
 
 .nav {
   display: flex;
-  height: 4.8rem;
+  gap: 1rem;
   background-color: #1b1b1b;
 
   @media (min-width: $breakpoint-large) {

--- a/examples/movies/src/routes/movie/[movieId]/layout.tsx
+++ b/examples/movies/src/routes/movie/[movieId]/layout.tsx
@@ -13,7 +13,7 @@ export default function MoviePage() {
       <Show when={data()}>
         <Hero item={data()?.item} />
       </Show>
-      <div class={styles.nav}>
+      <div class={`spacing ${styles.nav}`}>
         <A
           href={`/movie/${useParams().movieId}`}
           activeClass={styles.buttonActive}


### PR DESCRIPTION
I just did some small css improvements to:

- make the logo on mobile not touch the border of the nav
- make the menu in the movie details page not touch the border of the page and space the menu options out

I've checked and the Desktop design is still intact.

BEFORE & AFTER

Logo Before| Logo After
:-------------------------:|:-------------------------:
![Before](https://user-images.githubusercontent.com/26281609/198598421-88822ecf-a788-4823-8140-9d72c64975ac.png) | ![After)](https://user-images.githubusercontent.com/26281609/198598313-3b84cdda-c347-4939-91cf-008d86658132.png)  

Menu Before | Menu After
:-------------------------:|:-------------------------:
![Before](https://user-images.githubusercontent.com/26281609/198601393-af07bb47-c54b-4503-9c86-eca30694009a.png) | ![After](https://user-images.githubusercontent.com/26281609/198601362-281f0274-5d0e-49df-aeaa-d7e1a4bd2f10.png)


