### PR TITLE
fix vercel: make input optional

### DIFF
--- a/packages/start-vercel/index.d.ts
+++ b/packages/start-vercel/index.d.ts
@@ -15,4 +15,4 @@ export type SolidStartVercelOptions = {
   excludes?: string | string[];
   prerender?: PrerenderFunctionConfig;
 };
-export default function (props: SolidStartVercelOptions): import("solid-start/vite").Adapter;
+export default function (props?: SolidStartVercelOptions): import("solid-start/vite").Adapter;


### PR DESCRIPTION
This will not the force the user to pass an empty object when using the vercel adapter