### PR TITLE
check to see if httpService exists before using it

### DIFF
--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -143,15 +143,17 @@ function solidStartFileSystemRouter(options) {
       server = vite;
       router.watch(console.log);
       router.listener = listener;
-      vite.httpServer.once("listening", async () => {
-        setTimeout(() => {
-          if (vite.resolvedUrls) {
-            const url = vite.resolvedUrls.local[0];
-            // eslint-disable-next-line no-console
-            printUrls(router, url.substring(0, url.length - 1));
-          }
-        }, 100);
-      });
+      if(vite.httpServer !== null){
+        vite.httpServer.once("listening", async () => {
+          setTimeout(() => {
+            if (vite.resolvedUrls) {
+              const url = vite.resolvedUrls.local[0];
+              // eslint-disable-next-line no-console
+              printUrls(router, url.substring(0, url.length - 1));
+            }
+          }, 100);
+        });
+      }
     },
 
     transform(code, id, transformOptions) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When you try to use storybook with a solid-start project you'll run into this issue: https://github.com/solidjs/solid-start/issues/822

## What is the new behavior?
A simple if statement to check if `vite.httpServer` exists before using it. The documentation on the `vite.httpServer` field also comments that this field can be null when using it in a middleware so I doubt it's a problem with vite.
