### PR TITLE
fix SPA client build failing because of whitespace in path

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -373,7 +373,7 @@ prog
               "dev",
               "--mode",
               "production",
-              ...(config ? ["--config", config.configFile] : []),
+              ...(config ? ["--config", `"${config.configFile}"`] : []),
               ...(port ? ["--port", port] : [])
             ],
             {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
SPA client build will hang/fail because of whitespace in path. #913 

## What is the new behavior?
Building works.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
