### PR TITLE
Introduce resetOnSuccess prop for route action forms

### DIFF
--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -90,19 +90,27 @@ export function createRouteAction<T, U = void>(
       }) as Promise<U>;
   }
   submit.url = (fn as any).url;
-  submit.Form = ((props: Omit<FormProps, "action" | "onSubmission">) => {
+  submit.Form = ((
+    props: { resetOnSuccess?: boolean } & Omit<FormProps, "action" | "onSubmission">
+  ) => {
     let url = (fn as any).url;
-    return (
+    let form = (
       <FormImpl
         {...props}
         action={url}
-        onSubmission={submission => {
-          submit(submission.formData as any);
+        onSubmission={async submission => {
+          await submit(submission.formData as any);
+          if (!result()?.error && props.resetOnSuccess) {
+            if (form instanceof HTMLFormElement) {
+              form.reset();
+            }
+          }
         }}
       >
         {props.children}
       </FormImpl>
     );
+    return form;
   }) as T extends FormData ? ParentComponent<FormProps> : never;
 
   return [


### PR DESCRIPTION
This is somewhat related to #640.

I have a comment form in my solid-start project that I would like to reset upon successful submission, and _only_ on successful submission. I'm having trouble figuring out how to do that cleanly. So far I have the following:

```tsx
  createEffect(() => {
    if (!submittingComment.pending && !submittingComment.error) {
      formRef.reset();
    }
  });
```

The idea being that if the submission is not pending and there is no error then it's safe to call `formRef.reset()`. One way this gets tricky though is if there are multiple instances of `submitComment.Form` on the page (for instance, submitting a new thread vs submitting a reply to a thread both using the same `submitComment.Form` component, and therefore the same handler). Now one must handle multiple refs and determine which one submitted.

This is particularly tricky for `createServerAction$` because the action handler doesn't run any code client-side.

Looking at my proposed solutions for #640, I don't think any of them would work here. I'm not entirely sold on what I have in this PR. I did `form =` in order to preserve backwards compatibility with refs being passed in.

Am I overlooking something simple? I would basically like to be able to have multiple instances of my form on a page and clear whichever one successfully submits whenever any of them successfully submits.