### PR TITLE
Updates dependency in AuthJS example to fix build error

### DIFF
--- a/examples/with-authjs/package.json
+++ b/examples/with-authjs/package.json
@@ -16,7 +16,7 @@
     "vite": "^4.1.4"
   },
   "dependencies": {
-    "@auth/core": "^0.3.0",
+    "@auth/core": "^0.5.1",
     "@solid-auth/base": "^2.0.3",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",


### PR DESCRIPTION
Fixes #899 by updating the @auth/core dependency to 0.5.1 to resolve dependency tree. 