### PR TITLE
Omit action and onSubmission props from createRouteAction Form

### DIFF
--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -96,8 +96,9 @@ export function createRouteAction<T, U = void>(
       <FormImpl
         {...props}
         action={url}
-        onSubmission={submission => {
-          submit(submission.formData as any);
+        onSubmission={async submission => {
+          await submit(submission.formData as any);
+          props.onSubmission?.(submission);
         }}
       >
         {props.children}

--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -90,15 +90,14 @@ export function createRouteAction<T, U = void>(
       }) as Promise<U>;
   }
   submit.url = (fn as any).url;
-  submit.Form = ((props: FormProps) => {
+  submit.Form = ((props: Omit<FormProps, "action" | "onSubmission">) => {
     let url = (fn as any).url;
     return (
       <FormImpl
         {...props}
         action={url}
-        onSubmission={async submission => {
-          await submit(submission.formData as any);
-          props.onSubmission?.(submission);
+        onSubmission={submission => {
+          submit(submission.formData as any);
         }}
       >
         {props.children}


### PR DESCRIPTION
The props for the `Form` returned from `createRouteAction` accept an `onSubmission` prop, but it is always overridden.

My use-case is that I want to track the last successfully submitted `FormData`. If there is another way to do this I'm open to alternatives. We could also implement another prop for this if one doesn't exist. The problem with the `result` signal is that it gets set to `undefined` with every submission, resulting in the need to memoize the non-`undefined` values, which is easy to do, just not ergonomic.

Here are some alternative solutions to the root problem of a prop `onSubmission` being declared that isn't called that we could implement, depending on what behavior is ultimately desired by `solid-start`:

1. We can call both the internal `submit` and `props.onSubmission` in parallel
1. We can first call `props.onSubmission` and if it returns `false` then don't call the internal `submit`
1. We can allow `props.onSubmission` to override the internal `onSubmission` (though I'm not sure why we would want to do this)
1. We can change the props type to `Omit<FormProps, 'onSubmission'>`
