### PR TITLE
example: using native `<a>` for external links, updated navbar (tailwind example)

### DIFF
--- a/examples/with-tailwindcss/src/root.tsx
+++ b/examples/with-tailwindcss/src/root.tsx
@@ -1,6 +1,7 @@
 // @refresh reload
 import { Suspense } from "solid-js";
 import {
+  useLocation,
   A,
   Body,
   ErrorBoundary,
@@ -10,11 +11,16 @@ import {
   Meta,
   Routes,
   Scripts,
-  Title
+  Title,
 } from "solid-start";
 import "./root.css";
 
 export default function Root() {
+  const location = useLocation();
+  const active = (path: string) =>
+    path == location.pathname
+      ? "border-sky-600"
+      : "border-transparent hover:border-sky-600";
   return (
     <Html lang="en">
       <Head>
@@ -25,10 +31,16 @@ export default function Root() {
       <Body>
         <Suspense>
           <ErrorBoundary>
-            <A class="mr-2" href="/">
-              Index
-            </A>
-            <A href="/about">About</A>
+            <nav class="bg-sky-800">
+              <ul class="container flex items-center p-3 text-gray-200">
+                <li class={`border-b-2 ${active("/")} mx-1.5 sm:mx-6`}>
+                  <A href="/">Home</A>
+                </li>
+                <li class={`border-b-2 ${active("/about")} mx-1.5 sm:mx-6`}>
+                  <A href="/about">About</A>
+                </li>
+              </ul>
+            </nav>
             <Routes>
               <FileRoutes />
             </Routes>

--- a/examples/with-tailwindcss/src/routes/about.tsx
+++ b/examples/with-tailwindcss/src/routes/about.tsx
@@ -8,9 +8,9 @@ export default function About() {
       <Counter />
       <p class="mt-8">
         Visit{" "}
-        <A href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
-        </A>{" "}
+        </a>{" "}
         to learn how to build Solid apps.
       </p>
       <p class="my-4">


### PR DESCRIPTION
* Native `<A>` was being used for linking solidjs.com on `/about`, changed it to native `<a>`
* Navbar addition
![image](https://user-images.githubusercontent.com/84540554/208254904-1f914fb3-4eac-410b-a733-9f4eb662b954.png)
![gif](https://cdn.upload.systems/uploads/N6xFCwDq.gif)