### PR TITLE
[start-static] Add index.d.ts

### DIFF
--- a/packages/start-static/index.d.ts
+++ b/packages/start-static/index.d.ts
@@ -1,0 +1,1 @@
+export default function (): import("solid-start/vite").Adapter;

--- a/packages/start-static/package.json
+++ b/packages/start-static/package.json
@@ -2,6 +2,7 @@
   "name": "solid-start-static",
   "version": "0.2.23",
   "main": "./index.js",
+  "types": "./index.d.ts",
   "type": "module",
   "solid": {
     "type": "adapter"


### PR DESCRIPTION
Fixes this TS error.

```ts
// vite.config.ts
import { defineConfig } from "vite";
import solid from "solid-start/vite";
import adapter from "solid-start-static"; // 🔴 Could not find a declaration file for module 'solid-start-static'.

export default defineConfig({
  plugins: [
    solid({ adapter: adapter() }),
  ],
});
```