### PR TITLE
fix setting multiple set-cookie headers on response in undici >= 5.19.0

### DIFF
--- a/packages/start/node/fetch.js
+++ b/packages/start/node/fetch.js
@@ -2,7 +2,7 @@ import { once } from "events";
 import multipart from "parse-multipart-data";
 import { splitCookiesString } from "set-cookie-parser";
 import { Readable } from "stream";
-import { File, FormData, Headers, Request as BaseNodeRequest } from "undici";
+import { Request as BaseNodeRequest, File, FormData, Headers } from "undici";
 
 function nodeToWeb(nodeStream) {
   var destroyed = false;
@@ -159,7 +159,7 @@ export async function handleNodeResponse(webRes, res) {
 
   for (const [name, value] of webRes.headers) {
     if (name === "set-cookie") {
-      res.setHeader(name, splitCookiesString(value));
+      res.appendHeader(name, splitCookiesString(value));
     } else res.setHeader(name, value);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In undici >=5.19.0
Set-Cookie appears multiple times in headers. Server iterates over all set-cookie keys and only the last one will be set. Splitting does nothing here as the cookies are already splitted.

In undici 5.18.0
Set-Cookie appears only once in headers. Server splits the string and setHeader works as expected when passing in an array.

https://github.com/solidjs/solid-start/blob/52d44e2cad33faf3dc40148520d7ae41086dd6a8/packages/start/node/fetch.js#L160-L164

## What is the new behavior?

Now works in both versions.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

fixes #953 
