### PR TITLE
ignore me, test PR

### DIFF
--- a/examples/bare/package.json
+++ b/examples/bare/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/with-authjs/package.json
+++ b/examples/with-authjs/package.json
@@ -20,7 +20,7 @@
     "@auth/solid-start": "^0.1.0",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-mdx": "^0.0.6",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"

--- a/examples/with-prisma/package.json
+++ b/examples/with-prisma/package.json
@@ -16,7 +16,7 @@
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "prisma": "^4.9.0",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/with-solid-styled/package.json
+++ b/examples/with-solid-styled/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "solid-styled": "^0.8.1",
     "undici": "^5.15.1"

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -19,7 +19,7 @@
     "@vitest/coverage-c8": "^0.26.3",
     "@vitest/ui": "^0.26.3",
     "jsdom": "^20.0.3",
-    "solid-js": "^1.6.11",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.19",
     "solid-start-node": "^0.2.19",
     "typescript": "^4.9.4",

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -10,20 +10,22 @@
     "coverage": "vitest run --coverage"
   },
   "type": "module",
-  "devDependencies": {
+  "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
+    "solid-js": "^1.7.1",
+    "solid-start": "^0.2.24",
+    "undici": "^5.15.1"
+  },
+  "devDependencies": {
     "@solidjs/testing-library": "^0.5.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/testing-library__jest-dom": "^5.14.5",
     "@vitest/coverage-c8": "^0.26.3",
     "@vitest/ui": "^0.26.3",
     "jsdom": "^20.0.3",
-    "solid-js": "^1.7.1",
-    "solid-start": "^0.2.19",
     "solid-start-node": "^0.2.19",
     "typescript": "^4.9.4",
-    "undici": "^5.15.1",
     "vite": "^4.1.4",
     "vitest": "^0.26.3"
   }

--- a/examples/with-websocket/package.json
+++ b/examples/with-websocket/package.json
@@ -16,7 +16,7 @@
     "@cloudflare/workers-types": "^3.19.0",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.16",
+    "solid-js": "^1.7.1",
     "solid-start": "^0.2.24",
     "undici": "^5.15.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "graphql": "^16.6.0",
     "rimraf": "^3.0.2",
     "rollup": "^3.10.0",
-    "solid-js": "^1.6.11",
+    "solid-js": "^1.7.1",
     "solid-mdx": "^0.0.6",
     "solid-start": "workspace:*",
     "solid-start-cloudflare-workers": "workspace:^0.2.15",

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   },
   "dependencies": {
     "cross-env": "^7.0.3"
+  },
+  "engines": {
+    "pnpm": "=7"
   }
 }

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -118,7 +118,7 @@
     "@types/node": "^18.11.18",
     "@types/wait-on": "^5.3.1",
     "jsdom": "^20.0.3",
-    "solid-js": "^1.6.11",
+    "solid-js": "^1.7.1",
     "solid-start-cloudflare-pages": "workspace:*",
     "solid-start-cloudflare-workers": "workspace:*",
     "solid-start-deno": "workspace:*",
