### PR TITLE
Add support for optional params

### DIFF
--- a/packages/start/api/index.ts
+++ b/packages/start/api/index.ts
@@ -8,7 +8,30 @@ import { MatchRoute, Method, Route } from "./types";
 // @ts-ignore
 var api = $API_ROUTES;
 
-// `delete` is a reserved word in JS, so we use `del` instead
+// This is copied from https://github.com/solidjs/solid-router/blob/main/src/utils.ts
+function expandOptionals(pattern: string): string[] {
+  let match = /(\/?\:[^\/]+)\?/.exec(pattern);
+  if (!match) return [pattern];
+
+  let prefix = pattern.slice(0, match.index);
+  let suffix = pattern.slice(match.index + match[0].length);
+  const prefixes: string[] = [prefix, (prefix += match[1])];
+
+  // This section handles adjacent optional params. We don't actually want all permuations since
+  // that will lead to equivalent routes which have the same number of params. For example
+  // `/:a?/:b?/:c`? only has the unique expansion: `/`, `/:a`, `/:a/:b`, `/:a/:b/:c` and we can
+  // discard `/:b`, `/:c`, `/:b/:c` by building them up in order and not recursing. This also helps
+  // ensure predictability where earlier params have precidence.
+  while ((match = /^(\/\:[^\/]+)\?/.exec(suffix))) {
+    prefixes.push((prefix += match[1]));
+    suffix = suffix.slice(match[0].length);
+  }
+
+  return expandOptionals(suffix).reduce<string[]>(
+    (results, expansion) => [...results, ...prefixes.map(p => p + expansion)],
+    []
+  );
+}
 
 function routeToMatchRoute(route: Route): MatchRoute {
   const segments = route.path.split("/").filter(Boolean);
@@ -50,7 +73,13 @@ function routeToMatchRoute(route: Route): MatchRoute {
   };
 }
 
-const allRoutes = (api as Route[]).map(routeToMatchRoute).sort((a, b) => b.score - a.score);
+const allRoutes = (api as Route[])
+  .flatMap(route => {
+    const paths = expandOptionals(route.path);
+    return paths.map(path => ({ ...route, path }));
+  })
+  .map(routeToMatchRoute)
+  .sort((a, b) => b.score - a.score);
 
 registerApiRoutes(allRoutes);
 

--- a/packages/start/fs-router/path-utils.js
+++ b/packages/start/fs-router/path-utils.js
@@ -1,6 +1,19 @@
+/**
+ * @param {string} id
+ * @param removePathlessLayouts
+ * @returns
+ */
 export function toPath(id, removePathlessLayouts = true) {
   const idWithoutIndex = id.endsWith("/index") ? id.slice(0, -"index".length) : id;
   return (
     removePathlessLayouts ? idWithoutIndex.replace(/\/\([^)/]+\)/g, "") : idWithoutIndex
-  ).replace(/\[([^\[]+)\]/g, (_, m) => (m.startsWith("...") ? `*${m.slice(3)}` : `:${m}`));
+  ).replace(/\[([^\/]+)\]/g, (_, m) => {
+    if (m.length > 3 && m.startsWith("...")) {
+      return `*${m.slice(3)}`;
+    }
+    if (m.length > 2 && m.startsWith("[") && m.endsWith("]")) {
+      return `:${m.slice(1, -1)}?`;
+    }
+    return `:${m}`;
+  });
 }


### PR DESCRIPTION
This PR adds support for optional params to the file system routing.

The syntax chosen is `[[param]]`, the first set of square brackets indicate that it is a parameter and the second set indicate that it is optional.
This syntax was chosen because `?` is not a valid character in filenames on Windows.

#### Usage example:

> **_src/routes/[[lang]]/blog/test.tsx_**

| path | params |
| ------------- | ------------- |
| /blog/test  | {} |
| /en/blog/test  | { lang: "en" }  |
