### PR TITLE
fix(example:with-prisma): Fixed a breaking bug in with-prisma example

### DIFF
--- a/examples/with-prisma/src/routes/login.tsx
+++ b/examples/with-prisma/src/routes/login.tsx
@@ -19,7 +19,7 @@ function validatePassword(password: unknown) {
 
 export function routeData() {
   return createServerData$(async (_, { request }) => {
-    if (await getUser(request)) {
+    if (await getUser(db, request)) {
       throw redirect("/");
     }
     return {};


### PR DESCRIPTION
The app was breaking because we needed to pass `db` as well as `request` object to the getUser function called in `login.tsx`.

I updated the file and now the app starts without any bug!