### PR TITLE
Adjusted HTTPHeader cleanup function to check when it's not on the server

### DIFF
--- a/packages/start/server/components/HttpHeader.tsx
+++ b/packages/start/server/components/HttpHeader.tsx
@@ -14,7 +14,7 @@ export function HttpHeader(props: { name: string; value: string; append?: boolea
   }
 
   onCleanup(() => {
-    if (isServer) {
+    if (!isServer) {
       const value = pageContext!.responseHeaders.get(props.name);
       if (value) {
         const values = value.split(", ");


### PR DESCRIPTION
# Issue
When attempting to utilize the `HTTPHeader` component, the headers would not be sent on the server response. They were being removed up by `cleanup()`.

# Potential Solution 
This is a potential fix to execute the cleanup when not on the server. This performed as expected locally and headers were being received on the client. 