### PR TITLE
Get correct protocol when creating request.

### DIFF
--- a/packages/start/node/fetch.js
+++ b/packages/start/node/fetch.js
@@ -138,9 +138,10 @@ class NodeRequest extends BaseNodeRequest {
 }
 
 export function createRequest(req) {
+  let protocol = req.headers["x-forwarded-proto"] || "https";
   let origin = req.headers.origin && 'null' !== req.headers.origin
       ? req.headers.origin
-      : `http://${req.headers.host}`;
+      : `${protocol}://${req.headers.host}`;
   let url = new URL(req.url, origin);
 
   let init = {


### PR DESCRIPTION
This replaces defaulting to http which is not always correct nor safe.

This feature was removed in an older commit (https://github.com/solidjs/solid-start/commit/f69826f#diff-cf234a385fd7788d61976c078d5d093b2de418c259f1f7b3a15adb46ee1cedc3).

This commit re-implements said feature but with the standard of checking the "x-forwarded-proto" header or defaulting to "https". A standard which is already used in start-vercel: https://github.com/solidjs/solid-start/blob/925ea73b7f38b2126b1440a69ab25160dd8c6c16/packages/start-vercel/entry.js#L58 https://github.com/solidjs/solid-start/blob/925ea73b7f38b2126b1440a69ab25160dd8c6c16/packages/start-vercel/entry-prerender.js#L57

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The current behavior will incorrectly default some POST requests to use the HTTP protocol when sending information. This will trigger most browsers into warning the user about an unsecure exchange of information.

This will occur when the website headers does not include an origin header.

## What is the new behavior?
The new behavior tries to interpret the correct protocol (HTTP/HTTPS) from the "x-forwarded-proto" header which is the de-facto standard header for identifying the protocol.

If an origin header does not exist, the request protocol will still be correctly set to the appropriate protocol.