### PR TITLE
fix(examples/todomvc): move packages to dependencies

### DIFF
--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -7,19 +7,21 @@
   },
   "type": "module",
   "devDependencies": {
-    "@solidjs/meta": "^0.28.2",
-    "@solidjs/router": "^0.7.0",
     "@types/node": "^18.11.18",
     "csstype": "3.1.0",
     "esbuild": "^0.14.54",
     "postcss": "^8.4.21",
     "rollup": "^3.10.0",
-    "solid-js": "^1.6.9",
-    "solid-start": "^0.2.19",
     "solid-start-node": "^0.2.19",
     "typescript": "^4.9.4",
-    "undici": "^5.15.1",
     "vite": "^3.2.5"
+  },
+  "dependencies": {
+    "@solidjs/meta": "^0.28.2",
+    "@solidjs/router": "^0.7.0",
+    "solid-js": "^1.6.9",
+    "solid-start": "^0.2.19",
+    "undici": "^5.15.1"
   },
   "engines": {
     "node": ">=16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,19 +138,20 @@ importers:
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^3.2.5
-    devDependencies:
+    dependencies:
       '@solidjs/meta': 0.28.2_solid-js@1.6.9
       '@solidjs/router': 0.7.0_solid-js@1.6.9
+      solid-js: 1.6.9
+      solid-start: link:../../packages/start
+      undici: 5.15.1
+    devDependencies:
       '@types/node': 18.11.18
       csstype: 3.1.0
       esbuild: 0.14.54
       postcss: 8.4.21
       rollup: 3.10.0
-      solid-js: 1.6.9
-      solid-start: link:../../packages/start
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
-      undici: 5.15.1
       vite: 3.2.5_@types+node@18.11.18
 
   examples/with-auth:
@@ -2621,7 +2622,6 @@ packages:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.6.9
-    dev: true
 
   /@solidjs/router/0.7.0_solid-js@1.6.10:
     resolution: {integrity: sha512-8HI84twe5FjYRebSLMAhtkL9bRuTDIlxJK56kjfjU9WKGoUCTaWpCnkuj8Hqde1bWZ0X+GOZxKDfNkn1CjtjxA==}
@@ -2637,7 +2637,6 @@ packages:
       solid-js: ^1.5.3
     dependencies:
       solid-js: 1.6.9
-    dev: true
 
   /@solidjs/testing-library/0.5.2_solid-js@1.6.9:
     resolution: {integrity: sha512-GXUiI0Itz/7FfTJrV0RoICS2lL0RE3D1lNSrnuNg9nLC28qKnEQhm9Gfk4gFP9rGVzmsJJJC7yf8kbHMuyR2AA==}


### PR DESCRIPTION
Solid and associated dependencies should be added to prod dependencies and not dev dependencies. The other examples are correctly setup and this seemed to be the only incorrectly setup one