### PR TITLE
start/vite: Configurable hydration event names

### DIFF
--- a/packages/start/root/Scripts.tsx
+++ b/packages/start/root/Scripts.tsx
@@ -5,13 +5,16 @@ import { InlineStyles } from "./InlineStyles";
 
 const isDev = import.meta.env.MODE === "development";
 const isSSR = import.meta.env.START_SSR;
+const hydrationEvents = typeof import.meta.env.HYDRATION_EVENTS === 'string'
+  ? import.meta.env.HYDRATION_EVENTS.split(/\W\s*/g)
+  : undefined;
 const isIslands = import.meta.env.START_ISLANDS;
 
 export default function Scripts() {
   const context = useContext(ServerContext);
   return (
     <>
-      {isSSR && <HydrationScript />}
+      {isSSR && <HydrationScript eventNames={hydrationEvents} />}
       {isIslands && (
         <script>{`
         _$HY.islandMap = {};

--- a/packages/start/types.ts
+++ b/packages/start/types.ts
@@ -28,6 +28,7 @@ export type StartOptions = {
   appRoot: string;
   routesDir: string;
   ssr: boolean;
+  hydrationEvents: string[];
   islands: boolean;
   islandsRouter: boolean;
   lazy: boolean;
@@ -40,4 +41,4 @@ export type StartOptions = {
   appRootFile: string;
 };
 
-export {};
+export { };

--- a/packages/start/vite/plugin.d.ts
+++ b/packages/start/vite/plugin.d.ts
@@ -3,6 +3,7 @@ export type Options = {
   appRoot: string;
   routesDir: string;
   ssr: boolean;
+  hydrationEvents: string[];
   islands: boolean;
   islandsRouter: boolean;
   prerenderRoutes: any[];

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -501,6 +501,9 @@ function solidStartConfig(options) {
           "process.env.TEST_ENV": JSON.stringify(process.env.TEST_ENV),
           "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
           "import.meta.env.START_SSR": JSON.stringify(options.ssr ? true : false),
+          "import.meta.env.HYDRATION_EVENTS": options.hydrationEvents
+            ? JSON.stringify(options.hydrationEvents.join(', '))
+            : undefined,
           "import.meta.env.START_ISLANDS": JSON.stringify(options.islands ? true : false),
           "import.meta.env.START_ENTRY_CLIENT": JSON.stringify(options.clientEntry),
           "import.meta.env.START_ENTRY_SERVER": JSON.stringify(options.serverEntry),
@@ -590,6 +593,9 @@ export default function solidStart(options) {
       appRoot: "src",
       routesDir: "routes",
       ssr: process.env.START_SSR === "false" ? false : true,
+      hydrationEvents: typeof process.env.HYDRATION_EVENTS === 'string'
+        ? process.env.HYDRATION_EVENTS.split(/\W\s*/g)
+        : undefined,
       islands: process.env.START_ISLANDS === "true" ? true : false,
       islandsRouter: process.env.START_ISLANDS_ROUTER === "true" ? true : false,
       lazy: true,


### PR DESCRIPTION
At the moment, hydration only works for input and click events. Other events are not covered. In my case, I want to detect other events, so I want to have this configurable.