### PR TITLE
Stop choking if BASE_URL includes origin (fix #979)

### DIFF
--- a/packages/start/entry-client/StartClient.tsx
+++ b/packages/start/entry-client/StartClient.tsx
@@ -80,10 +80,22 @@ export default () => {
     );
   }
 
+  const BASE_URL = import.meta.env.BASE_URL;
+  let basePath = BASE_URL;
+  if (BASE_URL.startsWith("http")) {
+    try {
+      // SolidRouter expects a pathname for the `base` prop, not a full URL.
+      const url = new URL(BASE_URL);
+      basePath = url.pathname;
+    } catch (e) {
+      console.warn('BASE_URL starts with http, but `new URL` failed to parse it. Please check your BASE_URL:', BASE_URL);
+    }
+  }
+
   return (
     <ServerContext.Provider value={mockFetchEvent}>
       <MetaProvider>
-        <StartRouter base={import.meta.env.BASE_URL} data={dataFn}>
+        <StartRouter base={basePath} data={dataFn}>
           <Root />
         </StartRouter>
       </MetaProvider>


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)

Not sure how to test this: Do we have any tests that set a flag in vite, and then run the app to see there are no errors?

We could also move the code change into `@solidjs/router`, but this is a fix for SolidStart, and I'm not sure where it makes the most sense to add this small guard.

## PR Type

- [x] Bugfix

## What is the current behavior?
Setting this in `vite.config.ts`:
```
  base: 'http://localhost:1234'.
```
Would cause Solid's router to crash, because it wasn't expecting base urls to include origins. Solid's router expects a base path, without an origin.

## What is the new behavior?
Before we pass Vite's BASE_URL to Solid's router, check for and remove any origin, by checking if the BASE_URL starts with `'http'`.


Closes #979 