### PR TITLE
add solid-start routes command

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -32,6 +32,25 @@ const findAny = (path, name) => {
 };
 
 prog
+  .command("routes").describe("Show all routes in your app")
+  .action(async ({config: configFile, open, port, root, host, inspect}) => {
+    root = root || process.cwd();
+    const config = await resolveConfig({ mode: "production", configFile, root, command: "build" });
+
+    const { Router } = await import("./fs-router/router.js");
+
+    const router = new Router({
+      baseDir: path.posix.join(config.solidOptions.appRoot, config.solidOptions.routesDir),
+      pageExtensions: config.solidOptions.pageExtensions,
+      ignore: config.solidOptions.routesIgnore,
+      cwd: config.solidOptions.root
+    });
+    await router.init();
+
+    console.log(JSON.stringify(router.getFlattenedPageRoutes(), null, 2));
+  });
+
+prog
   .command("dev")
   .describe("Start a development server")
   .option("-o, --open", "Open a browser tab", false)


### PR DESCRIPTION
This PR creates `routes` command in solid-start cli.
This is similar to remix cli `route --json` command.
 https://github.com/remix-run/remix/blob/main/packages/remix-dev/cli/run.ts#LL26C8-L26C8

It allows you to see the generated page routes.

In an example run of `solid-start routes` of some solid-start project with simple routes, The printed result can be
```
[
  {
    id: '/index',
    path: '/',
    componentPath: 'src/routes/index.tsx',
    dataPath: 'src/routes/index.tsx?data'
  },
  { id: '/test', path: '/test', componentPath: 'src/routes/test.tsx' },
  {
    id: '/api/something/(other)',
    path: '/api/something',
    componentPath: 'src/routes/api/something/(other).tsx'
  },
  {
    id: '/api/something/[id]',
    path: '/api/something/:id',
    componentPath: 'src/routes/api/something/[id].tsx'
  }
]
```


## NOTICE:
I'm not sure it's useful.
I created a PR because it may be useful and I wanted it in order to create a plugin for `routes-gen`
to create type-safe page routes (without manually cloning solid-start page regexes).

See https://github.com/sandulat/routes-gen/pull/29
Also - see https://github.com/solidjs/solid-start/discussions/588

## TODO
- [ ] Edit docs with this command (if approved)
