### PR TITLE
Allow prerenderRoutes as promise

### DIFF
--- a/docs/api/vite.md
+++ b/docs/api/vite.md
@@ -74,7 +74,7 @@ The vite plugin exposes the following options:
 - `rootEntry` (_string_, default `"./root.tsx"`): the file path where to the root.
 - `clientEntry` (_string_, default `"./entry-client.tsx"`): the file path where to the client entry.
 - `serverEntry` (_string_, default `"./entry-server.tsx"`): the file path where to the server entry.
-- `prerenderRoutes` (_string[]_, default `[]`): list of route paths to prerender (currently only works with static adapter).
+- `prerenderRoutes` (_string[]_ | _Promise<string[]>_, default `[]`): list of route paths to prerender (currently only works with static adapter).
 - `inspect` (_boolean_, default `true`): turns on whether vite inspect plugin is enabled.
 - `ssr` (_boolean_, default `true`): toggles between client rendering and server rendering (ssr) mode. `server$` functions do not work with `ssr: false`.
 - `islands` (_boolean_, default `false`): _experimental_ toggles on "islands" mode.

--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -64,7 +64,7 @@ export default function () {
           .map(a => a.path)
           .filter(a => (a.includes(":") || a.includes("/")) && !a.includes("*")),
         "/404",
-        ...(config.solidOptions.prerenderRoutes || [])
+        ...await (config.solidOptions.prerenderRoutes || [])
       ];
       renderStatic(
         routes.map(url => ({

--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -64,7 +64,7 @@ export default function () {
           .map(a => a.path)
           .filter(a => (a.includes(":") || a.includes("/")) && !a.includes("*")),
         "/404",
-        ...await (config.solidOptions.prerenderRoutes || [])
+        ...(await config.solidOptions.prerenderRoutes || [])
       ];
       renderStatic(
         routes.map(url => ({

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -20,7 +20,7 @@ WIP this will change
 {
   preferStreaming: true, // use Streaming SSR on platforms that support it
   hot: true, // HMR in dev
-  adapter: adaptor(), // import adapter and initialize
+  adapter: adapter(), // import adapter and initialize
   prerenderRoutes: [] // routes that should be pre-rendered in static adapter
 }
 ```

--- a/packages/start/types.ts
+++ b/packages/start/types.ts
@@ -31,7 +31,7 @@ export type StartOptions = {
   islands: boolean;
   islandsRouter: boolean;
   lazy: boolean;
-  prerenderRoutes: string[];
+  prerenderRoutes: string[] | Promise<string[]>;
   inspect: boolean;
   pageExtensions: string[];
   root: string;

--- a/packages/start/vite/plugin.d.ts
+++ b/packages/start/vite/plugin.d.ts
@@ -12,7 +12,7 @@ export type Options = {
   ssr: boolean;
   islands: boolean;
   islandsRouter: boolean;
-  prerenderRoutes: any[];
+  prerenderRoutes: string[] | Promise<string[]>;
   inspect: boolean;
   rootEntry: string;
   serverEntry: string;


### PR DESCRIPTION
Allow prerenderRoutes to be provided as a promise (ie: to fetch routes from CMS)