### PR TITLE
Fix prisma example

### DIFF
--- a/examples/with-prisma/src/routes/login.tsx
+++ b/examples/with-prisma/src/routes/login.tsx
@@ -19,7 +19,7 @@ function validatePassword(password: unknown) {
 
 export function routeData() {
   return createServerData$(async (_, { request }) => {
-    if (await getUser(request)) {
+    if (await getUser(db, request)) {
       throw redirect("/");
     }
     return {};

--- a/examples/with-prisma/vite.config.ts
+++ b/examples/with-prisma/vite.config.ts
@@ -2,5 +2,6 @@ import solid from "solid-start/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [solid()]
+  plugins: [solid()],
+  ssr: { external: ["@prisma/client"] }
 });


### PR DESCRIPTION
Example does not work.

- Call to `getUser` in login.tsx is missing db as first argument
- Production build fails to start without externalizing `@prisma/client`

Trying to start production build without externalizing the prisma client will result in:
![prisma](https://user-images.githubusercontent.com/43080019/200378673-29ed37ca-da14-4319-b061-7572acbf9599.PNG)
