### PR TITLE
fix: use base path in client router

### DIFF
--- a/packages/start/entry-client/StartClient.tsx
+++ b/packages/start/entry-client/StartClient.tsx
@@ -83,7 +83,7 @@ export default () => {
   return (
     <ServerContext.Provider value={mockFetchEvent}>
       <MetaProvider>
-        <StartRouter data={dataFn}>
+        <StartRouter base={import.meta.env.BASE_URL} data={dataFn}>
           <Root />
         </StartRouter>
       </MetaProvider>


### PR DESCRIPTION
- fixes https://github.com/solidjs/solid-start/issues/397
- allows us to use github pages with the static adapter.