### PR TITLE
Allow vite to split dynamic imports to multiple files

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -306,10 +306,6 @@ prog
             rollupOptions: {
               input: config.solidOptions.serverEntry,
               external: ssrExternal,
-              output: {
-                inlineDynamicImports: true,
-                format: "esm"
-              }
             }
           }
         });


### PR DESCRIPTION
related #739 

by not allowing vite to split dynamic imports rollup is unable to do any dead code elimination... with the current setup vite will always include dynamic imports even if they are never available like clientOnly in ssr. also vite's default output in esm so setting it to esm its redundant

How does this effect adapters?
- For adapters that use file output nothing is changed it will still output a single file
- For adapters that use dir output rollup will dump the extra files in the output folder which is just dist in all cases currently and from my testing the frameworks had no issue picking up the extra files.

to confirm that client only is removed i have a example repo here https://github.com/arbassett/solid-start-clientOnly-fix with the patch and committed dist dir to show that the clientOnly import was removed from the server build

