### PR TITLE
[astro] Fix cloudflare adapter

### DIFF
--- a/packages/start/astro/builder.js
+++ b/packages/start/astro/builder.js
@@ -46,6 +46,7 @@ async function client(path, serverPath, config, resolved) {
   await build({
     ...config,
     build: {
+      emptyOutDir: false,
       outDir: path,
       ssrManifest: true,
       minify: process.env.START_MINIFY === "false" ? false : config.build?.minify ?? true,
@@ -91,6 +92,7 @@ async function spaClient(path, serverPath, config, resolved) {
   await build({
     ...config,
     build: {
+      emptyOutDir: false,
       outDir: path,
       minify: process.env.START_MINIFY == "false" ? false : config.build?.minify ?? true,
       ssrManifest: true,
@@ -155,6 +157,7 @@ async function islandsClient(path, serverPath, config, resolved) {
   await build({
     ...config,
     build: {
+      emptyOutDir: false,
       outDir: path,
       ssrManifest: true,
       minify: process.env.START_MINIFY === "false" ? false : config.build?.minify ?? true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cloudflare adapter not working.

## What is the new behavior?
Cloudflare adapter now works.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
More testing required. Don't want to break other adapters.

The serverPath for `@astro/cloudflare` adapter points inside the clientPath (basically outDir and clientPath are the same) and because of that the actual client build will delete the route manifest.
