### PR TITLE
feat: call handleRefetch() when the response is not a redirect

### DIFF
--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -254,7 +254,7 @@ function handleResponse(response: Response, navigate: Navigator, options?: { inv
     }
   }
 
-  if (isRedirectResponse(response)) return handleRefetch(response, options);
+  if (!isRedirectResponse(response)) return handleRefetch(response, options);
 }
 
 function checkFlash<T>(fn: any) {

--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -254,7 +254,7 @@ function handleResponse(response: Response, navigate: Navigator, options?: { inv
     }
   }
 
-  if (!isRedirectResponse(response)) return handleRefetch(response, options);
+  return handleRefetch(response, options);
 }
 
 function checkFlash<T>(fn: any) {


### PR DESCRIPTION
#682 
The createRouteAction.tsx, is already calling handleRefetch() when the response is not instance of Response interface.
```tsx
  .then(async data => {
        if (reqId === count) {
          if (data instanceof Response) {
            await handleResponse(data, navigate, options);
          } else await handleRefetch(data as any[], options);
          if (!data || isRedirectResponse(data)) setInput(undefined);
          else setResult({ data });
        }
        return data;
      })
      .catch(async e => {
        if (reqId === count) {
          if (e instanceof Response) {
            await handleResponse(e, navigate, options);
          }
          if (!isRedirectResponse(e)) {
            setResult({ error: e });
          } else setInput(undefined);
        }
```

When it is instance of Response, the handleResponse should call handleRefetch when it is not a redirect. I don't think it make sense to invalidate query only when is happening a redirect, should be exactly the contrary