### PR TITLE
Respect Vite envDir when loading environment vars

### DIFF
--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -457,7 +457,7 @@ function solidStartConfig(options) {
 
       // Load env file based on `mode` in the current working directory.
       // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-      options.env = await loadEnv(e.mode, process.cwd(), "");
+      options.env = await loadEnv(e.mode, options.envDir || process.cwd(), "");
 
       options.router = new Router({
         baseDir: path.posix.join(options.appRoot, options.routesDir),


### PR DESCRIPTION
Respect Vite's [options.envDir](https://vitejs.dev/config/shared-options.html#envdir) when loading Solid Start's environment variables.

## Why?

When working inside a monorepo it sometimes makes sense to be able to put the `.env` file in the root of the workspace and share it between all of the projects in subfolders. This allows you to do that.