### PR TITLE
Remove tailwind classes from prisma example

### DIFF
--- a/examples/with-prisma/src/root.css
+++ b/examples/with-prisma/src/root.css
@@ -1,6 +1,6 @@
 body {
   font-family: Gordita, Roboto, Oxygen, Ubuntu, Cantarell,
-  'Open Sans', 'Helvetica Neue', sans-serif;
+  'Open Sans', 'Helvetica Neue', sans-serif;  
 }
 
 main {
@@ -13,6 +13,7 @@ main {
 
 h1 {
   margin: 0;
+  font-size: 1.75rem;
 }
 
 p {
@@ -51,9 +52,17 @@ button {
   background: #d1d5db;
   border: none;
   border-radius: 0.3rem;
-  padding: 0.2rem;
+  padding: 0.4rem;
   font-size: 1rem;
   width: 100%;
+  margin-top: 8px;
+  cursor: pointer;
 }
 
+button[type='submit'] {
+  background-color: rgb(0 0 0 / 5%);
+}
 
+.full-width {
+  width: 100%;
+}

--- a/examples/with-prisma/src/routes/[...404].tsx
+++ b/examples/with-prisma/src/routes/[...404].tsx
@@ -1,7 +1,7 @@
 export default function NotFound() {
   return (
-    <main class="w-full p-4 space-y-2">
-      <h1 class="font-bold text-xl">Page Not Found</h1>
+    <main class="full-width">
+      <h1>Page Not Found</h1>
     </main>
   );
 }

--- a/examples/with-prisma/src/routes/index.tsx
+++ b/examples/with-prisma/src/routes/index.tsx
@@ -12,9 +12,9 @@ export default function Home() {
   const [, { Form }] = createServerAction$((f: FormData, { request }) => logout(request));
 
   return (
-    <main class="w-full p-4 space-y-2">
-      <h1 class="font-bold text-3xl">Hello {user()?.username}</h1>
-      <h3 class="font-bold text-xl">Message board</h3>
+    <main class="full-width">
+      <h1>Hello {user()?.username}</h1>
+      <h3>Message board</h3>
       <button onClick={() => refetchRouteData()}>Refresh</button>
       <Form>
         <button name="logout" type="submit">


### PR DESCRIPTION
The prism example uses tailwind classes even though it doesn't have tailwind,
so these classes don't take effect.
This PR replaces them with a bit of CSS additions to `main.css`

for example:
```html
<main class="w-full p-4 space-y-2">
  <h1 class="font-bold text-3xl">Hello {user()?.username}</h1>
  <h3 class="font-bold text-xl">Message board</h3>
  <button onClick={() => refetchRouteData()}>Refresh</button>
  <Form>
    <button name="logout" type="submit">
      Logout
    </button>
  </Form>
</main>
```