### PR TITLE
solid-start-aws: handler: clientAddress: fix: requestContext.identity…

### DIFF
--- a/packages/start-aws/entry.mjs
+++ b/packages/start-aws/entry.mjs
@@ -4,9 +4,12 @@ import manifest from "../../dist/client/route-manifest.json";
 import server from "./entry-server";
 
 export async function handler(event) {
+  const { requestContext } = event
   const response = await server({
     request: createRequest(event),
-    clientAddress: event.requestContext.identity.sourceIp,
+    clientAddress:
+      requestContext.identity?.sourceIp
+      ?? requestContext.http?.sourceIp,
     locals: {},
     env: { manifest },
   });

--- a/packages/start-aws/entry.mjs
+++ b/packages/start-aws/entry.mjs
@@ -18,8 +18,8 @@ export async function handler(event) {
   for (const [name, value] of response.headers) {
     headers[name] = value;
   }
-  if (webRes.headers.has('set-cookie')) {
-		const header = /** @type {string} */ (webRes.headers.get('set-cookie'));
+  if (response.headers.has('set-cookie')) {
+		const header = /** @type {string} */ (response.headers.get('set-cookie'));
 		// @ts-expect-error
 		headers['set-cookie'] =  splitCookiesString(header);
 	}


### PR DESCRIPTION
… is nullish: fallback to requestContext.http

fixes: https://github.com/solidjs/solid-start/issues/664