### PR TITLE
RouteAction returns undefined in case of error

### DIFF
--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -26,14 +26,14 @@ export type RouteAction<T, U> = [
     clear: () => void;
     retry: () => void;
   },
-  ((vars: T) => Promise<U>) & {
+  ((vars: T) => Promise<U | undefined>) & {
     Form: T extends FormData ? ParentComponent<FormProps> : never;
     url: string;
   }
 ];
 export type RouteMultiAction<T, U> = [
   Submission<T, U>[] & { pending: Submission<T, U>[] },
-  ((vars: T) => Promise<U>) & {
+  ((vars: T) => Promise<U | undefined>) & {
     Form: T extends FormData ? ParentComponent<FormProps> : never;
     url: string;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [x] TypeScript typings

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In case of error `createServerAction$` returns undefined as a result, but typings don't:
```tsx
import { FormError } from 'solid-start'
import { createServerAction$ } from 'solid-start/server'

export default function Page() {
  const [action, submit] = createServerAction$(async (formData: FormData) => {
    if (formData.get('hasError')) {
      throw new FormError('Validation failed')
    }
    return 'demo'
  })
  return (
    <submit.Form
      onsubmit={async (event) => {
        event.preventDefault()
        const formData = new FormData(event.currentTarget)
        const result = await submit(formData)
        console.log(action.result === result) // true
        console.log(action.result) // type: string | undefined
        /* ACTUAL:   */ console.log(result) // type: string
        /* EXPECTED: */ console.log(result) // type: string | undefined
      }}
    >
      <input type="checkbox" name="hasError" value="yes" />
      <input type="submit"/>
    </submit.Form>
  )
}
```

## What is the new behavior?
Typings reflect the actual behavior

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
