### PR TITLE
Inject vite.config build.commonjsOptions into adapters

### DIFF
--- a/packages/start-aws/index.mjs
+++ b/packages/start-aws/index.mjs
@@ -37,7 +37,7 @@ export default function ({ edge } = {}) {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
       await bundle.write({

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -148,7 +148,7 @@ export default function (miniflareOptions) {
             preferBuiltins: true,
             exportConditions: ["worker", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
 

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -160,7 +160,7 @@ export default function (miniflareOptions = {}) {
             preferBuiltins: true,
             exportConditions: ["worker", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-deno/index.js
+++ b/packages/start-deno/index.js
@@ -50,7 +50,7 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["deno", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -44,7 +44,7 @@ export default function ({ edge } = {}) {
             preferBuiltins: true,
             exportConditions: edge ? ["deno", "solid"] : ["node", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
       // or write the bundle to disk

--- a/packages/start-node/index.js
+++ b/packages/start-node/index.js
@@ -48,9 +48,7 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common({
-            strictRequires: true
-          })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ],
         external: ["undici", "stream/web", ...ssrExternal]
       });

--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -44,7 +44,7 @@ export default function () {
             preferBuiltins: true,
             exportConditions: ["node", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ],
         external: ["undici", "stream/web", ...ssrExternal]
       });

--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -48,7 +48,7 @@ export default function ({ edge, prerender } = {}) {
             preferBuiltins: true,
             exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
           }),
-          common({ strictRequires: true })
+          common({ strictRequires: true, ...config.build.commonjsOptions })
         ]
       });
 
@@ -112,7 +112,7 @@ export default function ({ edge, prerender } = {}) {
               preferBuiltins: true,
               exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
             }),
-            common({ strictRequires: true })
+            common({ strictRequires: true, ...config.build.commonjsOptions })
           ]
         });
 


### PR DESCRIPTION
Fixes #628 

in adapters, this pr changes

`common({ strictRequires: true })`

to:

`common({ strictRequires: true, ...config.build.commonjsOptions })`

making the vite.config.ts option functional