### PR TITLE
split vercel api routes function

### DIFF
--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -82,6 +82,57 @@ export default function ({ edge, prerender } = {}) {
           };
       writeFileSync(join(renderFuncDir, ".vc-config.json"), JSON.stringify(renderConfig, null, 2));
 
+      // Generate API function
+      const apiRoutes = config.solidOptions.router.getFlattenedApiRoutes()
+      if (apiRoutes.length > 0) {
+        let baseEntrypoint = "entry.js";
+        if (edge) baseEntrypoint = "entry-edge.js";
+        copyFileSync(join(__dirname, baseEntrypoint), entrypoint);
+
+        const bundle = await rollup({
+          // Same as render
+          input: entrypoint,
+          plugins: [
+            json(),
+            nodeResolve({
+              preferBuiltins: true,
+              exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
+            }),
+            common()
+          ]
+        });
+
+        const apiEntrypoint = "index.js";
+        const apiFuncDir = join(outputDir, "functions/api.func");
+        await bundle.write(
+          edge
+            ? {
+                format: "esm",
+                file: join(apiFuncDir, apiEntrypoint),
+                inlineDynamicImports: true
+              }
+            : {
+                format: "cjs",
+                file: join(apiFuncDir, apiEntrypoint),
+                exports: "auto",
+                inlineDynamicImports: true
+              }
+        );
+        await bundle.close();
+
+        const apiConfig = edge
+          ? {
+              runtime: "edge",
+              entrypoint: apiEntrypoint
+            }
+          : {
+              runtime: "nodejs16.x",
+              handler: apiEntrypoint,
+              launcherType: "Nodejs"
+            };
+        writeFileSync(join(apiFuncDir, ".vc-config.json"), JSON.stringify(apiConfig, null, 2));
+      }
+      
       // Routing Config
       const outputConfig = {
         version: 3,
@@ -95,6 +146,8 @@ export default function ({ edge, prerender } = {}) {
           },
           // Serve any matching static assets first
           { handle: "filesystem" },
+          // Invoke the API function for API routes
+          {...apiRoutes.length > 0 ? { src: "/api/(.*)", dest: "/api" } : {}},
           // Invoke the SSR function if not a static asset
           { src: prerender ? "/(?<path>.*)" : "/.*", dest: prerender ? "/render?path=$path" : "/render" }
         ]


### PR DESCRIPTION
This creates a seperate serverless function `api.func` to handle API routes. 

An effect of this is fixing https://github.com/solidjs/solid-start/issues/612

Build output
```
.vercel
├── output
│  ├── config.json
│  ├── functions
│  │  ├── api.func
│  │  │  └── index.js
│  │  └── render.func
│  │     └── index.js
```

Config
```ts
{
  "version": 3,
  "routes": [
    ...
    // Add route for api handler
    {
      "src": "/api/hello",
      "dest": "/api"
    },
    {
      "src": "/.*",
      "dest": "/render"
    }
  ]
}
```

Not sure if this is the best approach, but would at least make ISR work with API routes. We could limit it to only be done when prerender is enabled, but I think it should be fine even when it is not enabled.

If there is a way to get a server output with only API routes it would make more sense (and without API routes for `render.func`)