### PR TITLE
fix: start command of static adapter not working on windows

### DIFF
--- a/packages/start-static/index.js
+++ b/packages/start-static/index.js
@@ -16,10 +16,10 @@ export default function () {
     name: "static",
     start(config, { port }) {
       process.env.PORT = port;
-      const proc = spawn("npx", ["serve", "./dist/public"]);
-      proc.stdout.pipe(process.stdout);
-      proc.stderr.pipe(process.stderr);
-
+      spawn("npx", ["serve", "./dist/public"], {
+        shell: true,
+        stdio: "inherit"
+      });
       return `http://localhost:${process.env.PORT}`;
     },
     async build(config, builder) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

start command does not work on windows because spawn is called without shell.

## What is the new behavior?

works on windows.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

fixes #986