### PR TITLE
throw an error when building with solid start static when ssr is disabled

### DIFF
--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -23,6 +23,7 @@ export default function () {
       return `http://localhost:${process.env.PORT}`;
     },
     async build(config, builder) {
+      if(!config?.solidOptions?.ssr) throw new Error('solid-start-static needs ssr to be enabled for pre-rendering routes at build time');
       const ssrExternal = config?.ssr?.external || [];
       await builder.client(join(config.root, "dist", "public"));
       await builder.server(join(config.root, ".solid", "server"));


### PR DESCRIPTION
I got caught in the pitfall of thinking that solid start SSR option is for runtime SSR, so I disabled it when building a SSG app with the static adapter and got the error `getStaticHTML is not a function`.

This PR will throw a more descriptive error when building with static adapter and SSR disabled.

this is PR is related to the issue https://github.com/solidjs/solid-start/issues/325