### PR TITLE
fix: how cloudflare pages adapter checks for static asset request and give start a chance to handle request if not found

### DIFF
--- a/packages/start-cloudflare-pages/entry.js
+++ b/packages/start-cloudflare-pages/entry.js
@@ -3,7 +3,7 @@ import handler from "./entry-server";
 
 export const onRequestGet = async ({ request, next, env }) => {
   // Handle static assets
-  if (/\.\w+$/.test(request.url)) {
+  if (/\.\w+$/.test(request.url.pathname)) {
     let resp = await next(request);
     if (resp.status === 200 || 304) {
       return resp;
@@ -44,7 +44,7 @@ export const onRequestGet = async ({ request, next, env }) => {
 
 export const onRequestHead = async ({ request, next, env }) => {
   // Handle static assets
-  if (/\.\w+$/.test(request.url)) {
+  if (/\.\w+$/.test(request.url.pathname)) {
     let resp = await next(request);
     if (resp.status === 200 || 304) {
       return resp;

--- a/packages/start-cloudflare-pages/entry.js
+++ b/packages/start-cloudflare-pages/entry.js
@@ -3,7 +3,7 @@ import handler from "./entry-server";
 
 export const onRequestGet = async ({ request, next, env }) => {
   // Handle static assets
-  if (/\.\w+$/.test(request.url.pathname)) {
+  if (/\.\w+$/.test(new URL(request.url).pathname)) {
     let resp = await next(request);
     if (resp.status === 200 || 304) {
       return resp;
@@ -44,7 +44,7 @@ export const onRequestGet = async ({ request, next, env }) => {
 
 export const onRequestHead = async ({ request, next, env }) => {
   // Handle static assets
-  if (/\.\w+$/.test(request.url.pathname)) {
+  if (/\.\w+$/.test(new URL(request.url).pathname)) {
     let resp = await next(request);
     if (resp.status === 200 || 304) {
       return resp;

--- a/packages/start-cloudflare-pages/entry.js
+++ b/packages/start-cloudflare-pages/entry.js
@@ -5,7 +5,7 @@ export const onRequestGet = async ({ request, next, env }) => {
   // Handle static assets
   if (/\.\w+$/.test(new URL(request.url).pathname)) {
     let resp = await next(request);
-    if (resp.status === 200 || 304) {
+    if (resp.status === 200 || resp.status === 304) {
       return resp;
     }
   }
@@ -46,7 +46,7 @@ export const onRequestHead = async ({ request, next, env }) => {
   // Handle static assets
   if (/\.\w+$/.test(new URL(request.url).pathname)) {
     let resp = await next(request);
-    if (resp.status === 200 || 304) {
+    if (resp.status === 200 || resp.status === 304) {
       return resp;
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There were actually two bugs:

- The complete url is used to check for file endings causing 404 if the url ends with a query param that looks like a file ending.
`http://localhost?test=bad.png` would causes 404. 
- If the request for the static asset returns anything other than 200 the cloudflare error page will be shown instead of letting solid-start handle the request.

## What is the new behavior?

- Only looking at the pathname for file ending.
- If the request for static asset does not return 200 or 304 solid-start handels the request.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

fixes #963