### PR TITLE
fix: remove entry-server handler copy in adapters

### DIFF
--- a/packages/start-cloudflare-pages/entry.js
+++ b/packages/start-cloudflare-pages/entry.js
@@ -1,5 +1,5 @@
 import manifest from "../../dist/public/route-manifest.json";
-import handler from "./handler";
+import handler from "./entry-server";
 
 export const onRequestGet = async ({ request, next, env }) => {
   // Handle static assets

--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -140,10 +140,6 @@ export default function (miniflareOptions) {
 
       writeFileSync(join(config.root, "dist", "public", "_headers"), getHeadersFile(), "utf8");
 
-      copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
       copyFileSync(join(__dirname, "entry.js"), join(config.root, ".solid", "server", "server.js"));
       const bundle = await rollup({
         input: join(config.root, ".solid", "server", "server.js"),

--- a/packages/start-cloudflare-workers/entry.js
+++ b/packages/start-cloudflare-workers/entry.js
@@ -1,7 +1,7 @@
 import { getAssetFromKV, MethodNotAllowedError, NotFoundError } from "@cloudflare/kv-asset-handler";
 import manifestJSON from "__STATIC_CONTENT_MANIFEST";
 import manifest from "../../dist/public/route-manifest.json";
-import handler from "./handler";
+import handler from "./entry-server";
 
 /**
  * @example

--- a/packages/start-cloudflare-workers/index.js
+++ b/packages/start-cloudflare-workers/index.js
@@ -143,17 +143,13 @@ export default function (miniflareOptions = {}) {
         await builder.server(join(config.root, ".solid", "server"));
       }
 
-      copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
       copyFileSync(join(__dirname, "entry.js"), join(config.root, ".solid", "server", "server.js"));
       let durableObjects = Object.values(miniflareOptions?.durableObjects || {});
 
       if (durableObjects.length > 0) {
         let text = readFileSync(join(config.root, ".solid", "server", "server.js"), "utf8");
         durableObjects.forEach(item => {
-          text += `\nexport { ${item} } from "./handler";`;
+          text += `\nexport { ${item} } from "./entry-server";`;
         });
         writeFileSync(join(config.root, ".solid", "server", "server.js"), text);
       }

--- a/packages/start-deno/entry.js
+++ b/packages/start-deno/entry.js
@@ -1,6 +1,6 @@
 import { lookup } from "https://deno.land/x/media_types/mod.ts";
 import manifest from "../../dist/public/route-manifest.json";
-import handler from "./handler";
+import handler from "./entry-server";
 
 import { serve } from "https://deno.land/std@0.139.0/http/server.ts";
 

--- a/packages/start-deno/index.js
+++ b/packages/start-deno/index.js
@@ -37,10 +37,6 @@ export default function () {
         await builder.server(join(config.root, ".solid", "server"));
       }
 
-      copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
       copyFileSync(join(__dirname, "entry.js"), join(config.root, ".solid", "server", "server.js"));
       const bundle = await rollup({
         input: join(config.root, ".solid", "server", "server.js"),

--- a/packages/start-netlify/entry.js
+++ b/packages/start-netlify/entry.js
@@ -1,7 +1,7 @@
 import { splitCookiesString } from "solid-start/node/fetch.js";
 import "solid-start/node/globals.js";
 import manifest from "../../netlify/route-manifest.json";
-import handle from "./handler";
+import handle from "./entry-server";
 
 Response.redirect = function (url, status = 302) {
   let response = new Response(null, { status, headers: { Location: url }, counter: 1 });

--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -30,10 +30,6 @@ export default function ({ edge } = {}) {
       }
 
       copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
-      copyFileSync(
         join(__dirname, edge ? "entry-edge.js" : "entry.js"),
         join(config.root, ".solid", "server", "index.js")
       );

--- a/packages/start-node/entry.js
+++ b/packages/start-node/entry.js
@@ -3,7 +3,7 @@ import { createServer } from "solid-start-node/server.js";
 import "solid-start/node/globals.js";
 import { fileURLToPath } from "url";
 import manifest from "../../dist/public/route-manifest.json";
-import handler from "./handler.js";
+import handler from "./entry-server.js";
 
 const { PORT = 3000 } = process.env;
 

--- a/packages/start-node/index.js
+++ b/packages/start-node/index.js
@@ -1,7 +1,7 @@
 import common from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
-import { copyFileSync, readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { rollup } from "rollup";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -28,11 +28,6 @@ export default function () {
         await builder.client(join(config.root, "dist", "public"));
         await builder.server(join(config.root, ".solid", "server"));
       }
-
-      copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
 
       let text = readFileSync(join(__dirname, "entry.js")).toString();
 

--- a/packages/start-static/entry.js
+++ b/packages/start-static/entry.js
@@ -1,7 +1,7 @@
 import { createRequest } from "solid-start/node/fetch.js";
 import "solid-start/node/globals.js";
 import manifest from "../../dist/public/route-manifest.json";
-import handler from "./handler.js";
+import handler from "./entry-server.js";
 
 const MAX_REDIRECTS = 10;
 async function handleRequest(req) {

--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -27,10 +27,6 @@ export default function () {
       const ssrExternal = config?.ssr?.external || [];
       await builder.client(join(config.root, "dist", "public"));
       await builder.server(join(config.root, ".solid", "server"));
-      copyFileSync(
-        join(config.root, ".solid", "server", `entry-server.js`),
-        join(config.root, ".solid", "server", "handler.js")
-      );
       const pathToServer = join(config.root, ".solid", "server", "server.js");
       copyFileSync(join(__dirname, "entry.js"), pathToServer);
       const pathToDist = resolve(config.root, "dist", "public");


### PR DESCRIPTION
# Summary

Since dynamic imports were enabled again in the vite build (6469a0fe5b5f5abcc121305a5c471047226721b8), in certain cases the handler.js copy results in duplicate code. As example in the final build, dynamically imported modules might import their dependencies from the original entry-server.js instead of the handler.js copy, this would result in the following chain:

1. handler.js copied from entry-server.js (therefore has code of dep1, dep2, dep3)
2. handler.js dynamically imports SomeComponent.js
2. SomeComponent.js doesnt know about handler.js, imports dep2 from entry-server.js
3. entry-server.js has code for dep1, dep2, dep3
4. The final build includes dep1, dep2 and dep3 from handler.js and from entry-server.js

So by removing the handler.js copy and directly importing entry-server.js we can avoid the duplicate dependency code.

# Alternative solution
Undo 6469a0fe5b5f5abcc121305a5c471047226721b8

# Screenshots
- A possible result of this bug: [Bildschirmfoto vom 2023-02-25 10-39-19](https://user-images.githubusercontent.com/4012401/221351672-add91045-5bf8-4cef-aead-162fb609bedb.png)
- How it looks after the fix: [Bildschirmfoto vom 2023-02-25 11-10-41](https://user-images.githubusercontent.com/4012401/221351704-2dd10c7b-de68-492b-947a-6e2f3574ccfb.png)

- dist code before fix:
  - step 1, vite: [Bildschirmfoto vom 2023-02-25 10-42-50](https://user-images.githubusercontent.com/4012401/221351925-a0e643aa-aabe-4c79-bc51-5e614afb9d5e.png)
  - step 2, rollup: [Bildschirmfoto vom 2023-02-25 10-43-42](https://user-images.githubusercontent.com/4012401/221352157-7c948257-b66d-4349-8d35-69d0ca5d06be.png)


# Testing
- Reproduction project: [solid-start-duplicates.zip](https://github.com/solidjs/solid-start/files/10830842/solid-start-duplicates.zip)
  - Unzip it and open the folder
  - pnpm install
  - pnpm build
  - pnpm start

**So far I only tested this fix with the `start-node` adapter! I don't have the setup to test the other adapters and would need your help on those ones <3**

# History
Why does the handler.js copy exist in the first place? I don't know why the handler.js copy currently exists, but it looks like the copy had a usecase in the past, when it copied a different source file depending on `preferStreaming` https://github.com/solidjs/solid-start/blob/5ce1b813f19b3bbc779addeb507218f13ab5cc35/packages/start-node/index.js#L42

# Background info
I already informed about this in Discord: https://discord.com/channels/722131463138705510/910635844119982080/1078086226252402759, copy:

> To give you a summary on the bug: the dynamic import change (https://github.com/solidjs/solid-start/commit/6469a0fe5b5f5abcc121305a5c471047226721b8) results in duplication of dependency code in pnpm build, e.g. MetaContext is declared twice in dist and breaks server renders in prod. 
> 
> But this is actually not the fault of the dynamic import change. Its a bit more complicated:
> 1. Dynamically imported code which also has to import dependencies, imports those from "entry-server.js"
> 2. start-node copies entry-server.js into a new file handler.js
> 3. start-node creates a file server.js which imports handler.js
> 4. dynamically imported code still imports its dependencies from entry-server.js
> 5. rollup tries its best to bundle handler.js, stumbles upon the dynamic assets which import stuff from entry-server.js and thus it creates duplicate dependency code 💣 
> 
> I don't know why the entry-server.js to handler.js copy even exists, but afaik it ultimately breaks dynamic imports 😅 .
> 
> Workarounds:
> - Downgrade to solid-start 0.2.20
> - Patch https://github.com/solidjs/solid-start/blob/90cb8f721af0e99ca2a6aab4eb931cfbd7ea426f/packages/start-node/entry.js#L6 so that it just uses entry-server.js instead of handler.js




