### PR TITLE
Fix building with `inspect: false`

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -179,6 +179,10 @@ prog
     const { default: prepareManifest } = await import("./fs-router/manifest.js");
 
     const inspect = join(config.root, ".solid", "inspect");
+    if (!existsSync(inspect)) mkdirSync(inspect, {
+      recursive: true
+    });
+
     const vite = require("vite");
     config.adapter.name && console.log(c.blue(" adapter "), config.adapter.name);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

I am honestly intimidated by writing a test in a project that already has established testing conventions, so I did not do this.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It is outlined in #958

## What is the new behavior?

If the `.solid/inspect` folder doesn't exist, it is created.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
Fixes #958
