### PR TITLE
Add missing props param in the MySiteTitle example

### DIFF
--- a/docs/core-concepts/head-and-metadata.md
+++ b/docs/core-concepts/head-and-metadata.md
@@ -92,7 +92,7 @@ export default function About() {
 You can create custom components that wrap `Title` to add a site-specific prefix to all the titles, e.g.
 
 ```tsx
-export default function MySiteTitle() {
+export default function MySiteTitle(props) {
   return <Title>{props.children} | My Site</Title>;
 }
 ```


### PR DESCRIPTION
Hello, I notice that the `props` param is missing in this example on the `MySiteTitle` function:

```tsx
export default function MySiteTitle() {
  return <Title>{props.children} | My Site</Title>;
}
```

This is the first time I read a SolidJS related doc, so I was not 100% sure that the props came as param like React. But I tested it in the code sandbox and it throw an error without it, so I open this PR. This will avoid confusion with new devs like me.

Nice project by the way!