### PR TITLE
allow internalFetch to pass env and locals

### DIFF
--- a/packages/start/api/internalFetch.ts
+++ b/packages/start/api/internalFetch.ts
@@ -8,7 +8,7 @@ export const registerApiRoutes = (routes: MatchRoute[]) => {
   apiRoutes = routes;
 };
 
-export async function internalFetch(route: string, init: RequestInit) {
+export async function internalFetch(route: string, init: RequestInit, env: Env = {}, locals: Record<string, unknown> = {}) {
   if (route.startsWith("http")) {
     return await fetch(route, init);
   }
@@ -25,8 +25,8 @@ export async function internalFetch(route: string, init: RequestInit) {
     request,
     params: handler.params,
     clientAddress: "127.0.0.1",
-    env: {},
-    locals: {},
+    env,
+    locals,
     $type: FETCH_EVENT,
     fetch: internalFetch
   });

--- a/packages/start/api/types.ts
+++ b/packages/start/api/types.ts
@@ -3,7 +3,7 @@ import { FetchEvent, FETCH_EVENT } from "../server/types";
 export interface APIEvent extends FetchEvent {
   params: { [key: string]: string };
   $type: typeof FETCH_EVENT;
-  fetch: (route: string, init: RequestInit) => Promise<Response>;
+  fetch: (route: string, init: RequestInit, env?: Env, locals?: Record<string, unknown>) => Promise<Response>;
 }
 
 export type Route = { path: string; children?: Route[] } & {


### PR DESCRIPTION
With Cloudflare at least, `internalFetch` is mostly useless in many situations, as environment variables are only available through the event, and are reset to `{}` by `internalFetch`.

Also, `locals` is the most common place for middleware to store request context, and as middleware isn't run again when `internalFetch` is used, it's useful to be able to pass this through from the parent request.