### PR TITLE
Add `@latest` to `npm init solid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is the home of the Solid app framework. This is still a **work in progress*
 ```bash
 mkdir my-app
 cd my-app
-npm init solid
+npm init solid@latest
 npm install
 npm run dev
 ```

--- a/docs/getting-started/project-setup.mdx
+++ b/docs/getting-started/project-setup.mdx
@@ -14,7 +14,7 @@ To create your first SolidStart application, create a directory, change into tha
 ```bash
 # npm
 mkdir my-app && cd my-app
-npm init solid
+npm init solid@latest
 # pnpm
 mkdir my-app && cd my-app
 pnpm create solid

--- a/examples/bare/README.md
+++ b/examples/bare/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -3,7 +3,7 @@
 Hackernews example powered by [`solid-start`](https://start.solidjs.com);
 
 ```bash
-npm init solid -- --template hackernews
+npm init solid@latest -- --template hackernews
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/solidjs/solid-start/tree/main/examples/hackernews)

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-prisma/README.md
+++ b/examples/with-prisma/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-solid-styled/README.md
+++ b/examples/with-solid-styled/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/examples/with-websocket/README.md
+++ b/examples/with-websocket/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solis
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing

--- a/packages/create-solid/README.md
+++ b/packages/create-solid/README.md
@@ -8,7 +8,7 @@ The easiest way to get started with Solid is by using `create-solid`. This CLI t
 
 ```bash
 #or
-npm init solid ./my-solid-app
+npm init solid@latest ./my-solid-app
 
 # or
 yarn create solid ./my-solid-app
@@ -18,6 +18,6 @@ yarn create solid ./my-solid-app
 
 `create-solid` allows you to create a new Solid app within seconds. It is officially maintained by the creators of Solid, and includes a number of benefits:
 
-- **Interactive Experience**: Running `npm init solid` (with no arguments) launches an interactive experience that guides you through setting up a project.
+- **Interactive Experience**: Running `npm init solid@latest` (with no arguments) launches an interactive experience that guides you through setting up a project.
 - **Zero Dependencies**: Initializing a project is as quick as one second. Create Solid has zero dependencies.
-- **Support for Examples**: Create Solid App can bootstrap your application using an example from the SolidStart official examples collection (e.g. `npm init solid --example with-mdx`).
+- **Support for Examples**: Create Solid App can bootstrap your application using an example from the SolidStart official examples collection (e.g. `npm init solid@latest --example with-mdx`).

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -7,7 +7,7 @@ The quickest way to get started:
 ```bash
 mkdir my-app
 cd my-app
-npm init solid
+npm init solid@latest
 npm install
 npm run dev
 ```

--- a/test/template/README.md
+++ b/test/template/README.md
@@ -6,10 +6,10 @@ Everything you need to build a Solid project, powered by [`solid-start`](https:/
 
 ```bash
 # create a new project in the current directory
-npm init solid
+npm init solid@latest
 
 # create a new project in my-app
-npm init solid my-app
+npm init solid@latest my-app
 ```
 
 ## Developing


### PR DESCRIPTION
`npm init` uses a local cached package if existed.
So an outdated version could be called with `npm init solid`.

This PR changes all `npm init solid` to `npm init solid@latest` to prevent this. (pnpm always fetches the latest version and doesn't need `@latest`.)
