### PR TITLE
types: add types for the vercel adapter

### DIFF
--- a/packages/start-vercel/index.d.ts
+++ b/packages/start-vercel/index.d.ts
@@ -1,0 +1,18 @@
+export type PrerenderFunctionConfig = {
+  expiration: number | false;
+  group?: number;
+  bypassToken?: string;
+  fallback?: string;
+  allowQuery?: string[];
+};
+
+export type SolidStartVercelOptions = {
+  /**
+   * @default false
+   */
+  edge?: boolean;
+  includes?: string | string[];
+  excludes?: string | string[];
+  prerender?: PrerenderFunctionConfig;
+};
+export default function (props: SolidStartVercelOptions): import("solid-start/vite").Adapter;

--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -54,8 +54,8 @@ const copyDependencies = async ({ entry, outputDir, includes, excludes, workingD
 
   for (const error of warnings) {
     if (error.message.startsWith("Failed to resolve dependency")) {
-      const [, module, file] = /Cannot find module '(.+?)' loaded from (.+)/.exec(error.message);
-
+      const match = /Cannot find module '(.+?)' loaded from (.+)/.exec(error.message);
+      const [, module, file] = match ? match : [];
       if (fileURLToPath(entry) === file) {
         console.warn(
           `[solid-start-vercel] The module "${module}" couldn't be resolved. This may not be a problem, but it's worth checking.`

--- a/packages/start-vercel/package.json
+++ b/packages/start-vercel/package.json
@@ -2,6 +2,7 @@
   "name": "solid-start-vercel",
   "version": "0.2.19",
   "main": "./index.js",
+  "types": "./index.d.ts",
   "type": "module",
   "solid": {
     "type": "adapter"


### PR DESCRIPTION
This will remove the ugly ```@ts-ignore``` when using solid-start-vercel

closes https://github.com/solidjs/solid-start/issues/716