### PR TITLE
Fix: Infer useRouteData return type for nested routeData

### DIFF
--- a/packages/start/router.tsx
+++ b/packages/start/router.tsx
@@ -83,7 +83,7 @@ declare global {
 }
 
 export function useRouteData<T extends keyof StartRoutes>(): ReturnType<StartRoutes[T]["data"]>;
-export function useRouteData<T extends RouteDataFunc>(): ReturnType<T>;
+export function useRouteData<T extends (...args: any[]) => any>(): T extends RouteDataFunc<infer _, infer R> ? R : ReturnType<T>;
 export function useRouteData<T extends keyof StartRoutes>(): ReturnType<StartRoutes[T]["data"]> {
   // @ts-ignore
   return useBaseRouteData<T>();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?
See [#982](https://github.com/solidjs/solid-start/issues/982) the 2nd issue.

## What is the new behavior?
I made adjustments to the `useRouteData` overload in line with the `RouteDataFunc` return type inference first added by otonashi [here](https://github.com/solidjs/solid-router/pull/263)

This restores the ability to correctly infer nested routeData type. However, this seems only to work when using the type `RouteDataFuncArgs` instead of `RouteDataArgs`. I am not sure if there are breaking side-effects, it only fixes this specific issue. I have added an example to the [stackblitz mentioned in the issue](https://stackblitz.com/edit/solid-ssr-vite-nh2rkt?file=src%2Froutes%2Ffixed.tsx).

This might not be the desired solution but I consider it a first step.
