### PR TITLE
fix: using network host errors during logging

### DIFF
--- a/packages/start/dev/server.js
+++ b/packages/start/dev/server.js
@@ -128,7 +128,7 @@ export function createDevHandler(viteServer, config, options) {
   async function startHandler(req, res) {
     try {
       if (viteServer.resolvedUrls) {
-        const url = viteServer.resolvedUrls.local[0];
+        const url = viteServer.resolvedUrls.local[0] ?? viteServer.resolvedUrls.network[0];
         console.log(req.method, new URL(req.url ?? "/", url).href);
       }
       let webRes = await devFetch({

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -238,7 +238,7 @@ function solidStartFileSystemRouter(options) {
         vite.httpServer.once("listening", async () => {
           setTimeout(() => {
             if (vite.resolvedUrls) {
-              const url = vite.resolvedUrls.local[0];
+              const url = vite.resolvedUrls.local[0] ?? vite.resolvedUrls.network[0];
               // eslint-disable-next-line no-console
               printUrls(config.solidOptions.router, url.substring(0, url.length - 1));
             }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Providing a network IP as Host option is ok for Vite but errors because of Solid's logging - it only accounts for `local` addresses.
See [Discord](https://discord.com/channels/722131463138705510/910635844119982080/1150662412337426482)

## What is the new behavior?
If no `local` address defined, try `network` address.

## Other information
Should have no runtime implication since these values are only collected for logging.