### PR TITLE
Fix vercel adapter type definition to allow optional config

### DIFF
--- a/packages/start-vercel/index.d.ts
+++ b/packages/start-vercel/index.d.ts
@@ -15,4 +15,7 @@ export type SolidStartVercelOptions = {
   excludes?: string | string[];
   prerender?: PrerenderFunctionConfig;
 };
-export default function (props: SolidStartVercelOptions): import("solid-start/vite").Adapter;
+
+type ViteAdapter = import("solid-start/vite").Adapter;
+export default function (props: SolidStartVercelOptions): ViteAdapter;
+export default function (): ViteAdapter;


### PR DESCRIPTION
#717 made it so that you have to pass the options parameter, so code like [this](https://github.com/solidjs/solid-start/blob/main/packages/start-vercel/README.md) (which used to work) now throws a TS error:

```typescript
export default defineConfig({
  plugins: [solid({ adapter: vercel() })]
});
```

This fix changes it back to the way it used to work.