### PR TITLE
fix: api route scoring algorithm

### DIFF
--- a/packages/start/api/index.ts
+++ b/packages/start/api/index.ts
@@ -38,7 +38,7 @@ function routeToMatchRoute(route: Route): MatchRoute {
 
   const params: { type: "*" | ":"; name: string; index: number }[] = [];
   const matchSegments: (string | null)[] = [];
-  let score = route.path.endsWith("/") ? 4 : 0;
+  let score = 0;
   let wildcard = false;
 
   for (const [index, segment] of segments.entries()) {
@@ -52,6 +52,7 @@ function routeToMatchRoute(route: Route): MatchRoute {
       });
       matchSegments.push(null);
     } else if (segment[0] === "*") {
+      score -= 1;
       params.push({
         type: "*",
         name: segment.slice(1),

--- a/test/api-routes-test.ts
+++ b/test/api-routes-test.ts
@@ -119,6 +119,14 @@ test.describe("api routes", () => {
 
               return <Show when={data()}><div data-testid="data">{data()?.welcome}</div></Show>;
             }
+          `,
+          "src/routes/api/static.js": js`
+            import { json } from "solid-start/server";
+            export let GET = () => json({ static: true });
+          `,
+          "src/routes/api/[param]/index.js": js`
+            import { json } from "solid-start/server";
+            export let GET = ({ params }) => json(params);
           `
         }
       });
@@ -253,6 +261,12 @@ test.describe("api routes", () => {
       let res = await fixture.requestDocument("/api/fetch");
       expect(res.headers.get("content-type")).toEqual("application/json");
       expect(await res.json()).toEqual({ message: "Hello from Hogwarts" });
+    });
+
+    test("/:param/ should not be matched over /static", async () => {
+      let res = await fixture.requestDocument("/api/static");
+      expect(res.headers.get("content-type")).toEqual("application/json; charset=utf-8");
+      expect(await res.json()).toEqual({ static: true });
     });
   }
 });


### PR DESCRIPTION
Fixes #806

This fixes an issue with routes like
`/:param/` being scored higher than
routes like `/static`