### PR TITLE
explicitly handle serverResource server functions

### DIFF
--- a/packages/start/server/server-functions/babel.js
+++ b/packages/start/server/server-functions/babel.js
@@ -115,6 +115,7 @@ function transformServer({ types: t, template }) {
                     p =>
                       p.isVariableDeclarator() || p.isFunctionDeclaration() || p.isObjectProperty()
                   );
+                  const serverResource = path.getData("serverResource") ?? false;
                   let serverIndex = state.servers++;
                   let hasher = state.opts.minify ? hashFn : str => str;
                   const fName = state.filename.replace(state.opts.root, "").slice(1);
@@ -175,7 +176,7 @@ function transformServer({ types: t, template }) {
                   if (state.opts.ssr) {
                     statement.insertBefore(
                       template(`
-                      const $$server_module${serverIndex} = server$.createHandler(%%source%%, "${route}");
+                      const $$server_module${serverIndex} = server$.createHandler(%%source%%, "${route}", ${serverResource});
                       server$.registerHandler("${route}", $$server_module${serverIndex});
                       `)({
                         source: serverFn.node
@@ -187,10 +188,10 @@ function transformServer({ types: t, template }) {
                         `
                         ${
                           process.env.TEST_ENV === "client"
-                            ? `server$.registerHandler("${route}", server$.createHandler(%%source%%, "${route}"));`
+                            ? `server$.registerHandler("${route}", server$.createHandler(%%source%%, "${route}", ${serverResource}));`
                             : ``
                         }
-                        const $$server_module${serverIndex} = server$.createFetcher("${route}");`,
+                        const $$server_module${serverIndex} = server$.createFetcher("${route}", ${serverResource});`,
                         {
                           syntacticPlaceholders: true
                         }

--- a/packages/start/server/server-functions/browser.ts
+++ b/packages/start/server/server-functions/browser.ts
@@ -7,7 +7,6 @@ import {
   XSolidStartOrigin,
   XSolidStartResponseTypeHeader
 } from "../responses";
-import { FETCH_EVENT } from "../types";
 
 import { FormError } from "../../data";
 import { ServerError } from "../../data/FormError";
@@ -92,11 +91,6 @@ function createRequestInit(...args: any[]): RequestInit {
       }
     }
     body = JSON.stringify(args, (key, value) => {
-      if (value && typeof value === "object" && value.$type === FETCH_EVENT) {
-        return {
-          $type: "fetch_event"
-        };
-      }
       if (value instanceof Headers) {
         return {
           $type: "headers",
@@ -127,11 +121,11 @@ function createRequestInit(...args: any[]): RequestInit {
 
 type ServerCall = (route: string, init: RequestInit) => Promise<Response>;
 
-server$.createFetcher = route => {
+server$.createFetcher = (route, serverResource) => {
   let fetcher: any = function (this: Request, ...args: any[]) {
     if (this instanceof Request) {
     }
-    const requestInit = createRequestInit(...args);
+    const requestInit = serverResource ? createRequestInit(args[0]) : createRequestInit(...args);
     // request body: json, formData, or string
     return (server$.call as ServerCall)(route, requestInit);
   };

--- a/packages/start/server/server-functions/types.ts
+++ b/packages/start/server/server-functions/types.ts
@@ -8,9 +8,9 @@ export type CreateServerFunction = (<E extends any[], T extends (...args: [...E]
   fn: T
 ) => ServerFunction<E, T>) & {
   getHandler: (route: string) => any;
-  createHandler: (fn: any, hash: string) => any;
+  createHandler: (fn: any, hash: string, serverResource: boolean) => any;
   registerHandler: (route: string, handler: any) => any;
   hasHandler: (route: string) => boolean;
-  createFetcher(route: string): ServerFunction<any, any>;
+  createFetcher(route: string, serverResource: boolean): ServerFunction<any, any>;
   fetch(route: string, init?: RequestInit): Promise<Response>;
 } & FetchEvent;

--- a/packages/start/server/serverResource.js
+++ b/packages/start/server/serverResource.js
@@ -47,6 +47,7 @@ function transformRouteData({ types: t }) {
                     t.callExpression(t.identifier("createRouteData"), callPath.node.arguments)
                   );
                   callState.resourceRequired = true;
+                  callPath.get("arguments")[0].setData("serverResource", true);
                 }
 
                 if (callPath.get("callee").isIdentifier({ name: "createServerAction$" })) {
@@ -57,6 +58,7 @@ function transformRouteData({ types: t }) {
                     t.callExpression(t.identifier("createRouteAction"), callPath.node.arguments)
                   );
                   callState.actionRequired = true;
+                  callPath.get("arguments")[0].setData("serverResource", true);
                 }
 
                 if (callPath.get("callee").isIdentifier({ name: "createServerMultiAction$" })) {
@@ -70,6 +72,7 @@ function transformRouteData({ types: t }) {
                     )
                   );
                   callState.actionRequired = true;
+                  callPath.get("arguments")[0].setData("serverResource", true);
                 }
               }
             },


### PR DESCRIPTION
Server functions created using the server resource primitives ( `createServerData$`, `createServerAction$`, `createServerMultiAction$` ) will now be differentiated from regular `server$` calls.