### PR TITLE
Add .env to .gitignore

### DIFF
--- a/packages/create-solid/cli/index.js
+++ b/packages/create-solid/cli/index.js
@@ -22,6 +22,10 @@ dist
 .netlify
 netlify
 
+# Environment
+.env
+.env*.local
+
 # dependencies
 /node_modules
 


### PR DESCRIPTION
Adds `.env` patterns to `.gitignore` to avoid new Solid Start projects from committing their environment variables accidentally.

Thought here is `.env` in addition to `.env*.local` which will cover a variety of uses intended only for local environments.

More background behind thought on specific additions on Issue.

Fixes:  #763 