### PR TITLE
aws-start typo: there is no http.method

### DIFF
--- a/packages/start-aws/entry.mjs
+++ b/packages/start-aws/entry.mjs
@@ -43,7 +43,7 @@ function createRequest(event) {
   }
 
   const init = {
-    method: event.requestContext.http.method,
+    method: event.requestContext.httpMethod,
     headers,
   };
 

--- a/packages/start-aws/entry.mjs
+++ b/packages/start-aws/entry.mjs
@@ -33,7 +33,7 @@ export async function handler(event) {
 
 function createRequest(event) {
   const url = new URL(
-    event.rawPath,
+    event.path,
     `https://${event.requestContext.domainName}`
   );
 


### PR DESCRIPTION
The structure of the `event` is as follow, it has an `requestContext.httpMethod`. 
When I use the proposed changed I can call the function from my lambda method.

it also has a `.path` instead of `.rawPath`

<details>

```
{
  body: null,
  headers: {
    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
    'Accept-Encoding': 'gzip, deflate, br',
    'Accept-Language': 'de,en;q=0.9,en-GB;q=0.8,en-US;q=0.7',
    'Cache-Control': 'max-age=0',
    Connection: 'keep-alive',
    Cookie: 'AMP_MKTG_86cfb1920a=JTdCJTdE; AMP_86cfb1920a=JTdCJTIyb3B0T3V0JTIyJTNBZmFsc2UlMkMlMjJkZXZpY2VJZCUyMiUzQSUyMmY0MDA2OGYzLTQ3NmQtNDhmYy1iOTRhLTM4N2M4MjcwZTUzMSUyMiUyQyUyMmxhc3RFdmVudFRpbWUlMjIlM0ExNjgwMTA2MzgxMTA4JTJDJTIyc2Vzc2lvbklkJTIyJTNBMTY4MDEwNjM3ODk3MiU3RA==; AMP_MKTG_90364fee58=JTdCJTIycmVmZXJyZXIlMjIlM0ElMjJodHRwJTNBJTJGJTJGbG9jYWxob3N0JTNBMzAwMCUyRjA1MjJhMmY5LTY5OTAtNDZlNy1iYmY4LWUwZDM4NGIzMDFmMiUyMiUyQyUyMnJlZmVycmluZ19kb21haW4lMjIlM0ElMjJsb2NhbGhvc3QlM0EzMDAwJTIyJTdE; AMP_90364fee58=JTdCJTIyb3B0T3V0JTIyJTNBZmFsc2UlMkMlMjJkZXZpY2VJZCUyMiUzQSUyMjE1MzYwYzRlLWY5MzItNGM1Ni1hYjRjLTIxMTNiZjlkYTE2OCUyMiUyQyUyMmxhc3RFdmVudFRpbWUlMjIlM0ExNjg1MzUwNDE3MjQyJTJDJTIyc2Vzc2lvbklkJTIyJTNBMTY4NTM1MDM3MDA3MSU3RA==',
    Host: 'localhost:3000',
    'Sec-Ch-Ua': '"Google Chrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"',
    'Sec-Ch-Ua-Mobile': '?0',
    'Sec-Ch-Ua-Platform': '"macOS"',
    'Sec-Fetch-Dest': 'document',
    'Sec-Fetch-Mode': 'navigate',
    'Sec-Fetch-Site': 'none',
    'Sec-Fetch-User': '?1',
    'Upgrade-Insecure-Requests': '1',
    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
    'X-Forwarded-Port': '3000',
    'X-Forwarded-Proto': 'http'
  },
  httpMethod: 'GET',
  isBase64Encoded: true,
  multiValueHeaders: {
    Accept: [
      'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
    ],
    'Accept-Encoding': [ 'gzip, deflate, br' ],
    'Accept-Language': [ 'de,en;q=0.9,en-GB;q=0.8,en-US;q=0.7' ],
    'Cache-Control': [ 'max-age=0' ],
    Connection: [ 'keep-alive' ],
    Cookie: [
      'AMP_MKTG_86cfb1920a=JTdCJTdE; AMP_86cfb1920a=JTdCJTIyb3B0T3V0JTIyJTNBZmFsc2UlMkMlMjJkZXZpY2VJZCUyMiUzQSUyMmY0MDA2OGYzLTQ3NmQtNDhmYy1iOTRhLTM4N2M4MjcwZTUzMSUyMiUyQyUyMmxhc3RFdmVudFRpbWUlMjIlM0ExNjgwMTA2MzgxMTA4JTJDJTIyc2Vzc2lvbklkJTIyJTNBMTY4MDEwNjM3ODk3MiU3RA==; AMP_MKTG_90364fee58=JTdCJTIycmVmZXJyZXIlMjIlM0ElMjJodHRwJTNBJTJGJTJGbG9jYWxob3N0JTNBMzAwMCUyRjA1MjJhMmY5LTY5OTAtNDZlNy1iYmY4LWUwZDM4NGIzMDFmMiUyMiUyQyUyMnJlZmVycmluZ19kb21haW4lMjIlM0ElMjJsb2NhbGhvc3QlM0EzMDAwJTIyJTdE; AMP_90364fee58=JTdCJTIyb3B0T3V0JTIyJTNBZmFsc2UlMkMlMjJkZXZpY2VJZCUyMiUzQSUyMjE1MzYwYzRlLWY5MzItNGM1Ni1hYjRjLTIxMTNiZjlkYTE2OCUyMiUyQyUyMmxhc3RFdmVudFRpbWUlMjIlM0ExNjg1MzUwNDE3MjQyJTJDJTIyc2Vzc2lvbklkJTIyJTNBMTY4NTM1MDM3MDA3MSU3RA=='
    ],
    Host: [ 'localhost:3000' ],
    'Sec-Ch-Ua': [
      '"Google Chrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"'
    ],
    'Sec-Ch-Ua-Mobile': [ '?0' ],
    'Sec-Ch-Ua-Platform': [ '"macOS"' ],
    'Sec-Fetch-Dest': [ 'document' ],
    'Sec-Fetch-Mode': [ 'navigate' ],
    'Sec-Fetch-Site': [ 'none' ],
    'Sec-Fetch-User': [ '?1' ],
    'Upgrade-Insecure-Requests': [ '1' ],
    'User-Agent': [
      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36'
    ],
    'X-Forwarded-Port': [ '3000' ],
    'X-Forwarded-Proto': [ 'http' ]
  },
  multiValueQueryStringParameters: {
    'source-id': [ '0b5de3eb-cd31-48ca-b87d-2fec7a675419' ],
    'source-type': [ 'related-recast' ]
  },
  path: '/r/93f0f5d7-2534-45d2-b428-57ed4b77a112',
  pathParameters: { id: '93f0f5d7-2534-45d2-b428-57ed4b77a112' },
  queryStringParameters: {
    'source-id': '0b5de3eb-cd31-48ca-b87d-2fec7a675419',
    'source-type': 'related-recast'
  },
  requestContext: {
    accountId: '123456789012',
    apiId: '1234567890',
    domainName: 'localhost:3000',
    extendedRequestId: null,
    httpMethod: 'GET',
    identity: {
      accountId: null,
      apiKey: null,
      caller: null,
      cognitoAuthenticationProvider: null,
      cognitoAuthenticationType: null,
      cognitoIdentityPoolId: null,
      sourceIp: '127.0.0.1',
      user: null,
      userAgent: 'Custom User Agent String',
      userArn: null
    },
    path: '/r/{id}',
    protocol: 'HTTP/1.1',
    requestId: '1b58ad91-7f87-4109-9ad5-db5a30833aad',
    requestTime: '29/May/2023:12:23:09 +0000',
    requestTimeEpoch: 1685362989,
    resourceId: '123456',
    resourcePath: '/r/{id}',
    stage: 'Prod'
  },
  resource: '/r/{id}',
  stageVariables: null,
  version: '1.0'
}
```
</details>

