### PR TITLE
fix: islands not hydrating when build on windows

### DIFF
--- a/packages/start/islands/vite-plugin.js
+++ b/packages/start/islands/vite-plugin.js
@@ -37,7 +37,7 @@ export function islands() {
             import { ${f[1]} } from '${id.replace(/\?.*/, "?client")}';
 
             window._$HY.island("${
-              mode.command === "serve" ? `/@fs/${id}` : `${relative(process.cwd(), id)}`
+              mode.command === "serve" ? `/@fs/${id}` : `${normalizePath(relative(process.cwd(), id))}`
             }",  ${f[1]});
 
             `


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

One path is not being normalized breaking island hydration when build on windows.

## What is the new behavior?

Islands working when build on windows.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
