### PR TITLE
Debug Naming Conflict

### DIFF
--- a/packages/start/entry-client/mount.tsx
+++ b/packages/start/entry-client/mount.tsx
@@ -13,8 +13,8 @@ declare global {
 if (import.meta.env.DEV) {
   localStorage.setItem("debug", import.meta.env.DEBUG ?? "start*");
   // const { default: createDebugger } = await import("debug");
-  // window.DEBUG = createDebugger("start:client");
-  window.DEBUG = console.log as unknown as any;
+  // window.SOLID_DEBUG = createDebugger("start:client");
+  window.SOLID_DEBUG = console.log as unknown as any;
 
   DEBUG(`import.meta.env.DEV = ${import.meta.env.DEV}`);
   DEBUG(`import.meta.env.PROD = ${import.meta.env.PROD}`);
@@ -48,15 +48,17 @@ export default function mount(code?: () => JSX.Element, element?: Document) {
       );
 
       hydrate(
-        () => !Component || typeof Component === 'string' ? Component :
-          createComponent(Component, {
-            ...JSON.parse(el.dataset.props || "undefined"),
-            get children() {
-              const el = getNextElement();
-              (el as any).__$owner = getOwner();
-              return;
-            }
-          }),
+        () =>
+          !Component || typeof Component === "string"
+            ? Component
+            : createComponent(Component, {
+                ...JSON.parse(el.dataset.props || "undefined"),
+                get children() {
+                  const el = getNextElement();
+                  (el as any).__$owner = getOwner();
+                  return;
+                }
+              }),
         el,
         {
           renderId: el.dataset.hk.slice(0, el.dataset.hk.length - 1) + `1-`,
@@ -80,7 +82,7 @@ export default function mount(code?: () => JSX.Element, element?: Document) {
     window._$HY.hydrateIslands = () => {
       const islands = document.querySelectorAll("solid-island[data-hk]");
       const assets = new Set<string>();
-      islands.forEach((el: Element) => assets.add((el as HTMLElement).dataset.component || ''));
+      islands.forEach((el: Element) => assets.add((el as HTMLElement).dataset.component || ""));
       Promise.all([...assets].map(asset => import(/* @vite-ignore */ asset))).then(() => {
         islands.forEach((el: Element) => {
           if ((el as HTMLElement).dataset.when === "idle" && "requestIdleCallback" in window) {

--- a/packages/start/vite/plugin.d.ts
+++ b/packages/start/vite/plugin.d.ts
@@ -19,7 +19,7 @@ import type { Component } from "solid-js";
 declare global {
   export const DEBUG: Debugger;
   interface Window {
-    DEBUG: Debugger;
+    SOLID_DEBUG: Debugger;
     _$HY: {
       island(path: string, comp: Component): void;
       islandMap: { [path: string]: Component };


### PR DESCRIPTION
Changing the name of the property attached to the window in the global typescript scope from DEBUG to SOLID_DEBUG to prevent naming conflicts with other NPM packages.