### PR TITLE
fix route path for back navigation data fetching

### DIFF
--- a/packages/start/islands/router.ts
+++ b/packages/start/islands/router.ts
@@ -13,7 +13,7 @@ export default function mountRouter() {
     _$DEBUG("mounting islands router");
 
     const basePath = "/";
-    let [currentLocation, setCurrentLocation] = createSignal<Location>(getLocation());
+    let [currentLocation, setCurrentLocation] = createSignal(getLocation());
     window.LOCATION = currentLocation;
 
     function getLocation(): Location & LocationEntry {
@@ -101,9 +101,9 @@ export default function mountRouter() {
     }
 
     async function handlePopState(evt: PopStateEvent) {
-      const { pathname, state } = getLocation();
-      if (currentLocation().pathname !== pathname) {
-        if (await navigate(pathname)) {
+      const { path, state } = getLocation();
+      if (currentLocation().path !== path) {
+        if (await navigate(path)) {
           setCurrentLocation(getLocation());
         }
       }


### PR DESCRIPTION
Issue is quickly noticeable when performing any back navigation on https://solid-hn-islands.netlify.app/
This change fixes the problem by causing the full path (pathname + search + hash) to be fetched in `navigate()`.

While this is obviously correct for the search params, I'm not so sure about the hash. But it's also done for anchor links:
https://github.com/solidjs/solid-start/blob/7ab235584edb2bd37735614d15aa4d75f7bce62f/packages/start/islands/router.ts#L67
https://github.com/solidjs/solid-start/blob/7ab235584edb2bd37735614d15aa4d75f7bce62f/packages/start/islands/router.ts#L86
So if it's wrong, both should be changed to not include the hash.

