### PR TITLE
Use port provided in astro config if present

### DIFF
--- a/packages/start/astro/index.js
+++ b/packages/start/astro/index.js
@@ -11,7 +11,7 @@ export default function (solidOptions = {}) {
     hooks: {
       "astro:config:setup": async ({ config, updateConfig, injectRoute, command }) => {
         const randomPort = await getPort({ port: portNumbers(3000, 52000) }); // Prefer 3000, but pick any port if not available
-        process.env.PORT = process.env.PORT ?? randomPort + "";
+        process.env.PORT = process.env.PORT ?? config.server?.port ?? randomPort + "";
         inline = config.vite || {};
         injectRoute({
           entryPoint: new URL(


### PR DESCRIPTION
The `config.server.port` from astro.config.ts  is currently ignored, which feels like a bug.