### PR TITLE
feat(create-solid): prompt target if not supplied through args

### DIFF
--- a/packages/create-solid/cli/index.js
+++ b/packages/create-solid/cli/index.js
@@ -80,7 +80,16 @@ async function main() {
 
   let args = yargsParser(process.argv.slice(2));
 
-  const target = process.argv[2] || ".";
+  let target =
+    process.argv[2] ||
+    (
+      await prompts({
+        type: "text",
+        name: "value",
+        message: "Where do you want to create the app?",
+        initial: "my-app"
+      })
+    ).value;
 
   let config = {
     directory: args.example_dir ? args.example_dir : "examples",

--- a/packages/create-solid/cli/index.js
+++ b/packages/create-solid/cli/index.js
@@ -80,7 +80,7 @@ async function main() {
 
   let args = yargsParser(process.argv.slice(2));
 
-  let target =
+  const target =
     process.argv[2] ||
     (
       await prompts({


### PR DESCRIPTION
prompt user for target if they didn't supply one through argv

**Disclaimer:** I couldn't get the CLI to run locally (`pnpm build` errors, even tried `node cli/index.js` and that errored too). 

<img width="848" alt="CleanShot 2023-01-22 at 23 02 18@2x" src="https://user-images.githubusercontent.com/51714798/213942699-d80f047e-ef26-4cc2-9191-a1927b2a6ca1.png">

<img width="844" alt="CleanShot 2023-01-22 at 23 02 45@2x" src="https://user-images.githubusercontent.com/51714798/213942707-5a6c0772-0d7c-4d7c-a885-e0e5da155002.png">

Not sure how you build or run this CLI but this should do it.

ref: 
<img width="542" alt="CleanShot 2023-01-22 at 22 59 21@2x" src="https://user-images.githubusercontent.com/51714798/213942565-a4fb2d60-b29d-47c4-8d9e-673e80bc82bc.png">
