### PR TITLE
fix: examples build output not working inside the solid-start repo and update lock file

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build:all": "pnpm run -r --if-present build",
     "install:playwright": "pnpm --filter solid-start-tests run install:playwright",
     "test:all": "pnpm run clean:test && cross-env START_ADAPTER=solid-start-node npm run test",
-    "test:report": "pnpm --filter solid-start-tests report",
     "test": "pnpm run clean:test && pnpm --filter solid-start-tests test --",
     "show:test-report": "pnpm --filter solid-start-tests show:test-report",
     "bump": "node scripts/bump.cjs"

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -128,7 +128,7 @@
     "@types/node": "^18.16.19",
     "@types/wait-on": "^5.3.1",
     "jsdom": "^20.0.3",
-    "solid-js": "^1.7.9",
+    "solid-js": "^1.7.11",
     "solid-start-cloudflare-pages": "workspace:*",
     "solid-start-cloudflare-workers": "workspace:*",
     "solid-start-deno": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,7 +813,7 @@ importers:
         version: 0.17.19
       esbuild-plugin-solid:
         specifier: ^0.5.0
-        version: 0.5.0(esbuild@0.17.19)(solid-js@1.7.9)
+        version: 0.5.0(esbuild@0.17.19)(solid-js@1.7.11)
       fast-glob:
         specifier: ^3.3.0
         version: 3.3.0
@@ -861,7 +861,7 @@ importers:
         version: 0.7.33(rollup@3.26.2)(vite@4.4.6)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.9)(vite@4.4.6)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.4.6)
       wait-on:
         specifier: ^6.0.1
         version: 6.0.1(debug@4.3.4)
@@ -871,10 +871,10 @@ importers:
         version: 3.19.0
       '@solidjs/meta':
         specifier: ^0.28.5
-        version: 0.28.5(solid-js@1.7.9)
+        version: 0.28.5(solid-js@1.7.11)
       '@solidjs/router':
         specifier: ^0.8.2
-        version: 0.8.2(solid-js@1.7.9)
+        version: 0.8.2(solid-js@1.7.11)
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -891,8 +891,8 @@ importers:
         specifier: ^20.0.3
         version: 20.0.3
       solid-js:
-        specifier: ^1.7.9
-        version: 1.7.9
+        specifier: ^1.7.11
+        version: 1.7.11
       solid-start-cloudflare-pages:
         specifier: workspace:*
         version: link:../start-cloudflare-pages
@@ -916,7 +916,7 @@ importers:
         version: link:../start-vercel
       solid-testing-library:
         specifier: ^0.3.0
-        version: 0.3.0(solid-js@1.7.9)
+        version: 0.3.0(solid-js@1.7.11)
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -4007,7 +4007,6 @@ packages:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.7.11
-    dev: false
 
   /@solidjs/meta@0.28.5(solid-js@1.7.9):
     resolution: {integrity: sha512-52luJR6hVNMA1K8Od5OD0d8WVz/svqZG4is8lrDimiUGxdia3DzuLF+pK56dnEzbNt9cA42qVFL134U9LkC9Gg==}
@@ -4023,7 +4022,6 @@ packages:
       solid-js: ^1.5.3
     dependencies:
       solid-js: 1.7.11
-    dev: false
 
   /@solidjs/router@0.8.2(solid-js@1.7.9):
     resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
@@ -5932,7 +5930,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid@0.5.0(esbuild@0.17.19)(solid-js@1.7.9):
+  /esbuild-plugin-solid@0.5.0(esbuild@0.17.19)(solid-js@1.7.11):
     resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -5942,7 +5940,7 @@ packages:
       '@babel/preset-typescript': 7.22.5(@babel/core@7.22.9)
       babel-preset-solid: 1.7.7(@babel/core@7.22.9)
       esbuild: 0.17.19
-      solid-js: 1.7.9
+      solid-js: 1.7.11
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9566,6 +9564,7 @@ packages:
     dependencies:
       csstype: 3.1.0
       seroval: 0.5.1
+    dev: true
 
   /solid-mdx@0.0.6(solid-js@1.7.11)(vite@4.4.6):
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
@@ -9587,7 +9586,7 @@ packages:
       vite: 4.4.6
     dev: true
 
-  /solid-refresh@0.5.3(solid-js@1.7.9):
+  /solid-refresh@0.5.3(solid-js@1.7.11):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -9595,7 +9594,7 @@ packages:
       '@babel/generator': 7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@babel/types': 7.22.10
-      solid-js: 1.7.9
+      solid-js: 1.7.11
     dev: false
 
   /solid-ssr@1.7.2:
@@ -9642,7 +9641,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /solid-testing-library@0.3.0(solid-js@1.7.9):
+  /solid-testing-library@0.3.0(solid-js@1.7.11):
     resolution: {integrity: sha512-6NWVbySNVzyReBm2N6p3eF8bzxRZXHZTAmPix4vFWYol16QWVjNQsEUxvr+ZOutb0yuMZmNuGx3b6WIJYmjwMQ==}
     engines: {node: '>= 14'}
     deprecated: This package is now available at @solidjs/testing-library