@@ -134,7 +134,7 @@
   "peerDependencies": {
     "@solidjs/meta": "^0.28.0",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.2",
+    "solid-js": "^1.7.1",
     "solid-start-aws": "*",
     "solid-start-cloudflare-pages": "*",
     "solid-start-cloudflare-workers": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       graphql: ^16.6.0
       rimraf: ^3.0.2
       rollup: ^3.10.0
-      solid-js: ^1.6.11
+      solid-js: ^1.7.1
       solid-mdx: ^0.0.6
       solid-start: workspace:*
       solid-start-cloudflare-workers: workspace:^0.2.15
@@ -41,8 +41,8 @@ importers:
       '@rollup/plugin-commonjs': 24.0.0_rollup@3.10.0
       '@rollup/plugin-json': 6.0.0_rollup@3.10.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@3.10.0
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.8.2_solid-js@1.6.11
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
       '@tailwindcss/typography': 0.5.9_tailwindcss@3.2.4
       '@trpc/client': 9.27.4_@trpc+server@9.27.4
       '@trpc/server': 9.27.4
@@ -52,8 +52,8 @@ importers:
       graphql: 16.6.0
       rimraf: 3.0.2
       rollup: 3.10.0
-      solid-js: 1.6.11
-      solid-mdx: 0.0.6_solid-js@1.6.11+vite@4.1.4
+      solid-js: 1.7.1
+      solid-mdx: 0.0.6_solid-js@1.7.1+vite@4.1.4
       solid-start: link:packages/start
       solid-start-cloudflare-workers: link:packages/start-cloudflare-workers
       solid-start-mdx: link:packages/mdx
@@ -485,7 +485,7 @@ importers:
       sade: ^1.8.1
       set-cookie-parser: ^2.5.1
       sirv: ^2.0.2
-      solid-js: ^1.6.11
+      solid-js: ^1.7.1
       solid-start-cloudflare-pages: workspace:*
       solid-start-cloudflare-workers: workspace:*
       solid-start-deno: workspace:*
@@ -518,7 +518,7 @@ importers:
       dotenv: 16.0.3
       es-module-lexer: 1.1.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_bve56rijdtklnf27lceyb3zzei
+      esbuild-plugin-solid: 0.4.2_s2nawzltp7qrxlew2yj2j5w7h4
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -532,19 +532,19 @@ importers:
       terser: 5.16.1
       undici: 5.15.1
       vite-plugin-inspect: 0.7.14_rollup@3.10.0+vite@4.1.4
-      vite-plugin-solid: 2.6.1_solid-js@1.6.11+vite@4.1.4
+      vite-plugin-solid: 2.6.1_solid-js@1.7.1+vite@4.1.4
       wait-on: 6.0.1_debug@4.3.4
     devDependencies:
       '@cloudflare/workers-types': 3.19.0
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.8.2_solid-js@1.6.11
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
       '@testing-library/jest-dom': 5.16.5
       '@types/babel__core': 7.20.0
       '@types/debug': 4.1.7
       '@types/node': 18.11.18
       '@types/wait-on': 5.3.1
       jsdom: 20.0.3
-      solid-js: 1.6.11
+      solid-js: 1.7.1
       solid-start-cloudflare-pages: link:../start-cloudflare-pages
       solid-start-cloudflare-workers: link:../start-cloudflare-workers
       solid-start-deno: link:../start-deno
@@ -552,7 +552,7 @@ importers:
       solid-start-node: link:../start-node
       solid-start-static: link:../start-static
       solid-start-vercel: link:../start-vercel
-      solid-testing-library: 0.3.0_solid-js@1.6.11
+      solid-testing-library: 0.3.0_solid-js@1.7.1
       typescript: 4.9.4
       vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
       vitest: 0.20.3_jsdom@20.0.3+terser@5.16.1
@@ -833,7 +833,7 @@ importers:
       '@cloudflare/kv-asset-handler': ^0.1.3
       '@solidjs/meta': ^0.28.2
       '@solidjs/router': ^0.8.2
-      solid-js: ^1.6.11
+      solid-js: ^1.7.1
       solid-start: workspace:*
       solid-start-cloudflare-pages: workspace:*
       solid-start-cloudflare-workers: workspace:*
@@ -847,9 +847,9 @@ importers:
       wrangler: ^2.8.0
     devDependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.8.2_solid-js@1.6.11
-      solid-js: 1.6.11
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       solid-start-cloudflare-pages: link:../../packages/start-cloudflare-pages
       solid-start-cloudflare-workers: link:../../packages/start-cloudflare-workers
@@ -2837,29 +2837,12 @@ packages:
   /@sinclair/typebox/0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
 
-  /@solidjs/meta/0.28.2_solid-js@1.6.11:
-    resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
-    peerDependencies:
-      solid-js: '>=1.4.0'
-    dependencies:
-      solid-js: 1.6.11
-    dev: true
-
   /@solidjs/meta/0.28.2_solid-js@1.7.1:
     resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.7.1
-    dev: false
-
-  /@solidjs/router/0.8.2_solid-js@1.6.11:
-    resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
-    peerDependencies:
-      solid-js: ^1.5.3
-    dependencies:
-      solid-js: 1.6.11
-    dev: true
 
   /@solidjs/router/0.8.2_solid-js@1.7.1:
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
@@ -2867,7 +2850,6 @@ packages:
       solid-js: ^1.5.3
     dependencies:
       solid-js: 1.7.1
-    dev: false
 
   /@solidjs/testing-library/0.5.2_solid-js@1.7.1:
     resolution: {integrity: sha512-GXUiI0Itz/7FfTJrV0RoICS2lL0RE3D1lNSrnuNg9nLC28qKnEQhm9Gfk4gFP9rGVzmsJJJC7yf8kbHMuyR2AA==}
@@ -4050,8 +4032,8 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /csstype/3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+  /csstype/3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
   /dashdash/1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
@@ -4746,7 +4728,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_bve56rijdtklnf27lceyb3zzei:
+  /esbuild-plugin-solid/0.4.2_s2nawzltp7qrxlew2yj2j5w7h4:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -4756,7 +4738,7 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       babel-preset-solid: 1.6.9_@babel+core@7.20.12
       esbuild: 0.14.54
-      solid-js: 1.6.11
+      solid-js: 1.7.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8007,15 +7989,10 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: false
 
-  /solid-js/1.6.11:
-    resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
-    dependencies:
-      csstype: 3.1.1
-
   /solid-js/1.7.1:
     resolution: {integrity: sha512-G7wPaRsxY+Mr6GTVSHIqrpHoJNM5YHX6V/X03mPo9RmsuVZU6ZA2O+jVJty6mOyGME24WR30E55L0IQsxxO/vg==}
     dependencies:
-      csstype: 3.1.1
+      csstype: 3.1.2
       seroval: 0.5.1
 
   /solid-mdx/0.0.6:
@@ -8025,16 +8002,6 @@ packages:
       vite: '*'
     dev: false
 
-  /solid-mdx/0.0.6_solid-js@1.6.11+vite@4.1.4:
-    resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
-    peerDependencies:
-      solid-js: ^1.2.6
-      vite: '*'
-    dependencies:
-      solid-js: 1.6.11
-      vite: 4.1.4
-    dev: true
-
   /solid-mdx/0.0.6_solid-js@1.7.1+vite@4.1.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
     peerDependencies:
@@ -8043,9 +8010,8 @@ packages:
     dependencies:
       solid-js: 1.7.1
       vite: 4.1.4
-    dev: false
 
-  /solid-refresh/0.5.0_solid-js@1.6.11:
+  /solid-refresh/0.5.0_solid-js@1.7.1:
     resolution: {integrity: sha512-kBsHSjqBUMXD2I7cU/batNE5WlXGiB5Otob9JDx4Zl5+Vt+a5naGxjPf81fg/c4lh++IdX2GF5CORxEcVzyTgg==}
     peerDependencies:
       solid-js: ^1.3
@@ -8053,7 +8019,7 @@ packages:
       '@babel/generator': 7.21.1
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.21.2
-      solid-js: 1.6.11
+      solid-js: 1.7.1
     dev: false
 
   /solid-ssr/1.6.3:
@@ -8085,14 +8051,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /solid-testing-library/0.3.0_solid-js@1.6.11:
+  /solid-testing-library/0.3.0_solid-js@1.7.1:
     resolution: {integrity: sha512-6NWVbySNVzyReBm2N6p3eF8bzxRZXHZTAmPix4vFWYol16QWVjNQsEUxvr+ZOutb0yuMZmNuGx3b6WIJYmjwMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 7.31.2
-      solid-js: 1.6.11
+      solid-js: 1.7.1
     dev: true
 
   /source-map-js/1.0.2:
@@ -8910,7 +8876,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid/2.6.1_solid-js@1.6.11+vite@4.1.4:
+  /vite-plugin-solid/2.6.1_solid-js@1.7.1+vite@4.1.4:
     resolution: {integrity: sha512-/khM/ha3B5/pTWQWVJd/0n6ODPIrOcajwhbrD8Gnv37XmJJssu+KA8ssN73raMIicf2eiQKiTAV39w7dSl4Irg==}
     peerDependencies:
       solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
@@ -8921,8 +8887,8 @@ packages:
       '@types/babel__core': 7.20.0
       babel-preset-solid: 1.6.9_@babel+core@7.20.12
       merge-anything: 5.1.4
-      solid-js: 1.6.11
-      solid-refresh: 0.5.0_solid-js@1.6.11
+      solid-js: 1.7.1
+      solid-refresh: 0.5.0_solid-js@1.7.1
       vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
       vitefu: 0.2.4_vite@4.1.4
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -205,7 +205,7 @@ importers:
       vite: ^4.1.4
     dependencies:
       '@auth/core': 0.3.0
-      '@auth/solid-start': 0.1.0_@auth+core@0.3.0+solid-js@1.7.1
+      '@auth/solid-start': 0.1.0_foanlclj2e3cks6pty3g6y56yy
       '@solidjs/meta': 0.28.2_solid-js@1.7.1
       '@solidjs/router': 0.8.2_solid-js@1.7.1
       solid-js: 1.7.1
@@ -240,7 +240,7 @@ importers:
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
-      '@mdx-js/rollup': 2.2.1_rollup@3.10.0
+      '@mdx-js/rollup': 2.2.1
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
       vite: 4.1.4
@@ -293,7 +293,7 @@ importers:
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
       vite: 4.1.4
-      vite-plugin-solid-styled: 0.8.1_4ef3c9639e64a00a8e8ac110fe163fcd
+      vite-plugin-solid-styled: 0.8.1_3gvt4d22c7ovlwms4q7fjcjghy
 
   examples/with-tailwindcss:
     specifiers:
@@ -318,7 +318,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       solid-start-node: link:../../packages/start-node
-      tailwindcss: 3.2.4
+      tailwindcss: 3.2.4_postcss@8.4.21
       typescript: 4.9.4
       vite: 4.1.4
 
@@ -333,28 +333,29 @@ importers:
       '@vitest/ui': ^0.26.3
       jsdom: ^20.0.3
       solid-js: ^1.7.1
-      solid-start: ^0.2.19
+      solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^4.1.4
       vitest: ^0.26.3
-    devDependencies:
+    dependencies:
       '@solidjs/meta': 0.28.2_solid-js@1.7.1
       '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
+      solid-start: link:../../packages/start
+      undici: 5.15.1
+    devDependencies:
       '@solidjs/testing-library': 0.5.2_solid-js@1.7.1
       '@testing-library/jest-dom': 5.16.5
       '@types/testing-library__jest-dom': 5.14.5
-      '@vitest/coverage-c8': 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
+      '@vitest/coverage-c8': 0.26.3_lae363bjhdipllr6jstkmuhhna
       '@vitest/ui': 0.26.3
       jsdom: 20.0.3
-      solid-js: 1.7.1
-      solid-start: link:../../packages/start
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
-      undici: 5.15.1
       vite: 4.1.4
-      vitest: 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
+      vitest: 0.26.3_lae363bjhdipllr6jstkmuhhna
 
   examples/with-websocket:
     specifiers:
@@ -429,7 +430,7 @@ importers:
       yaml: ^2.2.1
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@mdx-js/rollup': 2.2.1_rollup@3.10.0
+      '@mdx-js/rollup': 2.2.1
       '@types/mdast': 3.0.10
       acorn: 8.8.1
       estree-util-is-identifier-name: 2.1.0
@@ -442,7 +443,7 @@ importers:
       remark-frontmatter: 4.0.1
       remark-mdx-frontmatter: 2.1.1
       remark-shiki-twoslash: 3.1.0
-      solid-mdx: 0.0.6_solid-js@1.6.11+vite@4.1.4
+      solid-mdx: 0.0.6
       unified: 10.1.2
       unist-util-visit: 4.1.1
       yaml: 2.2.1
@@ -517,7 +518,7 @@ importers:
       dotenv: 16.0.3
       es-module-lexer: 1.1.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_esbuild@0.14.54+solid-js@1.6.11
+      esbuild-plugin-solid: 0.4.2_bve56rijdtklnf27lceyb3zzei
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -553,7 +554,7 @@ importers:
       solid-start-vercel: link:../start-vercel
       solid-testing-library: 0.3.0_solid-js@1.6.11
       typescript: 4.9.4
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
       vitest: 0.20.3_jsdom@20.0.3+terser@5.16.1
 
   packages/start-aws:
@@ -612,7 +613,7 @@ importers:
     devDependencies:
       '@types/node': 18.11.18
       solid-start: link:../start
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
 
   packages/start-cloudflare-workers:
     specifiers:
@@ -651,7 +652,7 @@ importers:
     devDependencies:
       '@types/node': 18.11.18
       solid-start: link:../start
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
 
   packages/start-deno:
     specifiers:
@@ -688,7 +689,7 @@ importers:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@rollup/plugin-babel': 6.0.3_8da6c1384b00da6e713e06f0bbef55dc
+      '@rollup/plugin-babel': 6.0.3_rwtmcocladng44j6a3ylx32v3q
       '@rollup/plugin-commonjs': 24.0.0_rollup@3.10.0
       '@rollup/plugin-json': 6.0.0_rollup@3.10.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@3.10.0
@@ -823,7 +824,7 @@ importers:
       undici: 5.16.0
       vite: 4.1.4_@types+node@18.11.18
       vitest: 0.28.3
-      wait-on: 7.0.1_debug@4.3.4
+      wait-on: 7.0.1
     devDependencies:
       cross-env: 7.0.3
 
@@ -893,7 +894,7 @@ packages:
       preact-render-to-string: 5.2.3_preact@10.11.3
     dev: false
 
-  /@auth/solid-start/0.1.0_@auth+core@0.3.0+solid-js@1.7.1:
+  /@auth/solid-start/0.1.0_foanlclj2e3cks6pty3g6y56yy:
     resolution: {integrity: sha512-nQHDWrP3c7uML0p+vKtGwun+CJh6TyloB8rOcwcZRtKRTRVK879ZCvxKa9pRExyZzQ8KCc+2K3+doQzxawblUg==}
     peerDependencies:
       '@auth/core': ~0.2.2 || ^0.2.2
@@ -903,6 +904,7 @@ packages:
       '@auth/core': 0.3.0
       set-cookie-parser: 2.5.1
       solid-js: 1.7.1
+      solid-start: link:packages/start
     dev: false
 
   /@babel/code-frame/7.18.6:
@@ -2485,14 +2487,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@mdx-js/rollup/2.2.1_rollup@3.10.0:
+  /@mdx-js/rollup/2.2.1:
     resolution: {integrity: sha512-wpGeK9iO7gPEIyC/ZTiggLY/MkEWDj5IWSsjlpkefgjb5RbmUukXU6/D2rHA+VAopxigS3NlaIL2ctpYBi4fmg==}
     peerDependencies:
       rollup: '>=2'
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
-      rollup: 3.10.0
+      '@rollup/pluginutils': 5.0.2
       source-map: 0.7.4
       vfile: 5.3.6
     transitivePeerDependencies:
@@ -2711,7 +2712,7 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@rollup/plugin-babel/6.0.3_8da6c1384b00da6e713e06f0bbef55dc:
+  /@rollup/plugin-babel/6.0.3_rwtmcocladng44j6a3ylx32v3q:
     resolution: {integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2792,6 +2793,19 @@ packages:
       picomatch: 2.3.1
     dev: false
 
+  /@rollup/pluginutils/5.0.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+
   /@rollup/pluginutils/5.0.2_rollup@3.10.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
@@ -2837,6 +2851,7 @@ packages:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.7.1
+    dev: false
 
   /@solidjs/router/0.8.2_solid-js@1.6.11:
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
@@ -2852,6 +2867,7 @@ packages:
       solid-js: ^1.5.3
     dependencies:
       solid-js: 1.7.1
+    dev: false
 
   /@solidjs/testing-library/0.5.2_solid-js@1.7.1:
     resolution: {integrity: sha512-GXUiI0Itz/7FfTJrV0RoICS2lL0RE3D1lNSrnuNg9nLC28qKnEQhm9Gfk4gFP9rGVzmsJJJC7yf8kbHMuyR2AA==}
@@ -2940,7 +2956,6 @@ packages:
   /@trysound/sax/0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
-    dev: false
 
   /@types/acorn/4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -3005,7 +3020,6 @@ packages:
 
   /@types/css-tree/2.0.1:
     resolution: {integrity: sha512-eeRN9rsZK/ZD5nmJCeZXxyTwq+gsvN1EljeCPEyXk+vLOAwsgpsrdXio4lPBzxAuhIKu3MK7QvZxWUw9xDX8Bg==}
-    dev: false
 
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -3170,11 +3184,11 @@ packages:
       - supports-color
     dev: false
 
-  /@vitest/coverage-c8/0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3:
+  /@vitest/coverage-c8/0.26.3_lae363bjhdipllr6jstkmuhhna:
     resolution: {integrity: sha512-sjmVYPozajWY2DawzuvhYX6hEe/LD6p2xv9VmPvh1zzDeNNVCAnyLcvXoaSMQD522x9bqciuyPrlrnh2iNkE/w==}
     dependencies:
       c8: 7.12.0
-      vitest: 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
+      vitest: 0.26.3_lae363bjhdipllr6jstkmuhhna
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -3436,10 +3450,10 @@ packages:
       - debug
     dev: false
 
-  /axios/0.27.2_debug@4.3.4:
+  /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -3531,7 +3545,6 @@ packages:
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-    dev: false
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3625,7 +3638,6 @@ packages:
       caniuse-lite: 1.0.30001446
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-    dev: false
 
   /caniuse-lite/1.0.30001446:
     resolution: {integrity: sha512-fEoga4PrImGcwUUGEol/PoFCSBnSkA9drgdkxXkJLsUBOnJ8rs3zDv6ApqYXGQFOyMPsjh79naWhF4DAxbF8rw==}
@@ -3782,7 +3794,6 @@ packages:
 
   /colord/2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
-    dev: false
 
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3799,7 +3810,6 @@ packages:
   /commander/7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-    dev: false
 
   /commondir/1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -3822,6 +3832,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -3835,6 +3847,8 @@ packages:
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /console-clear/1.1.1:
@@ -3909,7 +3923,6 @@ packages:
       postcss: ^8.0.9
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /css-select/4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -3919,7 +3932,6 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       nth-check: 2.1.1
-    dev: false
 
   /css-select/5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -3937,7 +3949,6 @@ packages:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
-    dev: false
 
   /css-tree/2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
@@ -3945,12 +3956,10 @@ packages:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.0.2
-    dev: false
 
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
-    dev: false
 
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -3996,7 +4005,6 @@ packages:
       postcss-reduce-transforms: 5.1.0_postcss@8.4.21
       postcss-svgo: 5.1.0_postcss@8.4.21
       postcss-unique-selectors: 5.1.1_postcss@8.4.21
-    dev: false
 
   /cssnano-utils/3.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
@@ -4005,7 +4013,6 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /cssnano/5.1.15_postcss@8.4.21:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
@@ -4017,14 +4024,12 @@ packages:
       lilconfig: 2.0.6
       postcss: 8.4.21
       yaml: 1.10.2
-    dev: false
 
   /csso/4.2.0:
     resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
     engines: {node: '>=8.0.0'}
     dependencies:
       css-tree: 1.1.3
-    dev: false
 
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -4071,6 +4076,11 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -4204,7 +4214,6 @@ packages:
       domelementtype: 2.3.0
       domhandler: 4.3.1
       entities: 2.2.0
-    dev: false
 
   /dom-serializer/2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -4216,7 +4225,6 @@ packages:
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: false
 
   /domexception/4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -4230,7 +4238,6 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-    dev: false
 
   /domhandler/5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -4245,7 +4252,6 @@ packages:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
-    dev: false
 
   /domutils/3.0.1:
     resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
@@ -4302,7 +4308,6 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: false
 
   /entities/4.4.0:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
@@ -4741,7 +4746,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_esbuild@0.14.54+solid-js@1.6.11:
+  /esbuild-plugin-solid/0.4.2_bve56rijdtklnf27lceyb3zzei:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -5181,6 +5186,8 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-up/5.0.0:
@@ -5194,6 +5201,16 @@ packages:
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
+
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /follow-redirects/1.15.2_debug@4.3.4:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -5954,7 +5971,6 @@ packages:
   /js-xxhash/2.0.0:
     resolution: {integrity: sha512-R7Gad0Y0grmuF/WRBUmxgQA1bGpbmRWM/OwNJZQPVdJBAteJIdBYOBYcHbuJeJwxdddqBVIdP3EfrDNFqahJ2A==}
     engines: {node: '>=14.0.0'}
-    dev: false
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -6117,7 +6133,6 @@ packages:
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-    dev: false
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6125,7 +6140,6 @@ packages:
 
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
-    dev: false
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -6297,11 +6311,9 @@ packages:
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-    dev: false
 
   /mdn-data/2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
-    dev: false
 
   /merge-anything/5.1.4:
     resolution: {integrity: sha512-7PWKwGOs5WWcpw+/OvbiFiAvEP6bv/QHiicigpqMGKIqPPAtGhBLR8LFJW+Zu6m9TXiR/a8+AiPlGG0ko1ruoQ==}
@@ -6788,7 +6800,6 @@ packages:
   /normalize-url/6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
-    dev: false
 
   /npm-run-path/5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -6817,7 +6828,6 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
-    dev: false
 
   /nwsapi/2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
@@ -7081,7 +7091,6 @@ packages:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-colormin/5.3.1_postcss@8.4.21:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
@@ -7094,7 +7103,6 @@ packages:
       colord: 2.9.3
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-convert-values/5.1.3_postcss@8.4.21:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
@@ -7105,7 +7113,6 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-discard-comments/5.1.2_postcss@8.4.21:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
@@ -7114,7 +7121,6 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /postcss-discard-duplicates/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
@@ -7123,7 +7129,6 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /postcss-discard-empty/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
@@ -7132,7 +7137,6 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /postcss-discard-overridden/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
@@ -7141,7 +7145,17 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
+
+  /postcss-import/14.1.0:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
 
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
@@ -7155,6 +7169,15 @@ packages:
       resolve: 1.22.1
     dev: true
 
+  /postcss-js/4.0.0:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+    dev: true
+
   /postcss-js/4.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -7163,6 +7186,22 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
+    dev: true
+
+  /postcss-load-config/3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      yaml: 1.10.2
     dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.21:
@@ -7191,7 +7230,6 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1_postcss@8.4.21
-    dev: false
 
   /postcss-merge-rules/5.1.4_postcss@8.4.21:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
@@ -7204,7 +7242,6 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
-    dev: false
 
   /postcss-minify-font-values/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
@@ -7214,7 +7251,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-minify-gradients/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
@@ -7226,7 +7262,6 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-minify-params/5.1.4_postcss@8.4.21:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
@@ -7238,7 +7273,6 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-minify-selectors/5.2.1_postcss@8.4.21:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
@@ -7248,7 +7282,15 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
-    dev: false
+
+  /postcss-nested/6.0.0:
+    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.11
+    dev: true
 
   /postcss-nested/6.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
@@ -7266,7 +7308,6 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /postcss-normalize-display-values/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
@@ -7276,7 +7317,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-positions/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
@@ -7286,7 +7326,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-repeat-style/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
@@ -7296,7 +7335,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-string/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
@@ -7306,7 +7344,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-timing-functions/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
@@ -7316,7 +7353,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-unicode/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
@@ -7327,7 +7363,6 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-url/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
@@ -7338,7 +7373,6 @@ packages:
       normalize-url: 6.1.0
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-normalize-whitespace/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
@@ -7348,7 +7382,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-ordered-values/5.1.3_postcss@8.4.21:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
@@ -7359,7 +7392,6 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-reduce-initial/5.1.2_postcss@8.4.21:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
@@ -7370,7 +7402,6 @@ packages:
       browserslist: 4.21.4
       caniuse-api: 3.0.0
       postcss: 8.4.21
-    dev: false
 
   /postcss-reduce-transforms/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
@@ -7380,7 +7411,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-safe-parser/6.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
@@ -7389,7 +7419,6 @@ packages:
       postcss: ^8.3.3
     dependencies:
       postcss: 8.4.21
-    dev: false
 
   /postcss-selector-parser/6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -7415,7 +7444,6 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
-    dev: false
 
   /postcss-unique-selectors/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
@@ -7425,7 +7453,6 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
-    dev: false
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -7984,13 +8011,19 @@ packages:
     resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
     dependencies:
       csstype: 3.1.1
-    dev: true
 
   /solid-js/1.7.1:
     resolution: {integrity: sha512-G7wPaRsxY+Mr6GTVSHIqrpHoJNM5YHX6V/X03mPo9RmsuVZU6ZA2O+jVJty6mOyGME24WR30E55L0IQsxxO/vg==}
     dependencies:
       csstype: 3.1.1
       seroval: 0.5.1
+
+  /solid-mdx/0.0.6:
+    resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
+    peerDependencies:
+      solid-js: ^1.2.6
+      vite: '*'
+    dev: false
 
   /solid-mdx/0.0.6_solid-js@1.6.11+vite@4.1.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
@@ -8000,6 +8033,7 @@ packages:
     dependencies:
       solid-js: 1.6.11
       vite: 4.1.4
+    dev: true
 
   /solid-mdx/0.0.6_solid-js@1.7.1+vite@4.1.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
@@ -8050,7 +8084,6 @@ packages:
       solid-js: 1.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /solid-testing-library/0.3.0_solid-js@1.6.11:
     resolution: {integrity: sha512-6NWVbySNVzyReBm2N6p3eF8bzxRZXHZTAmPix4vFWYol16QWVjNQsEUxvr+ZOutb0yuMZmNuGx3b6WIJYmjwMQ==}
@@ -8111,7 +8144,6 @@ packages:
   /stable/0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
-    dev: false
 
   /stack-trace/0.0.10:
     resolution: {integrity: sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=}
@@ -8223,7 +8255,6 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
-    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -8253,7 +8284,6 @@ packages:
       csso: 4.2.0
       picocolors: 1.0.0
       stable: 0.1.8
-    dev: false
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8263,6 +8293,42 @@ packages:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.21
+      postcss-import: 14.1.0
+      postcss-js: 4.0.0
+      postcss-load-config: 3.1.4
+      postcss-nested: 6.0.0
+      postcss-selector-parser: 6.0.11
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
+  /tailwindcss/3.2.4_postcss@8.4.21:
+    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -8821,13 +8887,13 @@ packages:
       kolorist: 1.6.0
       sirv: 2.0.2
       ufo: 1.0.1
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: false
 
-  /vite-plugin-solid-styled/0.8.1_4ef3c9639e64a00a8e8ac110fe163fcd:
+  /vite-plugin-solid-styled/0.8.1_3gvt4d22c7ovlwms4q7fjcjghy:
     resolution: {integrity: sha512-KxBSNfRLeB/Dr+yDh07vw2wteIHpJ6t2Q/6mRkNGVHj6dNaidifnqgvukztbzdDQcxGeyl6oVGYG8NtZ7fV35w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -8836,7 +8902,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2
       solid-styled: 0.8.1_solid-js@1.7.1
       vite: 4.1.4
     transitivePeerDependencies:
@@ -8857,13 +8923,13 @@ packages:
       merge-anything: 5.1.4
       solid-js: 1.6.11
       solid-refresh: 0.5.0_solid-js@1.6.11
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
       vitefu: 0.2.4_vite@4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /vite/3.2.5_8173dee407829fef55badcae005b7829:
+  /vite/3.2.5_qfz55zahqkp66vn23sxaaw3yfe:
     resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8929,42 +8995,6 @@ packages:
       rollup: 3.10.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /vite/4.1.4_8173dee407829fef55badcae005b7829:
-    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.11.18
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.10.0
-      terser: 5.16.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
   /vite/4.1.4_@types+node@18.11.18:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
@@ -8996,6 +9026,40 @@ packages:
       postcss: 8.4.21
       resolve: 1.22.1
       rollup: 3.10.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite/4.1.4_qfz55zahqkp66vn23sxaaw3yfe:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.11.18
+      esbuild: 0.16.17
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.10.0
+      terser: 5.16.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9041,7 +9105,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.4_8173dee407829fef55badcae005b7829
+      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
     dev: false
 
   /vitest/0.20.3_jsdom@20.0.3+terser@5.16.1:
@@ -9078,7 +9142,7 @@ packages:
       local-pkg: 0.4.3
       tinypool: 0.2.4
       tinyspy: 1.0.2
-      vite: 3.2.5_8173dee407829fef55badcae005b7829
+      vite: 3.2.5_qfz55zahqkp66vn23sxaaw3yfe
     transitivePeerDependencies:
       - less
       - sass
@@ -9088,7 +9152,7 @@ packages:
       - terser
     dev: true
 
-  /vitest/0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3:
+  /vitest/0.26.3_lae363bjhdipllr6jstkmuhhna:
     resolution: {integrity: sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -9220,12 +9284,12 @@ packages:
       - debug
     dev: false
 
-  /wait-on/7.0.1_debug@4.3.4:
+  /wait-on/7.0.1:
     resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      axios: 0.27.2_debug@4.3.4
+      axios: 0.27.2
       joi: 17.7.0
       lodash: 4.17.21
       minimist: 1.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -74,16 +74,16 @@ importers:
       '@types/node': ^18.11.18
       esbuild: ^0.14.54
       postcss: ^8.4.21
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -102,16 +102,16 @@ importers:
       '@types/debug': ^4.1.7
       '@types/node': ^18.11.18
       esbuild: ^0.14.54
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -132,16 +132,16 @@ importers:
       esbuild: ^0.14.54
       postcss: ^8.4.21
       rollup: ^3.10.0
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -164,16 +164,16 @@ importers:
       esbuild: ^0.14.54
       postcss: ^8.4.21
       rollup: ^3.10.0
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -197,7 +197,7 @@ importers:
       esbuild: ^0.14.54
       next-auth: ^4.19.2
       postcss: ^8.4.21
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
@@ -205,10 +205,10 @@ importers:
       vite: ^4.1.4
     dependencies:
       '@auth/core': 0.3.0
-      '@auth/solid-start': 0.1.0_f47bk726z6cccd3ldt6kelrcxy
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@auth/solid-start': 0.1.0_@auth+core@0.3.0+solid-js@1.7.1
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.16.0
     devDependencies:
@@ -225,7 +225,7 @@ importers:
       '@mdx-js/rollup': ^2.2.1
       '@solidjs/meta': ^0.28.2
       '@solidjs/router': ^0.8.2
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-mdx: ^0.0.6
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
@@ -233,14 +233,14 @@ importers:
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
-      solid-mdx: 0.0.6_solid-js@1.6.16+vite@4.1.4
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
+      solid-mdx: 0.0.6_solid-js@1.7.1+vite@4.1.4
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
-      '@mdx-js/rollup': 2.2.1
+      '@mdx-js/rollup': 2.2.1_rollup@3.10.0
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
       vite: 4.1.4
@@ -251,7 +251,7 @@ importers:
       '@solidjs/meta': ^0.28.2
       '@solidjs/router': ^0.8.2
       prisma: ^4.9.0
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
@@ -259,10 +259,10 @@ importers:
       vite: ^4.1.4
     dependencies:
       '@prisma/client': 4.9.0_prisma@4.9.0
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
       prisma: 4.9.0
-      solid-js: 1.6.16
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -274,7 +274,7 @@ importers:
     specifiers:
       '@solidjs/meta': ^0.28.2
       '@solidjs/router': ^0.8.2
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       solid-styled: ^0.8.1
@@ -283,17 +283,17 @@ importers:
       vite: ^4.1.4
       vite-plugin-solid-styled: ^0.8.1
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
-      solid-styled: 0.8.1_solid-js@1.6.16
+      solid-styled: 0.8.1_solid-js@1.7.1
       undici: 5.15.1
     devDependencies:
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
       vite: 4.1.4
-      vite-plugin-solid-styled: 0.8.1_3gvt4d22c7ovlwms4q7fjcjghy
+      vite-plugin-solid-styled: 0.8.1_4ef3c9639e64a00a8e8ac110fe163fcd
 
   examples/with-tailwindcss:
     specifiers:
@@ -301,7 +301,7 @@ importers:
       '@solidjs/router': ^0.8.2
       autoprefixer: ^10.4.13
       postcss: ^8.4.21
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-node: ^0.2.19
       tailwindcss: ^3.2.4
@@ -309,16 +309,16 @@ importers:
       undici: ^5.15.1
       vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       solid-start-node: link:../../packages/start-node
-      tailwindcss: 3.2.4_postcss@8.4.21
+      tailwindcss: 3.2.4
       typescript: 4.9.4
       vite: 4.1.4
 
@@ -332,7 +332,7 @@ importers:
       '@vitest/coverage-c8': ^0.26.3
       '@vitest/ui': ^0.26.3
       jsdom: ^20.0.3
-      solid-js: ^1.6.11
+      solid-js: ^1.7.1
       solid-start: ^0.2.19
       solid-start-node: ^0.2.19
       typescript: ^4.9.4
@@ -340,21 +340,21 @@ importers:
       vite: ^4.1.4
       vitest: ^0.26.3
     devDependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.8.2_solid-js@1.6.11
-      '@solidjs/testing-library': 0.5.2_solid-js@1.6.11
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      '@solidjs/testing-library': 0.5.2_solid-js@1.7.1
       '@testing-library/jest-dom': 5.16.5
       '@types/testing-library__jest-dom': 5.14.5
-      '@vitest/coverage-c8': 0.26.3_lae363bjhdipllr6jstkmuhhna
+      '@vitest/coverage-c8': 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
       '@vitest/ui': 0.26.3
       jsdom: 20.0.3
-      solid-js: 1.6.11
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       solid-start-node: link:../../packages/start-node
       typescript: 4.9.4
       undici: 5.15.1
       vite: 4.1.4
-      vitest: 0.26.3_lae363bjhdipllr6jstkmuhhna
+      vitest: 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
 
   examples/with-websocket:
     specifiers:
@@ -362,7 +362,7 @@ importers:
       '@cloudflare/workers-types': ^3.19.0
       '@solidjs/meta': ^0.28.2
       '@solidjs/router': ^0.8.2
-      solid-js: ^1.6.16
+      solid-js: ^1.7.1
       solid-start: ^0.2.24
       solid-start-cloudflare-workers: ^0.2.15
       typescript: ^4.9.4
@@ -371,9 +371,9 @@ importers:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
       '@cloudflare/workers-types': 3.19.0
-      '@solidjs/meta': 0.28.2_solid-js@1.6.16
-      '@solidjs/router': 0.8.2_solid-js@1.6.16
-      solid-js: 1.6.16
+      '@solidjs/meta': 0.28.2_solid-js@1.7.1
+      '@solidjs/router': 0.8.2_solid-js@1.7.1
+      solid-js: 1.7.1
       solid-start: link:../../packages/start
       undici: 5.15.1
     devDependencies:
@@ -429,7 +429,7 @@ importers:
       yaml: ^2.2.1
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@mdx-js/rollup': 2.2.1
+      '@mdx-js/rollup': 2.2.1_rollup@3.10.0
       '@types/mdast': 3.0.10
       acorn: 8.8.1
       estree-util-is-identifier-name: 2.1.0
@@ -442,7 +442,7 @@ importers:
       remark-frontmatter: 4.0.1
       remark-mdx-frontmatter: 2.1.1
       remark-shiki-twoslash: 3.1.0
-      solid-mdx: 0.0.6
+      solid-mdx: 0.0.6_solid-js@1.6.11+vite@4.1.4
       unified: 10.1.2
       unist-util-visit: 4.1.1
       yaml: 2.2.1
@@ -517,7 +517,7 @@ importers:
       dotenv: 16.0.3
       es-module-lexer: 1.1.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_bve56rijdtklnf27lceyb3zzei
+      esbuild-plugin-solid: 0.4.2_esbuild@0.14.54+solid-js@1.6.11
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -553,7 +553,7 @@ importers:
       solid-start-vercel: link:../start-vercel
       solid-testing-library: 0.3.0_solid-js@1.6.11
       typescript: 4.9.4
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
       vitest: 0.20.3_jsdom@20.0.3+terser@5.16.1
 
   packages/start-aws:
@@ -612,7 +612,7 @@ importers:
     devDependencies:
       '@types/node': 18.11.18
       solid-start: link:../start
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
 
   packages/start-cloudflare-workers:
     specifiers:
@@ -651,7 +651,7 @@ importers:
     devDependencies:
       '@types/node': 18.11.18
       solid-start: link:../start
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
 
   packages/start-deno:
     specifiers:
@@ -688,7 +688,7 @@ importers:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@rollup/plugin-babel': 6.0.3_rwtmcocladng44j6a3ylx32v3q
+      '@rollup/plugin-babel': 6.0.3_8da6c1384b00da6e713e06f0bbef55dc
       '@rollup/plugin-commonjs': 24.0.0_rollup@3.10.0
       '@rollup/plugin-json': 6.0.0_rollup@3.10.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@3.10.0
@@ -823,7 +823,7 @@ importers:
       undici: 5.16.0
       vite: 4.1.4_@types+node@18.11.18
       vitest: 0.28.3
-      wait-on: 7.0.1
+      wait-on: 7.0.1_debug@4.3.4
     devDependencies:
       cross-env: 7.0.3
 
@@ -893,7 +893,7 @@ packages:
       preact-render-to-string: 5.2.3_preact@10.11.3
     dev: false
 
-  /@auth/solid-start/0.1.0_f47bk726z6cccd3ldt6kelrcxy:
+  /@auth/solid-start/0.1.0_@auth+core@0.3.0+solid-js@1.7.1:
     resolution: {integrity: sha512-nQHDWrP3c7uML0p+vKtGwun+CJh6TyloB8rOcwcZRtKRTRVK879ZCvxKa9pRExyZzQ8KCc+2K3+doQzxawblUg==}
     peerDependencies:
       '@auth/core': ~0.2.2 || ^0.2.2
@@ -902,8 +902,7 @@ packages:
     dependencies:
       '@auth/core': 0.3.0
       set-cookie-parser: 2.5.1
-      solid-js: 1.6.16
-      solid-start: link:packages/start
+      solid-js: 1.7.1
     dev: false
 
   /@babel/code-frame/7.18.6:
@@ -2486,13 +2485,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@mdx-js/rollup/2.2.1:
+  /@mdx-js/rollup/2.2.1_rollup@3.10.0:
     resolution: {integrity: sha512-wpGeK9iO7gPEIyC/ZTiggLY/MkEWDj5IWSsjlpkefgjb5RbmUukXU6/D2rHA+VAopxigS3NlaIL2ctpYBi4fmg==}
     peerDependencies:
       rollup: '>=2'
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      rollup: 3.10.0
       source-map: 0.7.4
       vfile: 5.3.6
     transitivePeerDependencies:
@@ -2711,7 +2711,7 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@rollup/plugin-babel/6.0.3_rwtmcocladng44j6a3ylx32v3q:
+  /@rollup/plugin-babel/6.0.3_8da6c1384b00da6e713e06f0bbef55dc:
     resolution: {integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2792,19 +2792,6 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@rollup/pluginutils/5.0.2:
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.0
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-
   /@rollup/pluginutils/5.0.2_rollup@3.10.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
@@ -2844,13 +2831,12 @@ packages:
       solid-js: 1.6.11
     dev: true
 
-  /@solidjs/meta/0.28.2_solid-js@1.6.16:
+  /@solidjs/meta/0.28.2_solid-js@1.7.1:
     resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.6.16
-    dev: false
+      solid-js: 1.7.1
 
   /@solidjs/router/0.8.2_solid-js@1.6.11:
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
@@ -2860,22 +2846,21 @@ packages:
       solid-js: 1.6.11
     dev: true
 
-  /@solidjs/router/0.8.2_solid-js@1.6.16:
+  /@solidjs/router/0.8.2_solid-js@1.7.1:
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.6.16
-    dev: false
+      solid-js: 1.7.1
 
-  /@solidjs/testing-library/0.5.2_solid-js@1.6.11:
+  /@solidjs/testing-library/0.5.2_solid-js@1.7.1:
     resolution: {integrity: sha512-GXUiI0Itz/7FfTJrV0RoICS2lL0RE3D1lNSrnuNg9nLC28qKnEQhm9Gfk4gFP9rGVzmsJJJC7yf8kbHMuyR2AA==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 8.20.0
-      solid-js: 1.6.11
+      solid-js: 1.7.1
     dev: true
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.4:
@@ -2955,6 +2940,7 @@ packages:
   /@trysound/sax/0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+    dev: false
 
   /@types/acorn/4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -3019,6 +3005,7 @@ packages:
 
   /@types/css-tree/2.0.1:
     resolution: {integrity: sha512-eeRN9rsZK/ZD5nmJCeZXxyTwq+gsvN1EljeCPEyXk+vLOAwsgpsrdXio4lPBzxAuhIKu3MK7QvZxWUw9xDX8Bg==}
+    dev: false
 
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -3183,11 +3170,11 @@ packages:
       - supports-color
     dev: false
 
-  /@vitest/coverage-c8/0.26.3_lae363bjhdipllr6jstkmuhhna:
+  /@vitest/coverage-c8/0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3:
     resolution: {integrity: sha512-sjmVYPozajWY2DawzuvhYX6hEe/LD6p2xv9VmPvh1zzDeNNVCAnyLcvXoaSMQD522x9bqciuyPrlrnh2iNkE/w==}
     dependencies:
       c8: 7.12.0
-      vitest: 0.26.3_lae363bjhdipllr6jstkmuhhna
+      vitest: 0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -3444,15 +3431,15 @@ packages:
   /axios/0.25.0_debug@4.3.4:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /axios/0.27.2:
+  /axios/0.27.2_debug@4.3.4:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -3544,6 +3531,7 @@ packages:
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3637,6 +3625,7 @@ packages:
       caniuse-lite: 1.0.30001446
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
+    dev: false
 
   /caniuse-lite/1.0.30001446:
     resolution: {integrity: sha512-fEoga4PrImGcwUUGEol/PoFCSBnSkA9drgdkxXkJLsUBOnJ8rs3zDv6ApqYXGQFOyMPsjh79naWhF4DAxbF8rw==}
@@ -3793,6 +3782,7 @@ packages:
 
   /colord/2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+    dev: false
 
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3809,6 +3799,7 @@ packages:
   /commander/7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+    dev: false
 
   /commondir/1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -3831,8 +3822,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -3846,8 +3835,6 @@ packages:
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /console-clear/1.1.1:
@@ -3922,6 +3909,7 @@ packages:
       postcss: ^8.0.9
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /css-select/4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -3931,6 +3919,7 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       nth-check: 2.1.1
+    dev: false
 
   /css-select/5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -3948,6 +3937,7 @@ packages:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+    dev: false
 
   /css-tree/2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
@@ -3955,10 +3945,12 @@ packages:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.0.2
+    dev: false
 
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+    dev: false
 
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -4004,6 +3996,7 @@ packages:
       postcss-reduce-transforms: 5.1.0_postcss@8.4.21
       postcss-svgo: 5.1.0_postcss@8.4.21
       postcss-unique-selectors: 5.1.1_postcss@8.4.21
+    dev: false
 
   /cssnano-utils/3.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
@@ -4012,6 +4005,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /cssnano/5.1.15_postcss@8.4.21:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
@@ -4023,12 +4017,14 @@ packages:
       lilconfig: 2.0.6
       postcss: 8.4.21
       yaml: 1.10.2
+    dev: false
 
   /csso/4.2.0:
     resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
     engines: {node: '>=8.0.0'}
     dependencies:
       css-tree: 1.1.3
+    dev: false
 
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -4075,11 +4071,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -4213,6 +4204,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 4.3.1
       entities: 2.2.0
+    dev: false
 
   /dom-serializer/2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -4224,6 +4216,7 @@ packages:
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
 
   /domexception/4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -4237,6 +4230,7 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: false
 
   /domhandler/5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -4251,6 +4245,7 @@ packages:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+    dev: false
 
   /domutils/3.0.1:
     resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
@@ -4307,6 +4302,7 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: false
 
   /entities/4.4.0:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
@@ -4745,7 +4741,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_bve56rijdtklnf27lceyb3zzei:
+  /esbuild-plugin-solid/0.4.2_esbuild@0.14.54+solid-js@1.6.11:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -5185,8 +5181,6 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-up/5.0.0:
@@ -5201,7 +5195,7 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
-  /follow-redirects/1.15.2:
+  /follow-redirects/1.15.2_debug@4.3.4:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -5209,6 +5203,8 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dependencies:
+      debug: 4.3.4
     dev: false
 
   /for-each/0.3.3:
@@ -5958,6 +5954,7 @@ packages:
   /js-xxhash/2.0.0:
     resolution: {integrity: sha512-R7Gad0Y0grmuF/WRBUmxgQA1bGpbmRWM/OwNJZQPVdJBAteJIdBYOBYcHbuJeJwxdddqBVIdP3EfrDNFqahJ2A==}
     engines: {node: '>=14.0.0'}
+    dev: false
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -6120,6 +6117,7 @@ packages:
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: false
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6127,6 +6125,7 @@ packages:
 
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+    dev: false
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -6298,9 +6297,11 @@ packages:
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
 
   /mdn-data/2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: false
 
   /merge-anything/5.1.4:
     resolution: {integrity: sha512-7PWKwGOs5WWcpw+/OvbiFiAvEP6bv/QHiicigpqMGKIqPPAtGhBLR8LFJW+Zu6m9TXiR/a8+AiPlGG0ko1ruoQ==}
@@ -6787,6 +6788,7 @@ packages:
   /normalize-url/6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
+    dev: false
 
   /npm-run-path/5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -6815,6 +6817,7 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: false
 
   /nwsapi/2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
@@ -7078,6 +7081,7 @@ packages:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-colormin/5.3.1_postcss@8.4.21:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
@@ -7090,6 +7094,7 @@ packages:
       colord: 2.9.3
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-convert-values/5.1.3_postcss@8.4.21:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
@@ -7100,6 +7105,7 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-discard-comments/5.1.2_postcss@8.4.21:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
@@ -7108,6 +7114,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /postcss-discard-duplicates/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
@@ -7116,6 +7123,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /postcss-discard-empty/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
@@ -7124,6 +7132,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /postcss-discard-overridden/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
@@ -7132,17 +7141,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
-
-  /postcss-import/14.1.0:
-    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.1
-    dev: true
+    dev: false
 
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
@@ -7156,15 +7155,6 @@ packages:
       resolve: 1.22.1
     dev: true
 
-  /postcss-js/4.0.0:
-    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.3.3
-    dependencies:
-      camelcase-css: 2.0.1
-    dev: true
-
   /postcss-js/4.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -7173,22 +7163,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
-    dev: true
-
-  /postcss-load-config/3.1.4:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.0.6
-      yaml: 1.10.2
     dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.21:
@@ -7217,6 +7191,7 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1_postcss@8.4.21
+    dev: false
 
   /postcss-merge-rules/5.1.4_postcss@8.4.21:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
@@ -7229,6 +7204,7 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
+    dev: false
 
   /postcss-minify-font-values/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
@@ -7238,6 +7214,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-minify-gradients/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
@@ -7249,6 +7226,7 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-minify-params/5.1.4_postcss@8.4.21:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
@@ -7260,6 +7238,7 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-minify-selectors/5.2.1_postcss@8.4.21:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
@@ -7269,15 +7248,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
-
-  /postcss-nested/6.0.0:
-    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-    dependencies:
-      postcss-selector-parser: 6.0.11
-    dev: true
+    dev: false
 
   /postcss-nested/6.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
@@ -7295,6 +7266,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /postcss-normalize-display-values/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
@@ -7304,6 +7276,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-positions/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
@@ -7313,6 +7286,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-repeat-style/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
@@ -7322,6 +7296,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-string/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
@@ -7331,6 +7306,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-timing-functions/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
@@ -7340,6 +7316,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-unicode/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
@@ -7350,6 +7327,7 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-url/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
@@ -7360,6 +7338,7 @@ packages:
       normalize-url: 6.1.0
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-normalize-whitespace/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
@@ -7369,6 +7348,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-ordered-values/5.1.3_postcss@8.4.21:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
@@ -7379,6 +7359,7 @@ packages:
       cssnano-utils: 3.1.0_postcss@8.4.21
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-reduce-initial/5.1.2_postcss@8.4.21:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
@@ -7389,6 +7370,7 @@ packages:
       browserslist: 4.21.4
       caniuse-api: 3.0.0
       postcss: 8.4.21
+    dev: false
 
   /postcss-reduce-transforms/5.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
@@ -7398,6 +7380,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-safe-parser/6.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
@@ -7406,6 +7389,7 @@ packages:
       postcss: ^8.3.3
     dependencies:
       postcss: 8.4.21
+    dev: false
 
   /postcss-selector-parser/6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -7431,6 +7415,7 @@ packages:
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
+    dev: false
 
   /postcss-unique-selectors/5.1.1_postcss@8.4.21:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
@@ -7440,6 +7425,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
+    dev: false
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -7901,6 +7887,10 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /seroval/0.5.1:
+    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
+    engines: {node: '>=10'}
+
   /set-blocking/2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
@@ -7994,18 +7984,13 @@ packages:
     resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
     dependencies:
       csstype: 3.1.1
+    dev: true
 
-  /solid-js/1.6.16:
-    resolution: {integrity: sha512-Ng4CahvLlpGA3BXIMiiMdwhI8WpObZ8gXqm97GCKR4+MpnODs6Pdpco+tmVCY/4ZDFaEKDxz7WRLAAdoXdlY7w==}
+  /solid-js/1.7.1:
+    resolution: {integrity: sha512-G7wPaRsxY+Mr6GTVSHIqrpHoJNM5YHX6V/X03mPo9RmsuVZU6ZA2O+jVJty6mOyGME24WR30E55L0IQsxxO/vg==}
     dependencies:
       csstype: 3.1.1
-
-  /solid-mdx/0.0.6:
-    resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
-    peerDependencies:
-      solid-js: ^1.2.6
-      vite: '*'
-    dev: false
+      seroval: 0.5.1
 
   /solid-mdx/0.0.6_solid-js@1.6.11+vite@4.1.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
@@ -8015,15 +8000,14 @@ packages:
     dependencies:
       solid-js: 1.6.11
       vite: 4.1.4
-    dev: true
 
-  /solid-mdx/0.0.6_solid-js@1.6.16+vite@4.1.4:
+  /solid-mdx/0.0.6_solid-js@1.7.1+vite@4.1.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
     peerDependencies:
       solid-js: ^1.2.6
       vite: '*'
     dependencies:
-      solid-js: 1.6.16
+      solid-js: 1.7.1
       vite: 4.1.4
     dev: false
 
@@ -8042,7 +8026,7 @@ packages:
     resolution: {integrity: sha512-ieG1NemdbGOOfKrCZdUNktfQJlrYSg4Nr2PG2CSoO/KCHs2PBIe3PsjLenvbiTop0qAQgHkSf2pNgcz5VoJzaw==}
     dev: false
 
-  /solid-styled/0.8.1_solid-js@1.6.16:
+  /solid-styled/0.8.1_solid-js@1.7.1:
     resolution: {integrity: sha512-OmiDb3/NaeUzCc7593Drk5/iHPAuHt108oNuOx2ty+lGJnAyHX5R1OxgIJHntd4Yp6iAnLeb8sk9wVq9tznEQA==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -8063,9 +8047,10 @@ packages:
       postcss: 8.4.21
       postcss-nested: 6.0.0_postcss@8.4.21
       postcss-safe-parser: 6.0.0_postcss@8.4.21
-      solid-js: 1.6.16
+      solid-js: 1.7.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /solid-testing-library/0.3.0_solid-js@1.6.11:
     resolution: {integrity: sha512-6NWVbySNVzyReBm2N6p3eF8bzxRZXHZTAmPix4vFWYol16QWVjNQsEUxvr+ZOutb0yuMZmNuGx3b6WIJYmjwMQ==}
@@ -8126,6 +8111,7 @@ packages:
   /stable/0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+    dev: false
 
   /stack-trace/0.0.10:
     resolution: {integrity: sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=}
@@ -8237,6 +8223,7 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
+    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -8266,6 +8253,7 @@ packages:
       csso: 4.2.0
       picocolors: 1.0.0
       stable: 0.1.8
+    dev: false
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8275,41 +8263,6 @@ packages:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      lilconfig: 2.0.6
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss-import: 14.1.0
-      postcss-js: 4.0.0
-      postcss-load-config: 3.1.4
-      postcss-nested: 6.0.0
-      postcss-selector-parser: 6.0.11
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - ts-node
-    dev: true
-
-  /tailwindcss/3.2.4_postcss@8.4.21:
-    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -8868,13 +8821,13 @@ packages:
       kolorist: 1.6.0
       sirv: 2.0.2
       ufo: 1.0.1
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: false
 
-  /vite-plugin-solid-styled/0.8.1_3gvt4d22c7ovlwms4q7fjcjghy:
+  /vite-plugin-solid-styled/0.8.1_4ef3c9639e64a00a8e8ac110fe163fcd:
     resolution: {integrity: sha512-KxBSNfRLeB/Dr+yDh07vw2wteIHpJ6t2Q/6mRkNGVHj6dNaidifnqgvukztbzdDQcxGeyl6oVGYG8NtZ7fV35w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -8883,8 +8836,8 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
-      '@rollup/pluginutils': 5.0.2
-      solid-styled: 0.8.1_solid-js@1.6.16
+      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      solid-styled: 0.8.1_solid-js@1.7.1
       vite: 4.1.4
     transitivePeerDependencies:
       - rollup
@@ -8904,13 +8857,13 @@ packages:
       merge-anything: 5.1.4
       solid-js: 1.6.11
       solid-refresh: 0.5.0_solid-js@1.6.11
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
       vitefu: 0.2.4_vite@4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /vite/3.2.5_qfz55zahqkp66vn23sxaaw3yfe:
+  /vite/3.2.5_8173dee407829fef55badcae005b7829:
     resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8976,6 +8929,42 @@ packages:
       rollup: 3.10.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vite/4.1.4_8173dee407829fef55badcae005b7829:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.11.18
+      esbuild: 0.16.17
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.10.0
+      terser: 5.16.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /vite/4.1.4_@types+node@18.11.18:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
@@ -9007,40 +8996,6 @@ packages:
       postcss: 8.4.21
       resolve: 1.22.1
       rollup: 3.10.0
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  /vite/4.1.4_qfz55zahqkp66vn23sxaaw3yfe:
-    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.11.18
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.10.0
-      terser: 5.16.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9086,7 +9041,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.4_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 4.1.4_8173dee407829fef55badcae005b7829
     dev: false
 
   /vitest/0.20.3_jsdom@20.0.3+terser@5.16.1:
@@ -9123,7 +9078,7 @@ packages:
       local-pkg: 0.4.3
       tinypool: 0.2.4
       tinyspy: 1.0.2
-      vite: 3.2.5_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 3.2.5_8173dee407829fef55badcae005b7829
     transitivePeerDependencies:
       - less
       - sass
@@ -9133,7 +9088,7 @@ packages:
       - terser
     dev: true
 
-  /vitest/0.26.3_lae363bjhdipllr6jstkmuhhna:
+  /vitest/0.26.3_@vitest+ui@0.26.3+jsdom@20.0.3:
     resolution: {integrity: sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -9265,12 +9220,12 @@ packages:
       - debug
     dev: false
 
-  /wait-on/7.0.1:
+  /wait-on/7.0.1_debug@4.3.4:
     resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      axios: 0.27.2
+      axios: 0.27.2_debug@4.3.4
       joi: 17.7.0
       lodash: 4.17.21
       minimist: 1.2.7

--- a/test/template/package.json
+++ b/test/template/package.json
@@ -10,7 +10,7 @@
     "@cloudflare/kv-asset-handler": "^0.1.3",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.6.11",
+    "solid-js": "^1.7.1",
     "solid-start": "workspace:*",
     "solid-start-cloudflare-pages": "workspace:*",
     "solid-start-cloudflare-workers": "workspace:*",


### PR DESCRIPTION
This PR extends https://github.com/solidjs/solid-start/pull/825 It exists because that PR had some CICD test failures when I tried to upgrade solid-js to 1.7.1. _I don't intend to ever merge this PR_, it just serves as a way for me to probe CICD.

(To be clear, I'm currently satisfied with the state of https://github.com/solidjs/solid-start/pull/825, though learnings from this draft PR may lead to another PR and/or issue.)