### PR TITLE
[astro] move node adapter to dev dependencies on all examples

### DIFF
--- a/examples/bare/package.json
+++ b/examples/bare/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/with-authjs/package.json
+++ b/examples/with-authjs/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@auth/core": "^0.5.1",
     "@solid-auth/base": "1.0.0-alpha.1",
     "@solidjs/meta": "^0.28.2",

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@mdx-js/mdx": "^2.3.0",
     "@mdx-js/rollup": "^2.3.0",
     "@types/babel__core": "^7.20.0",
@@ -19,7 +20,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/with-prisma/package.json
+++ b/examples/with-prisma/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@prisma/client": "^4.9.0",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",

--- a/examples/with-solid-styled/package.json
+++ b/examples/with-solid-styled/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -18,7 +19,6 @@
     "vite-plugin-solid-styled": "^0.8.1"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -19,7 +20,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@astrojs/tailwind": "^3.1.1",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",

--- a/examples/with-trpc/package.json
+++ b/examples/with-trpc/package.json
@@ -9,6 +9,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
@@ -17,7 +18,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "@tanstack/solid-query": "5.0.0-alpha.20",

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -13,22 +13,22 @@
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@astrojs/node": "^5.1.2",
+    "@solidjs/testing-library": "^0.5.2",
+    "@testing-library/jest-dom": "^5.16.5",
     "@types/babel__core": "^7.20.0",
     "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
-    "@solidjs/testing-library": "^0.5.2",
-    "@testing-library/jest-dom": "^5.16.5",
     "@types/testing-library__jest-dom": "^5.14.5",
     "@vitest/coverage-c8": "^0.26.3",
     "@vitest/ui": "^0.26.3",
-    "jsdom": "^20.0.3",
     "esbuild": "^0.14.54",
+    "jsdom": "^20.0.3",
     "postcss": "^8.4.21",
     "typescript": "^4.9.4",
     "vitest": "^0.26.3"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.2",
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
     "astro": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ importers:
 
   examples/bare:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -118,6 +115,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -139,9 +139,6 @@ importers:
 
   examples/hackernews:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -158,6 +155,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -179,9 +179,6 @@ importers:
 
   examples/todomvc:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -198,6 +195,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -219,9 +219,6 @@ importers:
 
   examples/with-auth:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -238,6 +235,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -259,9 +259,6 @@ importers:
 
   examples/with-authjs:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@auth/core':
         specifier: ^0.5.1
         version: 0.5.1
@@ -284,6 +281,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -305,9 +305,6 @@ importers:
 
   examples/with-mdx:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -327,6 +324,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@mdx-js/mdx':
         specifier: ^2.3.0
         version: 2.3.0
@@ -354,9 +354,6 @@ importers:
 
   examples/with-prisma:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@prisma/client':
         specifier: ^4.9.0
         version: 4.9.0(prisma@4.9.0)
@@ -379,6 +376,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -400,9 +400,6 @@ importers:
 
   examples/with-solid-styled:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -422,6 +419,9 @@ importers:
         specifier: ^0.8.1
         version: 0.8.1(@babel/core@7.22.5)(solid-js@1.7.7)
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -446,9 +446,6 @@ importers:
 
   examples/with-tailwindcss:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@astrojs/tailwind':
         specifier: ^3.1.1
         version: 3.1.1(astro@2.7.1)(tailwindcss@3.3.1)
@@ -468,6 +465,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -495,9 +495,6 @@ importers:
 
   examples/with-trpc:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -532,6 +529,9 @@ importers:
         specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -553,9 +553,6 @@ importers:
 
   examples/with-vitest:
     dependencies:
-      '@astrojs/node':
-        specifier: ^5.1.2
-        version: 5.1.2(astro@2.7.1)
       '@solidjs/meta':
         specifier: ^0.28.2
         version: 0.28.2(solid-js@1.7.7)
@@ -572,6 +569,9 @@ importers:
         specifier: ^0.3.0-alpha.7
         version: link:../../packages/start
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.2
+        version: 5.1.2(astro@2.7.1)
       '@solidjs/testing-library':
         specifier: ^0.5.2
         version: 0.5.2(solid-js@1.7.7)
@@ -1020,6 +1020,7 @@ packages:
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@astrojs/prism@2.1.2:
     resolution: {integrity: sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==}
@@ -1076,6 +1077,7 @@ packages:
     resolution: {integrity: sha512-mHZ7VgPNMeV3TYIw3SGHTKaJosBxA8bTzZ3QhNw509qvCJca4Lkjes8JywimuwTn+TMjEiv7ksNfwRluad3jqA==}
     dependencies:
       undici: 5.22.1
+    dev: true
 
   /@astrojs/webapi@2.2.0:
     resolution: {integrity: sha512-mHAOApWyjqSe5AQMOUD9rsZJqbMQqe3Wosb1a40JV6Okvyxj1G6GTlthwYadWCymq/lbgwh0PLiY8Fr4eFxtuQ==}
@@ -5162,6 +5164,7 @@ packages:
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+    dev: true
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -5170,6 +5173,7 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: true
 
   /devalue@4.3.2:
     resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
@@ -6158,6 +6162,7 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -6384,6 +6389,7 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /fs-extra@11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
@@ -6736,6 +6742,7 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+    dev: true
 
   /http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -7934,6 +7941,7 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -8039,6 +8047,7 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
 
   /mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -8182,6 +8191,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
+    dev: true
 
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
@@ -8946,6 +8956,7 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -9398,6 +9409,7 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /seroval@0.5.1:
     resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
@@ -9415,6 +9427,7 @@ packages:
 
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -9673,6 +9686,7 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+    dev: true
 
   /std-env@3.3.3:
     resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
@@ -9989,6 +10003,7 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+    dev: true
 
   /toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`@astrojs/node` is declared as dependency on all examples.

## What is the new behavior?
`@astrojs/node` is declared as dev dependency on all examples.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

Did `pnpm --filter example-<name> i -D @astrojs/node` on all examples. All package versions should have remained the same.
