### PR TITLE
fix: make island router replace outermost diffed route

### DIFF
--- a/packages/start/islands/server-router.tsx
+++ b/packages/start/islands/server-router.tsx
@@ -234,6 +234,7 @@ export function Router(props: RouterProps) {
           //   </outlet-wrapper>
           // );
           // return diffedRender;
+          break;
         }
         // Routes are shared
       } else {
@@ -249,6 +250,7 @@ export function Router(props: RouterProps) {
         //   </outlet-wrapper>
         // );
         // return diffedRender;
+        break;
       }
     }
   }


### PR DESCRIPTION
This PR fixes a bug that the islands router always replaces the innermost route of the whole nested routes, which is supposed to replace the outermost diffed route.