### PR TITLE
ci: add issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug report 🐛
+description: Create a bug report for Solid Start.
+labels: ['bug', 'needs triage']
+title: '[Bug?]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/solidjs/solid-start/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes, performance enhancements, and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: Current behavior 😯
+      description: Describe what happens instead of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Expected behavior 🤔
+      description: Describe what should happen.
+  - type: textarea
+    attributes:
+      label: Steps to reproduce 🕹
+      description: |
+        Provide a link to a live example (you can use codesandbox.io) and an unambiguous set of steps to reproduce this bug.
+        Include code to reproduce, if relevant (which it most likely is).
+
+        :bangbang: &nbsp; Issues that we can't reproduce will be closed. :bangbang:
+      value: |
+        Steps:
+
+        1.
+        2.
+        3.
+        4.
+  - type: textarea
+    attributes:
+      label: Context 🔦
+      description: What are you trying to accomplish? How has this issue affected you? Providing context helps us come up with a solution that is more useful in the real world.
+  - type: textarea
+    attributes:
+      label: Your environment 🌎
+      description: Please paste the output of running whatever the command is for your environment.
+      placeholder: |
+        System:
+          OS: Linux 5.10 Debian GNU/Linux 9 (stretch)
+          CPU: (8) arm64
+        Binaries:
+          Node: 14.17.0 - /usr/local/bin/node
+          Yarn: 1.22.5 - /usr/local/bin/yarn
+          npm: 6.14.13 - /usr/local/bin/npm
+        npmPackages:
+          solid-start: 1.0.0 => 1.0.0
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,37 @@
+name: Feature request 💄
+description: Suggest a new idea for Solid Start.
+labels: ['enhancement', 'needs triage']
+title: '[Feature?]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/solidjs/solid-start/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes, performance enhancements, and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary 💡
+      description: Describe how it should work.
+  - type: textarea
+    attributes:
+      label: Examples 🌈
+      description: Provide a link to the Solid Start specification, other implementations, or screenshots of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Motivation 🔦
+      description: What are you trying to accomplish? How has the lack of this feature affected you? Providing context helps us come up with a solution that is more useful in the real world.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,26 @@
+name: 'Questions / Help 💬'
+description: If you have questions, please check the Discussions tab
+title: '[Please read the message below]'
+labels: [':speech_balloon: Question']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Questions and Help 💬
+
+        This issue tracker is reserved for bug reports and feature proposals.
+
+        For anything else, such as questions or getting help, please see:
+
+        - [The Discussion Q&A page](https://github.com/solidjs/solid-start/discussions/categories/q-a)
+        - [All Discussions](https://github.com/solidjs/solid-start/discussions)
+  - type: checkboxes
+    id: no-post
+    attributes:
+      label: |
+        Please do not submit this issue.
+      description: |
+        :bangbang: &nbsp; This issue will be closed. :bangbang:
+      options:
+        - label: I understand
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## PR Checklist
+
+Please check if your PR fulfills the following requirements:
+
+- [ ] Tests for the changes have been added (for bug fixes / features)
+
+## PR Type
+
+What kind of change does this PR introduce?
+
+<!-- Please check the one that applies to this PR using "x". -->
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] infrastructure changes
+- [ ] Other... Please describe:
+
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+## What is the new behavior?
+
+## Other information
+<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,15 @@
+name: 'Close issues'
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  questions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Issue
+        uses: peter-evans/close-issue@v3
+        if: "${{ github.event.label.name == ':speech_balloon: Question' }}"
+        with:
+          comment: Please note this issue tracker is not a help forum. We recommend using [Discussions](https://github.com/solidjs/solid-start/discussions/categories/q-a) for questions.


### PR DESCRIPTION
Plus up the `.github` features by adding templates to issue creation and PRs for a better user experience for the community.