### PR TITLE
Check string "null" for req.headers.origin

### DIFF
--- a/packages/start/node/fetch.js
+++ b/packages/start/node/fetch.js
@@ -138,7 +138,9 @@ class NodeRequest extends BaseNodeRequest {
 }
 
 export function createRequest(req) {
-  let origin = req.headers.origin || `http://${req.headers.host}`;
+  let origin = req.headers.origin && 'null' !== req.headers.origin
+      ? req.headers.origin
+      : `http://${req.headers.host}`;
   let url = new URL(req.url, origin);
 
   let init = {


### PR DESCRIPTION
The value of `req.headers.origin` can be a string "null". We need to consider this situation.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin