### PR TITLE
docs: api-routes change trpc route param name

### DIFF
--- a/docs/core-concepts/api-routes.md
+++ b/docs/core-concepts/api-routes.md
@@ -241,7 +241,7 @@ export const client = createTRPCProxyClient<AppRouter>({
 
 Finally, you can use the `fetch` adapter to write an API route that acts as the tRPC server.
 
-```tsx filename="routes/api/trpc/[...].ts"
+```tsx filename="routes/api/trpc/[trpc].ts"
 import { type APIEvent } from "solid-start/api";
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from "~/lib/router";


### PR DESCRIPTION
The example route for trpc `routes/api/trpc/[...].ts` is not a valid route for vercel deployments.

if you use a route with a param on `...` vercel during deployment will error with. 
Error: Builder returned invalid routes: ["Route at index 6 has invalid `src` regular expression \"^/api/trpc/(?<...>[^/]+)$\"."]

generated `.vercel/output/config.json`
```json
{
  "version": 3,
  "routes": [
    {
      "src": "/assets/(.*)",
      "headers": {
        "Cache-Control": "public, max-age=31556952, immutable"
      },
      "continue": true
    },
    {
      "handle": "filesystem"
    },
    {
      "src": "/api/trpc/(?<...>[^/]+)",
      "dest": "/api"
    },
    {
      "src": "/.*",
      "dest": "/render"
    }
  ]
}
```

[discord issue](https://discord.com/channels/722131463138705510/910635844119982080/1090429884175749120)

change the route param to match what the community does in [create-t3-app](https://create.t3.gg/en/usage/trpc#-pagesapitrpctrpcts) and [create-jd-app](https://github.com/OrJDev/create-jd-app/blob/a29d5ebd38b9cc8278295374470e2061a51df5a9/template/trpc/api/%5Btrpc%5D.ts)