### PR TITLE
fix(start): types are not being exported properly in build

### DIFF
--- a/packages/start/index.tsx
+++ b/packages/start/index.tsx
@@ -42,6 +42,8 @@ export {
   type SessionIdStorageStrategy,
   type SessionStorage
 } from "./session";
+export * from "./types";
+
 import { JSX } from "solid-js";
-import "./types";
+
 export declare function FileRoutes(): JSX.Element;

--- a/packages/start/types.ts
+++ b/packages/start/types.ts
@@ -17,7 +17,7 @@ declare global {
   }
 }
 
-type Adapter = {
+export type Adapter = {
   start(): void;
   build(): void;
   dev?(): void;
@@ -39,6 +39,3 @@ export type StartOptions = {
   serverEntry: string;
   appRootFile: string;
 };
-
-export { };
-


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When running the latest version of solid-start with the latest version of typescript, there are node_module errors that are not ignored like:

```bash
node_modules/.pnpm/solid-start@0.2.27_@solidjs+meta@0.28.6_@solidjs+router@0.8.2_solid-js@1.7.8_solid-start-node@0.2.19_vite@4.1.4/node_modules/solid-start/islands/router.ts:152:5 - error TS2552: Cannot find name '_$DEBUG'. Did you mean 'debug'?

152     _$DEBUG("mounted islands router");
```

## What is the new behavior?
Updates the index file to export all the types from `./types` vs. importing the file. I find this works as a better solution regarding libraries and DX.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->