### PR TITLE
fix: pass only pathname to getMatchedBranch

### DIFF
--- a/packages/start/entry-client/StartClient.tsx
+++ b/packages/start/entry-client/StartClient.tsx
@@ -22,7 +22,7 @@ export default () => {
         return throwClientError("request");
       }
     },
-    get prevUrl() {
+    get prevPath() {
       if (process.env.NODE_ENV === "development") {
         return throwClientError("request");
       }

--- a/packages/start/entry-server/StartServer.tsx
+++ b/packages/start/entry-server/StartServer.tsx
@@ -54,7 +54,7 @@ export function createHandler(...exchanges: Middleware[]) {
 export function StartRouter(
   props: RouterProps & {
     location: string;
-    prevLocation: string;
+    prevPath: string;
     routes: RouteDefinition | RouteDefinition[];
   }
 ) {
@@ -82,7 +82,7 @@ export default function StartServer({ event }: { event: PageEvent }) {
           url={path}
           out={event.routerContext}
           location={path}
-          prevLocation={event.prevUrl}
+          prevPath={event.prevPath}
           data={dataFn}
           routes={fileRoutes}
         >

--- a/packages/start/entry-server/StartServer.tsx
+++ b/packages/start/entry-server/StartServer.tsx
@@ -53,7 +53,7 @@ export function createHandler(...exchanges: Middleware[]) {
 
 export function StartRouter(
   props: RouterProps & {
-    location: string;
+    location: URL;
     prevPath: string;
     routes: RouteDefinition | RouteDefinition[];
   }
@@ -81,7 +81,7 @@ export default function StartServer({ event }: { event: PageEvent }) {
         <StartRouter
           url={path}
           out={event.routerContext}
-          location={path}
+          location={parsed}
           prevPath={event.prevPath}
           data={dataFn}
           routes={fileRoutes}

--- a/packages/start/entry-server/render.ts
+++ b/packages/start/entry-server/render.ts
@@ -145,7 +145,7 @@ function createPageEvent(event: FetchEvent) {
     "Content-Type": "text/html"
   });
 
-  const prevPath = event.request.headers.get("x-solid-referrer");
+  const prevPath = event.request.headers.get("x-solid-referrer") ?? '';
 
   let statusCode = 200;
 
@@ -159,7 +159,7 @@ function createPageEvent(event: FetchEvent) {
 
   const pageEvent: PageEvent = Object.freeze({
     request: event.request,
-    prevUrl: prevPath || '',
+    prevPath,
     routerContext: {},
     tags: [],
     env: event.env,

--- a/packages/start/islands/server-router.tsx
+++ b/packages/start/islands/server-router.tsx
@@ -194,7 +194,7 @@ export const useRouteParams = () => {
 
 export interface RouterProps {
   location: string;
-  prevLocation: string;
+  prevPath: string;
   routes: RouteDefinition | RouteDefinition[];
   children: JSX.Element;
   out?: any;
@@ -208,7 +208,7 @@ export function Router(props: RouterProps) {
 
   const nextRoutes = next.routes;
 
-  const prev = props.prevLocation ? getMatchedBranch(props.routes, props.prevLocation) : null;
+  const prev = props.prevPath ? getMatchedBranch(props.routes, props.prevPath) : null;
   if (prev) {
     const prevRoutes = prev.routes;
 

--- a/packages/start/islands/server-router.tsx
+++ b/packages/start/islands/server-router.tsx
@@ -171,7 +171,7 @@ export function getMatchedBranch(
 
 export interface RouterContextState {
   routes: MatchedRoute[];
-  location: string;
+  location: URL;
 }
 
 export const RouterContext = createContext<RouterContextState>();
@@ -193,7 +193,7 @@ export const useRouteParams = () => {
 };
 
 export interface RouterProps {
-  location: string;
+  location: URL;
   prevPath: string;
   routes: RouteDefinition | RouteDefinition[];
   children: JSX.Element;
@@ -201,7 +201,7 @@ export interface RouterProps {
 }
 
 export function Router(props: RouterProps) {
-  const next = getMatchedBranch(props.routes, props.location);
+  const next = getMatchedBranch(props.routes, props.location.pathname);
   if (!next || !next.routes.length) {
     return [];
   }

--- a/packages/start/server/types.tsx
+++ b/packages/start/server/types.tsx
@@ -67,7 +67,7 @@ export interface ServerFunctionEvent extends FetchEvent {
 }
 
 export interface PageEvent extends FetchEvent {
-  prevUrl: string;
+  prevPath: string;
   responseHeaders: Headers;
   routerContext?: RouterContext;
   tags?: TagDescription[];

--- a/test/template/functions/[[path]].js
+++ b/test/template/functions/[[path]].js
@@ -1174,7 +1174,7 @@ function createPageEvent(event) {
   }
   const pageEvent = Object.freeze({
     request: event.request,
-    prevUrl: prevPath,
+    prevPath,
     routerContext: {},
     tags: [],
     env: event.env,
@@ -2427,7 +2427,7 @@ function StartServer({
             location: path,
 
             get prevLocation() {
-              return event.prevUrl;
+              return event.prevPath;
             },
 
             data: dataFn,


### PR DESCRIPTION
`getMatchedBranch()` doesn't work properly with location strings that have search params included. However, the island router is currently receiving a plain string location that includes search params.

This PR fixes it by making the location prop to be an URL and passing only the pathname when calling `getMatchedBranch()`.