### PR TITLE
Use safest defaults for @rollup/plugin-commonjs

### DIFF
--- a/packages/start-aws/index.mjs
+++ b/packages/start-aws/index.mjs
@@ -37,7 +37,7 @@ export default function ({ edge } = {}) {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
       await bundle.write({

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -148,7 +148,7 @@ export default function (miniflareOptions) {
             preferBuiltins: true,
             exportConditions: ["worker", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
 

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -160,7 +160,7 @@ export default function (miniflareOptions = {}) {
             preferBuiltins: true,
             exportConditions: ["worker", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-deno/index.js
+++ b/packages/start-deno/index.js
@@ -50,7 +50,7 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["deno", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -44,7 +44,7 @@ export default function ({ edge } = {}) {
             preferBuiltins: true,
             exportConditions: edge ? ["deno", "solid"] : ["node", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-node/index.js
+++ b/packages/start-node/index.js
@@ -48,7 +48,9 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common()
+          common({
+            strictRequires: true
+          })
         ],
         external: ["undici", "stream/web", ...ssrExternal]
       });

--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -44,7 +44,7 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ],
         external: ["undici", "stream/web", ...ssrExternal]
       });

--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -48,7 +48,7 @@ export default function ({ edge, prerender } = {}) {
             preferBuiltins: true,
             exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
           }),
-          common()
+          common({ strictRequires: true })
         ]
       });
 
@@ -112,7 +112,7 @@ export default function ({ edge, prerender } = {}) {
               preferBuiltins: true,
               exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
             }),
-            common()
+            common({ strictRequires: true })
           ]
         });
 


### PR DESCRIPTION
Fixes #623 

Vite has an option to inject configuration parameters to @rollup/plugin-commonjs in the vite.config.ts like this:

```ts
import { defineConfig } from "vite";

export default defineConfig({
  build: {
    **commonjsOptions: {}**
  },
});
```

Unfortunately that doesn't work in solid-start, because the node adapter takes control over the 3 default rollup plugins like this ( separate issue #628 ):

https://github.com/solidjs/solid-start/blob/df206edb975de4941e368c92ec9e25c825592005/packages/start-node/index.js#L45-L52

Arguably it would be ideal to have a way of injecting the parameters from vite.config.ts in here, but as long as there is no such way, the way to adjust the parameters of commonjs plugin for users of SolidStart, it's wisest to use the safest default option that is least likely to cause errors, know as strictRequires (more info [here])(https://github.com/rollup/plugins/tree/master/packages/commonjs#strictrequires)): 

{ strictRequires: true }

It's [considered by a maintainer](https://github.com/rollup/rollup/issues/4787#issuecomment-1371842223) of the plugin, that this might be the better default config. 