### PR TITLE
Make css link tests compatible with Vite 4 css paths

### DIFF
--- a/test/css-link-test.ts
+++ b/test/css-link-test.ts
@@ -150,7 +150,7 @@ test.describe("CSS link tags", () => {
           .replace("[", "\\[")
           .replace("]", "\\]")
           .replace("(", "\\(")
-          .replace(")", "\\)")}\\.[a-f0-9]+\.css$`
+          .replace(")", "\\)")}\[\.\-][a-f0-9]+\.css$`
       ).test(x);
   }
 


### PR DESCRIPTION
Part of #660 

In Vite 4 apparently a dot is swapped with a dash in the css path - and that doesn't match the RegExp used to match css files causing all css-link-tests to fail.

This PR makes the tests find on files with both dots and dashes.

If vite 4 also breaks the actual loading of the css files is not clear to me, and it will have to be resolved separately.

**Vite 4**
[
  '/assets/entry-client-a5369801.css',
  '/assets/login-1d9a1004.css',
  '/assets/(auth)-cf9318ab.css'
]

**Vite 3**
[
  '/assets/entry-client.a5369801.css',
  '/assets/login.1d9a1004.css',
  '/assets/(auth).cf9318ab.css'
]
