### PR TITLE
fix: router not generating same path for renamed index as for index file

### DIFF
--- a/packages/start/fs-router/router.js
+++ b/packages/start/fs-router/router.js
@@ -146,7 +146,7 @@ export class Router {
       let routeConfig = this.createRouteConfig(path);
 
       // renamed index should have a trailing slash like index files
-      if (!routeConfig.path.endsWith("/") && /\([^)/]+\)$/.test(routeConfig.id)) {
+      if (!routeConfig.path.endsWith("/") && /\/\([^)/]+\)$/.test(routeConfig.id)) {
         routeConfig.path += "/";
       }
 

--- a/packages/start/fs-router/router.js
+++ b/packages/start/fs-router/router.js
@@ -145,6 +145,11 @@ export class Router {
       log("processing", path);
       let routeConfig = this.createRouteConfig(path);
 
+      // renamed index should have a trailing slash like index files
+      if (!routeConfig.path.endsWith("/") && /\([^)/]+\)$/.test(routeConfig.id)) {
+        routeConfig.path += "/";
+      }
+
       if (this.routes[routeConfig.id]) {
         // get old config, we want to compare the oldConfig with the new one to
         // detect changes and restart the vite server


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The router does not generate the same path for a renamed index as it would for an index file.

Example:

|Index|Id|Path|Index (Renamed)|Id|Path|
|------|--|------|----------|-|----|
|index.tsx|/index|/|(home).tsx|/(home)||
|test/index.tsx|/test/index|`/test/`|test/(test).tsx|/test/(test)|`/test`|

This happens because `toPath` in `path-utils.js` removes every segment looking like a route group from the id which includes renamed index.

This also causes the static adapter to not generate an index.html for routes with a renamed index as it relies on the trailing slash.

## What is the new behavior?

When processing a route file, after creating the route config, check if the route id ends with a renamed index and add a trailing slash to the path.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

fixes #1012

Tests passed and did a quick manual test. Let's see if it breaks anything else... 🤣 