### PR TITLE
Make TypeScript the default when running create-solid (#421)

### DIFF
--- a/packages/create-solid/cli/index.js
+++ b/packages/create-solid/cli/index.js
@@ -145,7 +145,7 @@ async function main() {
       type: "confirm",
       name: "value",
       message: "Use TypeScript?",
-      initial: false
+      initial: true
     })
   ).value;
 


### PR DESCRIPTION
tested manually by running a bin file produced by `pnpm --filter create-solid build`