### PR TITLE
Fix trpc example in docs

### DIFF
--- a/docs/core-concepts/api-routes.md
+++ b/docs/core-concepts/api-routes.md
@@ -200,31 +200,28 @@ export const appRouter = t.router({
     return `hello ${input ?? 'world'}`;
   }),
 });
+
+export type AppRouter = typeof appRouter;
 ```
 
 Here is a simple client that you can use in your `routeData` function to fetch data from your [tRPC][trpc] server. You can also use the proxy in `createServerData$` and `createServerAction$` functions, but it's usually better to just use it in a `createResource` or `createRouteData` function.
 
 ```tsx filename="lib/trpc.ts"
-export type AppRouter = typeof appRouter;
-
 import {
-  createTRPCClient,
-  createTRPCClientProxy,
+  createTRPCProxyClient,
   httpBatchLink,
   loggerLink,
 } from '@trpc/client';
-import type { AppRouter } from "./router.ts";
+import type { AppRouter } from "./router";
 
-const client = createTRPCClient<AppRouter>({
+export const client = createTRPCProxyClient<AppRouter>({
   links: [loggerLink(), httpBatchLink({ url: "/api/trpc" })],
 });
-
-export const proxy = createTRPCClientProxy(client);
 ```
 
 And finally, you can use the `fetch` adapter to write an API route that acts as the tRPC server.
 
-```tsx filename="routes/api/trpc.ts"
+```tsx filename="routes/api/trpc/[...].ts"
 import { APIEvent } from "solid-start/api";
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from "~/lib/router";


### PR DESCRIPTION
After creating a new solid-start project (bare/ts/no-ssr), installing tRPC and following the tRPC example in the docs, I ended up with a non-working state.

![issue1](https://user-images.githubusercontent.com/43080019/198960220-66a37262-ab96-45f9-be72-398abdc4bd3f.PNG)

Calling proxy.hello.query() results in a 404.

![issue2](https://user-images.githubusercontent.com/43080019/198960503-ddbee785-75bf-4bf4-bbcc-df3df7d8f687.PNG)

Let's update it.

- Replace createTRPCClient and createTRPCClientProxy with createTRPCProxyClient
- Move type AppRouter to lib/router.ts
- Use a catchall route

The tRPC client calls `/api/trpc/hello` which does not get handled by `routes/api/trpc.ts`.
Should the use of a catchall route be mentioned or is it enough to change filename to `routes/api/trpc/[...].ts`?