### PR TITLE
Undefined when converted to string returns "undefined"

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -131,7 +131,7 @@ prog
         stdio: "inherit",
         env: {
           ...process.env,
-          NODE_OPTIONS: `--experimental-vm-modules ${inspect ? "--inspect" : undefined}`
+          NODE_OPTIONS: `--experimental-vm-modules ${inspect ? "--inspect" : ''}`
         }
       }
     );


### PR DESCRIPTION
Also while I'm here. Do you think we should pass original NODE_OPTIONS, like

```ts
NODE_OPTIONS: `--experimental-vm-modules ${inspect ? "--inspect" : ''} ${process.env.NODE_OPTIONS || ''}`
```
?