### PR TITLE
Remove the need to `nohoist` (2nd attempt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,56 +40,6 @@ npm install -g pnpm
 
 Run `pnpm install` to install all the dependencies for the packages and examples in your monorepo.
 
-<details>
-<summary><h4>Monorepo & <code>project.json</code> <code>"workspace"</code> support</h4></summary>
-
-If you are using Solid Start within a monorepo that takes advantage of the `package.json` `"workspaces"` property (e.g. [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)) with hoisted dependencies (the default for yarn), you must include `solid-start` within the optional `"nohoist"` (for yarn v2 or higher, see further down for instructions) workspaces property.
-
-- _In the following, "workspace root" refers to the root of your repository while "project root" refers to the root of a child package within your repository_
-
-For example, if specifying `"nohoist"` options from the workspace root (i.e. for all packages):
-
-```jsonc
-// in workspace root
-{
-  "workspaces": {
-    "packages": [
-      /* ... */
-    ],
-    "nohoist": ["**/solid-start"]
-  }
-}
-```
-
-If specifying `"nohoist"` options for a specific package using `solid-start`:
-
-```jsonc
-// in project root of a workspace child
-{
-  "workspaces": {
-    "nohoist": ["solid-start"]
-  }
-}
-```
-
-Regardless of where you specify the `nohoist` option, you also need to include `solid-start` as a `devDependency` in the child `package.json`.
-
-The reason why this is necessary is because `solid-start` creates an `index.html` file within your project which expects to load a script located in `/node_modules/solid-start/runtime/entry.jsx` (where `/` is the path of your project root). By default, if you hoist the `solid-start` dependency into the workspace root then that script will not be available within the package's `node_modules` folder.
-
-**Yarn v2 or higher**
-
-The `nohoist` option is no longer available in Yarn v2+. In this case, we can use the `installConfig` property in the `package.json` (either workspace package or a specific project package) to make sure our deps are not hoisted.
-
-```jsonc
-// in project root of a workspace child
-{
-  "installConfig": {
-    "hoistingLimits": "dependencies"
-  }
-}
-```
-
-</details>
 
 ## Changelog
 

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -4,10 +4,13 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import { spawn } from "child_process";
 import { copyFileSync, writeFileSync } from "fs";
 import { Miniflare } from "miniflare";
-import { dirname, join } from "path";
+import { createRequire } from "module";
+import { dirname, join, relative } from "path";
 import { rollup } from "rollup";
 import { fileURLToPath } from "url";
 import { createServer } from "./dev-server.js";
+
+const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
 
 export default function (miniflareOptions) {
   return {
@@ -113,8 +116,9 @@ export default function (miniflareOptions) {
     },
     start(config, { port }) {
       process.env.PORT = port;
+      const relWranglerPath = relative(process.cwd(), dirname(requireCwd.resolve("wrangler/package.json")));
       const proc = spawn("node", [
-        join(config.root, "node_modules", "wrangler", "bin", "wrangler.js"),
+        join(relWranglerPath, "bin", "wrangler.js"),
         "pages",
         "dev",
         "./dist/public",

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -7,10 +7,10 @@ import { Miniflare } from "miniflare";
 import { createRequire } from "module";
 import { dirname, join, relative } from "path";
 import { rollup } from "rollup";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { createServer } from "./dev-server.js";
 
-const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), 'dummy.js')));
 
 export default function (miniflareOptions) {
   return {

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -10,7 +10,7 @@ import { rollup } from "rollup";
 import { fileURLToPath, pathToFileURL } from "url";
 import { createServer } from "./dev-server.js";
 
-const requireCwd = createRequire(pathToFileURL(join(process.cwd(), 'dummy.js')));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 
 export default function (miniflareOptions) {
   return {
@@ -116,7 +116,10 @@ export default function (miniflareOptions) {
     },
     start(config, { port }) {
       process.env.PORT = port;
-      const relWranglerPath = relative(process.cwd(), dirname(requireCwd.resolve("wrangler/package.json")));
+      const relWranglerPath = relative(
+        process.cwd(),
+        dirname(requireCwd.resolve("wrangler/package.json"))
+      );
       const proc = spawn("node", [
         join(relWranglerPath, "bin", "wrangler.js"),
         "pages",

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -6,10 +6,13 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import { spawn } from "child_process";
 import { copyFileSync, readFileSync, writeFileSync } from "fs";
 import { Miniflare } from "miniflare";
-import { dirname, join } from "path";
+import { createRequire } from "module";
+import { dirname, join, relative } from "path";
 import { rollup } from "rollup";
 import { fileURLToPath } from "url";
 import { createServer } from "./dev-server.js";
+
+const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
 
 export default function (miniflareOptions = {}) {
   return {
@@ -116,8 +119,9 @@ export default function (miniflareOptions = {}) {
     },
     start(config, { port }) {
       process.env.PORT = port;
+      const relWranglerPath = relative(process.cwd(), dirname(requireCwd.resolve("wrangler/package.json")));
       const proc = spawn("node", [
-        join(config.root, "node_modules", "wrangler", "bin", "wrangler.js"),
+        join(relWranglerPath, "bin", "wrangler.js"),
         "dev",
         "./dist/server.js",
         "--site",

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -9,10 +9,10 @@ import { Miniflare } from "miniflare";
 import { createRequire } from "module";
 import { dirname, join, relative } from "path";
 import { rollup } from "rollup";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { createServer } from "./dev-server.js";
 
-const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
 
 export default function (miniflareOptions = {}) {
   return {
@@ -119,7 +119,10 @@ export default function (miniflareOptions = {}) {
     },
     start(config, { port }) {
       process.env.PORT = port;
-      const relWranglerPath = relative(process.cwd(), dirname(requireCwd.resolve("wrangler/package.json")));
+      const relWranglerPath = relative(
+        process.cwd(),
+        dirname(requireCwd.resolve("wrangler/package.json"))
+      );
       const proc = spawn("node", [
         join(relWranglerPath, "bin", "wrangler.js"),
         "dev",

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -12,7 +12,7 @@ import { rollup } from "rollup";
 import { fileURLToPath, pathToFileURL } from "url";
 import { createServer } from "./dev-server.js";
 
-const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 
 export default function (miniflareOptions = {}) {
   return {

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -20,14 +20,15 @@ const DEBUG = require("debug")("start");
 const { createRequire } = require("module");
 const { pathToFileURL } = require("url");
 
-
-throw new Error(`
+if (require('os').platform() === 'win32') {
+  throw new Error(`
 DEBUG DEBUG DEBUG
 process.cwd(): ${process.cwd()}
 join(process.cwd(), "dummy.js"): ${join(process.cwd(), "dummy.js")}
 pathToFileURL(join(process.cwd(), "dummy.js")).href: ${pathToFileURL(join(process.cwd(), "dummy.js")).href}
 DEBUG DEBUG DEBUG
-`);
+  `);
+}
 
 const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 globalThis.DEBUG = DEBUG;

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -20,11 +20,14 @@ const DEBUG = require("debug")("start");
 const { createRequire } = require("module");
 const { pathToFileURL } = require("url");
 
-console.log('DEBUG DEBUG DEBUG');
-console.log(process.cwd());
-console.log(join(process.cwd(), "dummy.js"));
-console.log(pathToFileURL(join(process.cwd(), "dummy.js")).href);
-console.log('DEBUG DEBUG DEBUG');
+
+throw new Error(`
+DEBUG DEBUG DEBUG
+process.cwd(): ${process.cwd()}
+join(process.cwd(), "dummy.js"): ${join(process.cwd(), "dummy.js")}
+pathToFileURL(join(process.cwd(), "dummy.js")).href: ${pathToFileURL(join(process.cwd(), "dummy.js")).href}
+DEBUG DEBUG DEBUG
+`);
 
 const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 globalThis.DEBUG = DEBUG;

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -17,6 +17,8 @@ const {
 const waitOn = require("wait-on");
 const pkg = require(join(__dirname, "package.json"));
 const DEBUG = require("debug")("start");
+const { createRequire } = require("module");
+const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
 globalThis.DEBUG = DEBUG;
 
 const prog = sade("solid-start").version("beta");
@@ -526,9 +528,13 @@ async function resolveConfig({ configFile, root, mode, command }) {
 
   async function resolveAdapter(config) {
     if (typeof config.solidOptions.adapter === "string") {
-      return (await import(config.solidOptions.adapter)).default();
+      return (await import(
+        requireCwd.resolve(config.solidOptions.adapter)
+      )).default();
     } else if (Array.isArray(config.solidOptions.adapter)) {
-      return (await import(config.solidOptions.adapter[0])).default(config.solidOptions.adapter[1]);
+      return (await import(
+        requireCwd.resolve(config.solidOptions.adapter[0])
+      )).default(config.solidOptions.adapter[1]);
     } else {
       return config.solidOptions.adapter;
     }

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -181,7 +181,7 @@ prog
     const { default: prepareManifest } = await import("./fs-router/manifest.js");
 
     const inspect = join(config.root, ".solid", "inspect");
-    const vite = require("vite");
+    const vite = requireCwd("vite");
     config.adapter.name && console.log(c.blue(" adapter "), config.adapter.name);
 
     config.adapter.build(config, {
@@ -509,7 +509,7 @@ prog.parse(process.argv);
  * @returns {Promise<import('node_modules/vite').ResolvedConfig & { solidOptions: import('./types').StartOptions, adapter: import('./types').Adapter }>}
  */
 async function resolveConfig({ configFile, root, mode, command }) {
-  const vite = require("vite");
+  const vite = requireCwd("vite");
   root = root || process.cwd();
   if (!configFile) {
     if (!configFile) {

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -18,7 +18,8 @@ const waitOn = require("wait-on");
 const pkg = require(join(__dirname, "package.json"));
 const DEBUG = require("debug")("start");
 const { createRequire } = require("module");
-const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
+const { pathToFileURL } = require("url");
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
 globalThis.DEBUG = DEBUG;
 
 const prog = sade("solid-start").version("beta");
@@ -34,8 +35,9 @@ const findAny = (path, name) => {
 };
 
 prog
-  .command("routes").describe("Show all routes in your app")
-  .action(async ({config: configFile, open, port, root, host, inspect}) => {
+  .command("routes")
+  .describe("Show all routes in your app")
+  .action(async ({ config: configFile, open, port, root, host, inspect }) => {
     root = root || process.cwd();
     const config = await resolveConfig({ mode: "production", configFile, root, command: "build" });
 
@@ -155,10 +157,10 @@ prog
           NODE_OPTIONS: [
             process.env.NODE_OPTIONS,
             "--experimental-vm-modules",
-            inspect ? "--inspect" : "",
+            inspect ? "--inspect" : ""
           ]
             .filter(Boolean)
-            .join(" "),
+            .join(" ")
         }
       }
     );
@@ -176,7 +178,7 @@ prog
     console.log(c.magenta(" version "), pkg.version);
 
     const config = await resolveConfig({ configFile, root, mode: "production", command: "build" });
-    const startPath = dirname(requireCwd.resolve('solid-start/package.json'));
+    const startPath = dirname(requireCwd.resolve("solid-start/package.json"));
 
     const { default: prepareManifest } = await import("./fs-router/manifest.js");
 
@@ -197,9 +199,7 @@ prog
             ssrManifest: true,
             minify: process.env.START_MINIFY === "false" ? false : config.build?.minify ?? true,
             rollupOptions: {
-              input: [
-                join(startPath, "islands", "entry-client")
-              ],
+              input: [join(startPath, "islands", "entry-client")],
               output: {
                 manualChunks: undefined
               }
@@ -388,12 +388,9 @@ prog
               env: {
                 ...process.env,
                 START_INDEX_HTML: "true",
-                NODE_OPTIONS: [
-                  process.env.NODE_OPTIONS,
-                  "--experimental-vm-modules",
-                ]
+                NODE_OPTIONS: [process.env.NODE_OPTIONS, "--experimental-vm-modules"]
                   .filter(Boolean)
-                  .join(" "),
+                  .join(" ")
               }
             }
           );
@@ -529,13 +526,11 @@ async function resolveConfig({ configFile, root, mode, command }) {
 
   async function resolveAdapter(config) {
     if (typeof config.solidOptions.adapter === "string") {
-      return (await import(
-        requireCwd.resolve(config.solidOptions.adapter)
-      )).default();
+      return (await import(requireCwd.resolve(config.solidOptions.adapter))).default();
     } else if (Array.isArray(config.solidOptions.adapter)) {
-      return (await import(
-        requireCwd.resolve(config.solidOptions.adapter[0])
-      )).default(config.solidOptions.adapter[1]);
+      return (await import(requireCwd.resolve(config.solidOptions.adapter[0]))).default(
+        config.solidOptions.adapter[1]
+      );
     } else {
       return config.solidOptions.adapter;
     }

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -19,6 +19,13 @@ const pkg = require(join(__dirname, "package.json"));
 const DEBUG = require("debug")("start");
 const { createRequire } = require("module");
 const { pathToFileURL } = require("url");
+
+console.log('DEBUG DEBUG DEBUG');
+console.log(process.cwd());
+console.log(join(process.cwd(), "dummy.js"));
+console.log(pathToFileURL(join(process.cwd(), "dummy.js")).href);
+console.log('DEBUG DEBUG DEBUG');
+
 const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 globalThis.DEBUG = DEBUG;
 

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -19,7 +19,7 @@ const pkg = require(join(__dirname, "package.json"));
 const DEBUG = require("debug")("start");
 const { createRequire } = require("module");
 const { pathToFileURL } = require("url");
-const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 globalThis.DEBUG = DEBUG;
 
 const prog = sade("solid-start").version("beta");

--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -3,7 +3,7 @@
 
 const { exec, spawn } = require("child_process");
 const sade = require("sade");
-const { resolve, join } = require("path");
+const { resolve, join, dirname } = require("path");
 const path = require("path");
 const c = require("picocolors");
 const {
@@ -176,6 +176,7 @@ prog
     console.log(c.magenta(" version "), pkg.version);
 
     const config = await resolveConfig({ configFile, root, mode: "production", command: "build" });
+    const startPath = dirname(requireCwd.resolve('solid-start/package.json'));
 
     const { default: prepareManifest } = await import("./fs-router/manifest.js");
 
@@ -197,7 +198,7 @@ prog
             minify: process.env.START_MINIFY === "false" ? false : config.build?.minify ?? true,
             rollupOptions: {
               input: [
-                resolve(join(config.root, "node_modules", "solid-start", "islands", "entry-client"))
+                join(startPath, "islands", "entry-client")
               ],
               output: {
                 manualChunks: undefined

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -40,6 +40,7 @@
   },
   "exports": {
     ".": "./index.tsx",
+    "./package.json": "./package.json",
     "./router": "./router.tsx",
     "./vite": {
       "types": "./vite/plugin.d.ts",

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -4,6 +4,7 @@ import debug from "debug";
 import dotenv from "dotenv";
 import { solidPlugin } from "esbuild-plugin-solid";
 import fs, { existsSync } from "fs";
+import { createRequire } from "module";
 import path, { dirname, join } from "path";
 import c from "picocolors";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -17,6 +18,8 @@ import routeData from "../server/routeData.js";
 import routeDataHmr from "../server/routeDataHmr.js";
 import babelServerModule from "../server/server-functions/babel.js";
 import routeResource from "../server/serverResource.js";
+
+const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
 
 // @ts-ignore
 globalThis.DEBUG = debug("start:vite");
@@ -402,9 +405,13 @@ function solidsStartRouteManifest(options) {
 
 async function resolveAdapter(config) {
   if (typeof config.solidOptions.adapter === "string") {
-    return (await import(config.solidOptions.adapter)).default();
+    return (await import(
+      requireCwd.resolve(config.solidOptions.adapter)
+    )).default();
   } else if (Array.isArray(config.solidOptions.adapter)) {
-    return (await import(config.solidOptions.adapter[0])).default(config.solidOptions.adapter[1]);
+    return (await import(
+      requireCwd.resolve(config.solidOptions.adapter[0])
+    )).default(config.solidOptions.adapter[1]);
   } else {
     return config.solidOptions.adapter;
   }

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -19,7 +19,7 @@ import routeDataHmr from "../server/routeDataHmr.js";
 import babelServerModule from "../server/server-functions/babel.js";
 import routeResource from "../server/serverResource.js";
 
-const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")).href);
 
 // @ts-ignore
 globalThis.DEBUG = debug("start:vite");

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -19,7 +19,7 @@ import routeDataHmr from "../server/routeDataHmr.js";
 import babelServerModule from "../server/server-functions/babel.js";
 import routeResource from "../server/serverResource.js";
 
-const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
+const requireCwd = createRequire(pathToFileURL(join(process.cwd(), "dummy.js")));
 
 // @ts-ignore
 globalThis.DEBUG = debug("start:vite");
@@ -405,13 +405,11 @@ function solidsStartRouteManifest(options) {
 
 async function resolveAdapter(config) {
   if (typeof config.solidOptions.adapter === "string") {
-    return (await import(
-      requireCwd.resolve(config.solidOptions.adapter)
-    )).default();
+    return (await import(requireCwd.resolve(config.solidOptions.adapter))).default();
   } else if (Array.isArray(config.solidOptions.adapter)) {
-    return (await import(
-      requireCwd.resolve(config.solidOptions.adapter[0])
-    )).default(config.solidOptions.adapter[1]);
+    return (await import(requireCwd.resolve(config.solidOptions.adapter[0]))).default(
+      config.solidOptions.adapter[1]
+    );
   } else {
     return config.solidOptions.adapter;
   }


### PR DESCRIPTION
# Summary

A 2nd attempt at applying #459, this time without breaking things :-) 

Basically my `requireCwd` was broken because it was using a directory as the base for `createRequire`, instead of a file path.
To fix this, I joined `cwd()` with `dummy.js`, similarly to what was [done in `import-from`](https://github.com/sindresorhus/import-from/blob/6063941cfac93086ae7f5a2e9ec2ac23f4bee401/index.js#L9).

---

**Side note:**
I noticed adapter auto-detection was removed entirely recently, in favor of only supporting explicit ones by directly importing them and providing them via `solidOptions.adapter`.

While this PR still fixes other cases of unsafe imports, I'll follow-up with another PR in case auto-detection is still something we want.