### PR TITLE
import vite rather than requiring it

### DIFF
--- a/packages/start/bin.cjs
+++ b/packages/start/bin.cjs
@@ -183,7 +183,7 @@ prog
       recursive: true
     });
 
-    const vite = require("vite");
+    const vite = await import("vite");
     config.adapter.name && console.log(c.blue(" adapter "), config.adapter.name);
 
     config.adapter.build(config, {
@@ -502,12 +502,11 @@ prog
 prog.parse(process.argv);
 
 /**
- *
  * @param {*} param0
  * @returns {Promise<import('node_modules/vite').ResolvedConfig & { solidOptions: import('./types').StartOptions, adapter: import('./types').Adapter }>}
  */
 async function resolveConfig({ configFile, root, mode, command }) {
-  const vite = require("vite");
+  const vite = await import("vite");
   root = root || process.cwd();
   if (!configFile) {
     if (!configFile) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`require` the CJS version of Vite

## What is the new behavior?

`import` the ESM version of Vite. The next major version of Vite may start producing warnings when Vite is required to encourage people to move off of the legacy CJS syntax and onto modern ESM. We should make a change now to get ahead of it and ensure users don't see this warning

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
