### PR TITLE
Fix `with-websocket` Example

### DIFF
--- a/examples/with-websocket/package.json
+++ b/examples/with-websocket/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",
     "@cloudflare/workers-types": "^3.17.0",
+    "@solidjs/meta": "^0.28.0",
     "@solidjs/router": "^0.5.0",
     "solid-js": "^1.6.0",
     "solid-start": "^0.2.0",


### PR DESCRIPTION
Added missing dependency for `with-websocket` example.

Related to https://github.com/solidjs/solid-start/issues/417