### PR TITLE
fix: :zap: check node version before applying Web Crypto API on globa…

### DIFF
--- a/packages/start-cloudflare-pages/index.js
+++ b/packages/start-cloudflare-pages/index.js
@@ -62,17 +62,30 @@ export default function (miniflareOptions) {
               WebSocketPair,
               TransformStream
             } = g;
-            Object.assign(globalThis, {
-              Request,
-              Response,
-              fetch,
-              crypto,
-              Headers,
-              ReadableStream,
-              WritableStream,
-              TransformStream,
-              WebSocketPair
-            });
+            if (process.version < "v19") {
+              Object.assign(globalThis, {
+                Request,
+                Response,
+                fetch,
+                crypto,
+                Headers,
+                ReadableStream,
+                WritableStream,
+                TransformStream,
+                WebSocketPair
+              });
+            } else {
+              Object.assign(globalThis, {
+                Request,
+                Response,
+                fetch,
+                Headers,
+                ReadableStream,
+                WritableStream,
+                TransformStream,
+                WebSocketPair
+              });
+            }
 
             console.log(
               "🔥",


### PR DESCRIPTION
start-cloudflare-pages adapter: May not be the best solution but works...

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If client is on Node 19+  when running in dev you'll encounter `GET /: TypeError: Cannot set property crypto of #<Object>`

## What is the new behavior?
Check is made to see if client is less than Node v19 before applying Web Crypto API on globalThis.crypto 
