### PR TITLE
feat[start-vercel]: upgrade functions to run with nodejs18.x

### DIFF
--- a/packages/start-vercel/index.js
+++ b/packages/start-vercel/index.js
@@ -211,7 +211,7 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
             entrypoint: relative(fileURLToPath(renderBaseUrl), fileURLToPath(renderFuncEntrypoint))
           }
         : {
-            runtime: "nodejs16.x",
+            runtime: "nodejs18.x",
             handler: relative(fileURLToPath(renderBaseUrl), fileURLToPath(renderFuncEntrypoint)),
             launcherType: "Nodejs"
           };
@@ -290,7 +290,7 @@ export default function ({ edge, prerender, includes, excludes } = {}) {
               entrypoint: relative(fileURLToPath(apiBaseUrl), fileURLToPath(apiFuncEntrypoint))
             }
           : {
-              runtime: "nodejs16.x",
+              runtime: "nodejs18.x",
               handler: relative(fileURLToPath(apiBaseUrl), fileURLToPath(apiFuncEntrypoint)),
               launcherType: "Nodejs"
             };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Breaking on version 0.3.2 on vercel on settings headers.

## What is the new behavior?
Vercel are using nodejs 18.x as default version for functions and start-vercel was using 16.x and with the new version (0.3.2) of solid-start was breaking on setting headers.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
https://vercel.com/docs/concepts/functions/serverless-functions/runtimes/node-js#node.js-version

I suggest generating a new version 0.4.x because it can break other projects and need some tests
