### PR TITLE
Allow passing in `routerProps` to `<StartClient`

### DIFF
--- a/packages/start/entry-client/StartClient.tsx
+++ b/packages/start/entry-client/StartClient.tsx
@@ -16,7 +16,22 @@ function throwClientError(field: string): any {
   );
 }
 
-export default () => {
+export default ({
+  routerProps
+}: {
+  /**
+   * Override props passed to `<Router`.
+   * 
+   * Only `source` is supported today.
+   * 
+   * If you need to pass in other props, please submit a PR.
+   */
+  // Before actually submitting a PR, you can test out the new prop like so:
+  //   import type { RouterProps } from "@solidjs/router";
+  //   const routerProps = { newProp } as RouterProps;
+  //   <StartClient routerProps={routerProps as unknown as undefined} />
+  routerProps?: Pick<RouterProps, 'source'>
+}) => {
   let mockFetchEvent: PageEvent = {
     get request() {
       if (process.env.NODE_ENV === "development") {
@@ -95,7 +110,7 @@ export default () => {
   return (
     <ServerContext.Provider value={mockFetchEvent}>
       <MetaProvider>
-        <StartRouter base={basePath} data={dataFn}>
+        <StartRouter base={basePath} data={dataFn} {...routerProps}>
           <Root />
         </StartRouter>
       </MetaProvider>

--- a/packages/start/entry-client/StartClient.tsx
+++ b/packages/start/entry-client/StartClient.tsx
@@ -31,7 +31,7 @@ export default ({
   //   const routerProps = { newProp } as RouterProps;
   //   <StartClient routerProps={routerProps as unknown as undefined} />
   routerProps?: Pick<RouterProps, 'source'>
-}) => {
+} = {}) => {
   let mockFetchEvent: PageEvent = {
     get request() {
       if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
Closes #96

When embedding a SolidStart app into a larger javascript app, users may need to customize the router source/integration, to avoid messing with the parent/host apps url. Users could use an in-memory based router, a [search-param based router](https://github.com/solidjs/solid-router/pull/291), hash-based router, etc.

## PR Checklist

There aren't any existing tests for `<StartClient`. I think in the future it would be good to add a "solid-as-a-micro-frontend" example, and we could add a test which ensures that example app renders with [`searchParamIntegration`](https://github.com/solidjs/solid-router/pull/291)

## PR Type

- [x] Feature

## What is the current behavior?
Use `patch-package` to pass in routerProps

## What is the new behavior?

Users can customize router source/integration.

## Other information

