### PR TITLE
Vercel & Netlify forward ssr.external to rollup build

### DIFF
--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -16,6 +16,7 @@ export default function ({ edge } = {}) {
       proc.stderr.pipe(process.stderr);
     },
     async build(config, builder) {
+      const ssrExternal = config?.ssr?.external || [];
       const __dirname = dirname(fileURLToPath(import.meta.url));
       if (!config.solidOptions.ssr) {
         await builder.spaClient(join(config.root, "netlify"));
@@ -45,7 +46,8 @@ export default function ({ edge } = {}) {
             exportConditions: edge ? ["deno", "solid"] : ["node", "solid"]
           }),
           common({ strictRequires: true, ...config.build.commonjsOptions })
-        ]
+        ],
+        external: ssrExternal
       });
       // or write the bundle to disk
       await bundle.write({

--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -128,6 +128,7 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
       proc.stderr.pipe(process.stderr);
     },
     async build(config, builder) {
+      const ssrExternal = config?.ssr?.external || [];
       // Vercel Build Output API v3 (https://vercel.com/docs/build-output-api/v3)
       const __dirname = dirname(fileURLToPath(import.meta.url));
       const workingDir =
@@ -171,7 +172,8 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
             exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
           }),
           common({ strictRequires: true, ...config.build.commonjsOptions })
-        ]
+        ],
+        external: ssrExternal
       });
 
       const renderFuncEntrypoint = new URL(`./index.${edge ? "mjs" : "cjs"}`, outputDir); // join(renderFuncDir, renderEntrypoint);
@@ -251,7 +253,8 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
               exportConditions: edge ? ["worker", "solid"] : ["node", "solid"]
             }),
             common({ strictRequires: true, ...config.build.commonjsOptions })
-          ]
+          ],
+          external: ssrExternal
         });
 
         const apiFuncEntrypoint = new URL(`./index.${edge ? "mjs" : "cjs"}`, outputDir); // join(apiFuncDir, apiEntrypoint);


### PR DESCRIPTION
related #739 

Its possible to have packages that can't be processed for a server bundle ex `monaco-editor`. you can tell vite to not process this with ssr.external config value but for vercel and netlify this is not forwarded to the final build.. normally we wan't to bundle everything that we can butthere should be a escape hatch for these cases which the node adapter already does.

if the file is truely needed it will be copied during the final parts of the build process to where it is needed unprocessed by rollup and vite
- #702 for vercel
- Netlify does this automatically in their ci platform with [zip-it-and-ship-it](https://github.com/netlify/zip-it-and-ship-it) 

this also works with #744 to remove client only imports with `unstable_clientOnly`