@@ -9650,7 +9649,7 @@ packages:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 7.31.2
-      solid-js: 1.7.9
+      solid-js: 1.7.11
     dev: true
 
   /solid-trpc@0.1.0-sssr.7(@tanstack/solid-query@5.0.0-alpha.20)(@trpc/client@10.34.0)(@trpc/server@10.34.0)(solid-js@1.7.11)(solid-start@packages+start):
@@ -10525,7 +10524,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid@2.7.0(solid-js@1.7.9)(vite@4.4.6):
+  /vite-plugin-solid@2.7.0(solid-js@1.7.11)(vite@4.4.6):
     resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -10536,8 +10535,8 @@ packages:
       '@types/babel__core': 7.20.1
       babel-preset-solid: 1.7.7(@babel/core@7.22.9)
       merge-anything: 5.1.7
-      solid-js: 1.7.9
-      solid-refresh: 0.5.3(solid-js@1.7.9)
+      solid-js: 1.7.11
+      solid-refresh: 0.5.3(solid-js@1.7.11)
       vite: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
       vitefu: 0.2.4(vite@4.4.6)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1303,13 +1303,13 @@ importers:
         version: 0.1.3
       '@solidjs/meta':
         specifier: ^0.28.5
-        version: 0.28.5(solid-js@1.7.9)
+        version: 0.28.5(solid-js@1.7.11)
       '@solidjs/router':
         specifier: ^0.8.2
-        version: 0.8.2(solid-js@1.7.9)
+        version: 0.8.2(solid-js@1.7.11)
       solid-js:
-        specifier: ^1.7.9
-        version: 1.7.9
+        specifier: ^1.7.11
+        version: 1.7.11
       solid-start:
         specifier: workspace:*
         version: link:../../packages/start

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@types/node':
@@ -146,7 +146,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@types/babel__core':
@@ -189,7 +189,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
       solid-start-netlify:
         specifier: ^0.3.0
@@ -250,7 +250,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
       string_decoder:
         specifier: ^1.3.0
@@ -287,7 +287,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@types/node':
@@ -327,7 +327,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@types/babel__core':
@@ -373,7 +373,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@types/node':
@@ -413,7 +413,7 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6(solid-js@1.7.11)(vite@4.4.6)
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       '@mdx-js/rollup':
@@ -447,7 +447,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       solid-start-node:
@@ -472,7 +472,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
       solid-styled:
         specifier: ^0.8.2
@@ -506,7 +506,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       autoprefixer:
@@ -549,7 +549,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
       solid-start-trpc:
         specifier: ^0.0.16
@@ -643,7 +643,7 @@ importers:
         specifier: ^1.7.11
         version: 1.7.11
       solid-start:
-        specifier: ^0.3.2
+        specifier: ^0.3.3
         version: link:../../packages/start
     devDependencies:
       solid-start-cloudflare-workers:

--- a/test/template/package.json
+++ b/test/template/package.json
@@ -10,7 +10,7 @@
     "@cloudflare/kv-asset-handler": "^0.1.3",
     "@solidjs/meta": "^0.28.5",
     "@solidjs/router": "^0.8.2",
-    "solid-js": "^1.7.9",
+    "solid-js": "^1.7.11",
     "solid-start": "workspace:*",
     "solid-start-cloudflare-pages": "workspace:*",
     "solid-start-cloudflare-workers": "workspace:*",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Build output of examples inside the solid-start repo don't work.
Only inside the solid-start repo. Projects initialized with create-solid cli are **not** affected.

```
pnpm i
pnpm --filter example-bare run build
pnpm --filter example-bare run start
```

Result:

Counter button not working. Browser console showing:
```console
Uncaught TypeError: Cannot read properties of null (reading 'push')
    at nn (entry-client-0002a3d6.js:1:1062)
    at Object.fn (entry-client-0002a3d6.js:1:5465)
    at ln (entry-client-0002a3d6.js:1:2337)
    at Pe (entry-client-0002a3d6.js:1:2280)
    at oe (entry-client-0002a3d6.js:1:834)
    at Object.fn (entry-client-0002a3d6.js:1:5323)
    at ln (entry-client-0002a3d6.js:1:2337)
    at Pe (entry-client-0002a3d6.js:1:2280)
    at oe (entry-client-0002a3d6.js:1:834)
    at get children [as children] (entry-client-0002a3d6.js:1:5212)
```

## What is the new behavior?

Updated solid-js version of the solid-start package and test template to `^1.7.11`.

- Build output of examples work again inside the repo
- Tests work
  - They worked before but changing the solid-js version on solid-start requires to change it on the test template too
- GitHub tests should work again
- Removed non existing run script `test:report`

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

bump script may require an update to prevent all this in the future.

GitHub tests look ok. 
Windows versions show warnings for slow test files and one of the tests timing out.

```console
1) [chromium] › misc-test.ts:57:5 › miscellaneous tests › with SSR › should be able to create a server function inside of a .js file 

    "beforeAll" hook timeout of 120000ms exceeded.
```
