### PR TITLE
fix: vercel build not working because runtime config is set to node 16

### DIFF
--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -211,7 +211,7 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
             entrypoint: relative(fileURLToPath(renderBaseUrl), fileURLToPath(renderFuncEntrypoint))
           }
         : {
-            runtime: "nodejs16.x",
+            runtime: "nodejs18.x",
             handler: relative(fileURLToPath(renderBaseUrl), fileURLToPath(renderFuncEntrypoint)),
             launcherType: "Nodejs"
           };
@@ -290,7 +290,7 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
               entrypoint: relative(fileURLToPath(apiBaseUrl), fileURLToPath(apiFuncEntrypoint))
             }
           : {
-              runtime: "nodejs16.x",
+              runtime: "nodejs18.x",
               handler: relative(fileURLToPath(apiBaseUrl), fileURLToPath(apiFuncEntrypoint)),
               launcherType: "Nodejs"
             };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

0.3.x does not work on node 16.

## What is the new behavior?

Updated runtime config to node 18 on the vercel adapter.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

fixes #983