### PR TITLE
Fix error when use edge function in netlify adapter

### DIFF
--- a/packages/start-netlify/entry-edge.js
+++ b/packages/start-netlify/entry-edge.js
@@ -1,5 +1,5 @@
 import manifest from "../../netlify/route-manifest.json";
-import handler from "./handler";
+import handler from "./entry-server.js";
 
 export default (request, context) =>
   handler({


### PR DESCRIPTION
This fixes a bug in `entry-edge.js` that caused it to use the removed handler instead of importing `entry-server.js` directly. This bug was introduced in #770 and affected the edge function on Netlify.