### PR TITLE
fix: always render doctype

### DIFF
--- a/packages/start/entry-server/StartServer.tsx
+++ b/packages/start/entry-server/StartServer.tsx
@@ -82,7 +82,10 @@ export default function StartServer({ event }: { event: PageEvent }) {
   return (
     <ServerContext.Provider value={event}>
       {devNoSSR ? (
-        <Root />
+        <>
+          {docType as unknown as any}
+          <Root />
+        </>
       ) : (
         <MetaProvider tags={event.tags as ComponentProps<typeof MetaProvider>["tags"]}>
           <StartRouter


### PR DESCRIPTION
Fixes #731.

Unsure if this is the preferred way to solve this problem, as I don't have much knowledge in this codebase. I tested by making this change in the `node_modules` of a project I'm working on, but I was unable to follow the steps in the `CONTRIBUTING.md` to test.

More than happy to test, but currently getting:

```
~/github/solid-start$ pnpm --filter example-hackernews run dev

> example-hackernews@ dev github/solid-start/examples/hackernews
> solid-start dev

 solid-start dev 
 version  0.2.20
failed to load config from github/solid-start/examples/hackernews/vite.config.ts
node:internal/errors:478
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /github/solid-start/packages/start/fs-router/fileRoutesImport.ts
    at new NodeError (node:internal/errors:387:5)
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:75:11)
    at defaultGetFormat (node:internal/modules/esm/get_format:117:38)
    at defaultLoad (node:internal/modules/esm/load:81:20)
    at nextLoad (node:internal/modules/esm/loader:163:28)
    at ESMLoader.load (node:internal/modules/esm/loader:605:26)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:457:22)
    at new ModuleJob (node:internal/modules/esm/module_job:63:26)
    at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:480:17)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:434:34) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
/github/solid-start/examples/hackernews:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  example-hackernews@ dev: `solid-start dev`
Exit status 1```