### PR TITLE
start-netlify: Add context to request handler

### DIFF
--- a/packages/start-netlify/entry-edge.js
+++ b/packages/start-netlify/entry-edge.js
@@ -4,10 +4,10 @@ import handler from "./handler";
 export default (request, context) =>
   handler({
     request,
-    context,
     clientAddress: request.headers.get('x-nf-client-connection-ip'),
     locals: {},
     env: {
+      ...context,
       manifest,
       getStaticHTML: path => context.rewrite(new URL(`${path}.html`, request.url).href)
     }

--- a/packages/start-netlify/entry-edge.js
+++ b/packages/start-netlify/entry-edge.js
@@ -4,6 +4,7 @@ import handler from "./handler";
 export default (request, context) =>
   handler({
     request,
+    context,
     clientAddress: request.headers.get('x-nf-client-connection-ip'),
     locals: {},
     env: {

--- a/packages/start-netlify/entry.js
+++ b/packages/start-netlify/entry.js
@@ -14,10 +14,9 @@ export const handler = async function (event, context) {
 
   const webRes = await handle({
     request: createRequest(event),
-    context,
     clientAddress: event.headers["x-nf-client-connection-ip"],
     locals: {},
-    env: { manifest }
+    env: { ...context, manifest }
   });
   const headers = {};
   for (const [name, value] of webRes.headers) {

--- a/packages/start-netlify/entry.js
+++ b/packages/start-netlify/entry.js
@@ -14,6 +14,7 @@ export const handler = async function (event, context) {
 
   const webRes = await handle({
     request: createRequest(event),
+    context,
     clientAddress: event.headers["x-nf-client-connection-ip"],
     locals: {},
     env: { manifest }


### PR DESCRIPTION
Netlify exposes certain information that is useful to the handler via context. It's request function provides a separate context value that was never added to the handler.

This PR ensures that it is apart of it so the user can gain access to things like the geolocation data provided by Edge Functions: https://edge-functions-examples.netlify.app/example/geolocation