### PR TITLE
Handle clickedButtonRef when clicked element is an SVGElement

### DIFF
--- a/packages/start/data/Form.tsx
+++ b/packages/start/data/Form.tsx
@@ -189,7 +189,7 @@ export let FormImpl = (_props: FormImplProps) => {
     if (!form) return;
 
     function handleClick(event: MouseEvent) {
-      if (!(event.target instanceof HTMLElement)) return;
+      if (!(event.target instanceof HTMLElement || event.target instanceof SVGElement)) return;
       let submitButton = event.target.closest<HTMLButtonElement | HTMLInputElement>(
         "button,input[type=submit]"
       );


### PR DESCRIPTION
As implemented, if you place an SVG inside a submit button in a progressively-enhanced form, and then click the SVG instead of any other part of the button, `clickedButtonRef` fails to be set. Thus, when submitting the form, the target is the form rather than the button, and any `name` / `value` attributes on the button are ignored when constructing the `FormData` to submit.

I tested with JavaScript disabled and clicking the icon inside the button _does_ submit that button's `name`/`value` attributes, so I think the progressive enhancement implementation should replicate this.

The current workaround is to set `pointer-events: none;` on the SVG element inside the submit button, but this is not necessary with JavaScript disabled.