### PR TITLE
Add chmod +x to .stackblitzrc

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "chmod +x ./packages/start/bin.cjs && pnpm run docs:dev"
+}


### PR DESCRIPTION
Fixes solidjs/solid-start#550 and stackblitz/core#2226