### PR TITLE
fix(data): update Form types in createRouteAction.tsx

### DIFF
--- a/packages/start/data/createRouteAction.tsx
+++ b/packages/start/data/createRouteAction.tsx
@@ -27,14 +27,14 @@ export type RouteAction<T, U> = [
     retry: () => void;
   },
   ((vars: T) => Promise<U>) & {
-    Form: T extends FormData ? ParentComponent<FormProps> : never;
+    Form: ParentComponent<FormProps | T>;
     url: string;
   }
 ];
 export type RouteMultiAction<T, U> = [
   Submission<T, U>[] & { pending: Submission<T, U>[] },
   ((vars: T) => Promise<U>) & {
-    Form: T extends FormData ? ParentComponent<FormProps> : never;
+    Form: ParentComponent<FormProps | T>;
     url: string;
   }
 ];
@@ -71,7 +71,7 @@ export function createRouteAction<T, U = void>(
         if (reqId === count) {
           if (data instanceof Response) {
             await handleResponse(data, navigate, options);
-          } else await handleRefetch(data as any[], options);
+          } else await handleRefetch(data as unknown as any[], options);
           if (!data || isRedirectResponse(data)) setInput(undefined);
           else setResult({ data });
         }
@@ -103,7 +103,7 @@ export function createRouteAction<T, U = void>(
         {props.children}
       </FormImpl>
     );
-  }) as T extends FormData ? ParentComponent<FormProps> : never;
+  }) as ParentComponent<FormProps | T>;
 
   return [
     {
@@ -187,7 +187,7 @@ export function createRouteMultiAction<T, U = void>(
         if (data instanceof Response) {
           await handleResponse(data, navigate, options);
           data = data.body;
-        } else await handleRefetch(data as any[], options);
+        } else await handleRefetch(data as unknown as any[], options);
         data ? setResult({ data }) : submission.clear();
 
         return data;
@@ -224,7 +224,7 @@ export function createRouteMultiAction<T, U = void>(
         {props.children}
       </FormImpl>
     );
-  }) as T extends FormData ? ParentComponent<FormProps> : never;
+  }) as ParentComponent<FormProps | T>;
 
   return [
     new Proxy<Submission<T, U>[] & { pending: Submission<T, U>[] }>([] as any, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you use the `createRouteAction` controller using the `Form` it returns without an argument, the types are set to `never` which results in an TS/IDE error.

This is because the typing incorrectly forces the return value based on if someone passes `FormData` as an argument which may not always be the case.

## What is the new behavior?
- Updates the types to use the correct return for the component while utilizing the type as a Union/alternate so the IDE or TS doesn't error, allowing users to still use the `Form` magic component without needing arguments.
- Also fixes current actual type errors in the file from not using the `unknown as` pattern.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
Example use case, when using Supabase Auth, the API's have to run on the client and `signOut` doesn't need arguments and to keep the UI a11y to all users, you should use a form for the button submission.

```typescript
const [, { Form: SignOutForm }] = createRouteAction(async () => {
    return signOut()
  })
```