### PR TITLE
feat(bun): Add bun adapter

### DIFF
--- a/packages/start-bun/README.md
+++ b/packages/start-bun/README.md
@@ -1,0 +1,5 @@
+# start-bun
+
+Adapter for Solid apps that builds a Bun server.
+
+This is very experimental; the adapter API isn't at all fleshed out, and things will definitely change.

--- a/packages/start-bun/entry.js
+++ b/packages/start-bun/entry.js
@@ -1,0 +1,84 @@
+//@ts-check
+import fs from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+//@ts-ignore It will be generated when building.
+import manifest from "../../dist/public/route-manifest.json";
+//@ts-ignore It will be generated when building.
+import handler from "./entry-server.js";
+
+const { PORT = 3000 } = process.env;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const paths = {
+  assets: join(__dirname, "/public")
+};
+
+const hasAssets = fs.existsSync(paths.assets);
+const assetsWebPath = "/assets/";
+
+const env = { manifest };
+
+const server = Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const { pathname } = new URL(req.url);
+
+    /**
+     * @param {string} assetPath
+     */
+    env.getStaticHTML = async assetPath => {
+      let text = Bun.file(join(paths.assets, `${assetPath}.html`));
+      return new Response(text, {
+        headers: {
+          "content-type": "text/html"
+        }
+      });
+    };
+
+    function internalFetch(route, init = {}) {
+      if (route.startsWith("http")) {
+        return fetch(route, init);
+      }
+
+      let url = new URL(route, "http://internal");
+      const request = new Request(url.href, init);
+      console.log("[internal]", req.method, url.href);
+      return handler({
+        request: request,
+        httpServer: server,
+        clientAddress: "0.0.0.0", // FIXME
+        locals: {},
+        env,
+        fetch: internalFetch
+      });
+    }
+
+    if (hasAssets && pathname.startsWith(assetsWebPath)) {
+      try {
+        const assetFile = Bun.file(join(paths.assets, pathname));
+        const blob = await assetFile.arrayBuffer();
+        return new Response(blob, {
+          headers: {
+            "content-type": assetFile.type,
+            "cache-control": "public, max-age=31536000, immutable"
+          }
+        });
+      } catch (e) {
+        console.log("[assets] not found: %s", pathname);
+      }
+    }
+
+    const response = await handler({
+      request: req,
+      httpServer: server,
+      clientAddress: "0.0.0.0", // FIXME
+      locals: {},
+      env,
+      fetch: internalFetch
+    });
+
+    return response;
+  },
+});

--- a/packages/start-bun/index.js
+++ b/packages/start-bun/index.js
@@ -1,0 +1,60 @@
+import common from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { rollup } from "rollup";
+import { createAdapter } from "solid-start/vite";
+import { fileURLToPath, pathToFileURL } from "url";
+
+export default function bunAdapter() {
+  return createAdapter({
+    name: "bun",
+    start: (config, { port }) => {
+      process.env.PORT = port;
+      import(pathToFileURL(join(config.root, "dist", "server.js")).toString());
+      return `http://localhost:${process.env.PORT}`;
+    },
+    async build(config, builder) {
+      const ssrExternal = config?.ssr?.external || [];
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+
+      if (!config.solidOptions.ssr) {
+        await builder.spaClient(join(config.root, "dist", "public"));
+        await builder.server(join(config.root, ".solid", "server"));
+      } else if (config.solidOptions.experimental.islands) {
+        await builder.islandsClient(join(config.root, "dist", "public"));
+        await builder.server(join(config.root, ".solid", "server"));
+      } else {
+        await builder.client(join(config.root, "dist", "public"));
+        await builder.server(join(config.root, ".solid", "server"));
+      }
+
+      let text = readFileSync(join(__dirname, "entry.js")).toString();
+
+      writeFileSync(join(config.root, ".solid", "server", "server.js"), text);
+
+      builder.debug(`bundling server with rollup`);
+
+      const bundle = await rollup({
+        input: join(config.root, ".solid", "server", "server.js"),
+        plugins: [
+          json(),
+          nodeResolve({
+            preferBuiltins: true,
+            exportConditions: ["node", "solid"]
+          }),
+          common({ strictRequires: true, ...config.build.commonjsOptions })
+        ],
+        external: ["stream/web", ...ssrExternal]
+      });
+      // or write the bundle to disk
+      await bundle.write({ format: "esm", dir: join(config.root, "dist") });
+
+      // closes the bundle
+      await bundle.close();
+
+      builder.debug(`bundling server done`);
+    }
+  });
+}

--- a/packages/start-bun/package.json
+++ b/packages/start-bun/package.json
@@ -7,16 +7,10 @@
     "type": "adapter"
   },
   "dependencies": {
-    "@elysiajs/static": "^0.6.0",
     "@rollup/plugin-commonjs": "^24.1.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
-    "compression": "^1.7.4",
-    "elysia": "^0.6.22",
-    "polka": "1.0.0-next.22",
-    "rollup": "^3.26.2",
-    "sirv": "^2.0.3",
-    "terser": "^5.19.0"
+    "rollup": "^3.26.2"
   },
   "devDependencies": {
     "bun-types": "^1.0.1",

--- a/packages/start-bun/package.json
+++ b/packages/start-bun/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "solid-start-bun",
+  "version": "0.3.5",
+  "main": "./index.js",
+  "type": "module",
+  "solid": {
+    "type": "adapter"
+  },
+  "dependencies": {
+    "@elysiajs/static": "^0.6.0",
+    "@rollup/plugin-commonjs": "^24.1.0",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.1.0",
+    "compression": "^1.7.4",
+    "elysia": "^0.6.22",
+    "polka": "1.0.0-next.22",
+    "rollup": "^3.26.2",
+    "sirv": "^2.0.3",
+    "terser": "^5.19.0"
+  },
+  "devDependencies": {
+    "bun-types": "^1.0.1",
+    "solid-start": "workspace:*",
+    "vite": "^4.4.6"
+  },
+  "peerDependencies": {
+    "solid-start": "*",
+    "vite": "*"
+  }
+}

--- a/packages/start/node/globals.js
+++ b/packages/start/node/globals.js
@@ -1,7 +1,14 @@
 import crypto from "crypto";
 import Streams from "stream/web";
 
-Object.assign(globalThis, Streams);
+// Bun does not support this assignment.
+// We only assign globalThis if the runtime
+// is not Bun.
+//
+// https://bun.sh/guides/util/detect-bun
+if (!process.versions.bun) {
+  Object.assign(globalThis, Streams);
+}
 
 if (globalThis.crypto != crypto.webcrypto) {
   // @ts-ignore

--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -632,6 +632,19 @@ const findAny = (path, name, exts = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts
   return null;
 };
 
+const findAdapter = () => {
+  if (process.env.START_ADAPTER) {
+    return process.env.START_ADAPTER;
+  }
+
+  // https://bun.sh/guides/util/detect-bun
+  if (process.versions.bun) {
+    return "solid-start-bun";
+  }
+
+  return "solid-start-node";
+}
+
 /**
  * @param {import('./plugin').Options} options
  * @returns {import('vite').PluginOption[]}
@@ -639,7 +652,7 @@ const findAny = (path, name, exts = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts
 export default function solidStart(options) {
   options = Object.assign(
     {
-      adapter: process.env.START_ADAPTER ? process.env.START_ADAPTER : "solid-start-node",
+      adapter: findAdapter(),
       appRoot: "src",
       routesDir: "routes",
       ssr:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 4.7.4
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -273,7 +273,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
 
   examples/todomvc:
     dependencies:
@@ -427,7 +427,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
 
   examples/with-prisma:
     dependencies:
@@ -458,7 +458,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
 
   examples/with-solid-styled:
     dependencies:
@@ -489,7 +489,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
       vite-plugin-solid-styled:
         specifier: ^0.8.3
         version: 0.8.3(rollup@3.26.2)(solid-styled@0.8.2)(vite@4.4.9)
@@ -526,7 +526,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
 
   examples/with-trpc:
     dependencies:
@@ -620,7 +620,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
       vitest:
         specifier: ^0.26.3
         version: 0.26.3(@vitest/ui@0.26.3)(jsdom@20.0.3)
@@ -654,7 +654,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.0)
+        version: 4.4.9(@types/node@18.16.19)
 
   packages/create-solid:
     devDependencies:
@@ -950,7 +950,32 @@ importers:
         version: link:../start
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
+
+  packages/start-bun:
+    dependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^24.1.0
+        version: 24.1.0(rollup@3.28.0)
+      '@rollup/plugin-json':
+        specifier: ^6.0.0
+        version: 6.0.0(rollup@3.28.0)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.1.0
+        version: 15.1.0(rollup@3.28.0)
+      rollup:
+        specifier: ^3.26.2
+        version: 3.28.0
+    devDependencies:
+      bun-types:
+        specifier: ^1.0.1
+        version: 1.0.1
+      solid-start:
+        specifier: workspace:*
+        version: link:../start
+      vite:
+        specifier: ^4.4.6
+        version: 4.4.9(@types/node@18.16.19)
 
   packages/start-cloudflare-pages:
     dependencies:
@@ -1085,7 +1110,7 @@ importers:
         version: link:../start
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
 
   packages/start-netlify:
     dependencies:
@@ -1122,7 +1147,7 @@ importers:
         version: link:../start
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
 
   packages/start-node:
     dependencies:
@@ -1156,7 +1181,7 @@ importers:
         version: link:../start
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
 
   packages/start-static:
     dependencies:
@@ -1187,7 +1212,7 @@ importers:
         version: 5.19.0
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
 
   packages/start-vercel:
     dependencies:
@@ -1221,7 +1246,7 @@ importers:
         version: link:../start
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
 
   test:
     dependencies:
@@ -1284,7 +1309,7 @@ importers:
         version: 5.22.1
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(@types/node@18.16.19)
       vitest:
         specifier: ^0.28.5
         version: 0.28.5
@@ -1336,7 +1361,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.4.6
-        version: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+        version: 4.4.6(terser@5.19.0)
       wrangler:
         specifier: ^2.20.0
         version: 2.20.0
@@ -3920,6 +3945,24 @@ packages:
       magic-string: 0.27.0
       rollup: 3.26.2
 
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.28.0):
+    resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.3(rollup@3.28.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.27.0
+      rollup: 3.28.0
+    dev: false
+
   /@rollup/plugin-json@4.0.0(rollup@2.78.0):
     resolution: {integrity: sha512-Z65CtEVWv40+ri4CvmswyhtuUtki9yP5p0UJN/GyCKKyU4jRuDS9CG0ZuV7/XuS7zGkoajyE7E4XBEaC4GW62A==}
     peerDependencies:
@@ -3940,6 +3983,19 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       rollup: 3.26.2
+
+  /@rollup/plugin-json@6.0.0(rollup@3.28.0):
+    resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.3(rollup@3.28.0)
+      rollup: 3.28.0
+    dev: false
 
   /@rollup/plugin-node-resolve@13.0.2(rollup@2.78.0):
     resolution: {integrity: sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==}
@@ -3972,6 +4028,24 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.4
       rollup: 3.26.2
+
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.28.0):
+    resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.3(rollup@3.28.0)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.4
+      rollup: 3.28.0
+    dev: false
 
   /@rollup/pluginutils@3.1.0(rollup@2.78.0):
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
@@ -4896,6 +4970,10 @@ packages:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
       semver: 7.5.4
+
+  /bun-types@1.0.1:
+    resolution: {integrity: sha512-7NrXqhMIaNKmWn2dSWEQ50znMZqrN/5Z0NBMXvQTRu/+Y1CvoXRznFy0pnqLe024CeZgVdXoEpARNO1JZLAPGw==}
+    dev: true
 
   /bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -9687,7 +9765,7 @@ packages:
       vite: '*'
     dependencies:
       solid-js: 1.7.11
-      vite: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+      vite: 4.4.6
     dev: true
 
   /solid-mdx@0.0.6(solid-js@1.7.11)(vite@4.4.9):
@@ -9697,7 +9775,7 @@ packages:
       vite: '*'
     dependencies:
       solid-js: 1.7.11
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9
     dev: false
 
   /solid-refresh@0.5.3(solid-js@1.7.11):
@@ -10591,7 +10669,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+      vite: 4.4.9(@types/node@18.16.19)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10632,7 +10710,7 @@ packages:
       '@babel/core': 7.22.10
       '@rollup/pluginutils': 5.0.3(rollup@3.26.2)
       solid-styled: 0.8.2(@babel/core@7.22.10)(solid-js@1.7.11)
-      vite: 4.4.9(@types/node@20.5.0)
+      vite: 4.4.9
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -10692,6 +10770,77 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite@4.4.6:
+    resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@4.4.6(@types/node@18.16.19):
+    resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.19
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
   /vite@4.4.6(@types/node@18.16.19)(terser@5.19.0):
     resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -10725,6 +10874,111 @@ packages:
       postcss: 8.4.28
       rollup: 3.26.2
       terser: 5.19.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@4.4.6(terser@5.19.0):
+    resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.0
+      terser: 5.19.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@4.4.9:
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@4.4.9(@types/node@18.16.19):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.19
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10798,6 +11052,7 @@ packages:
       rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vite@4.4.9(sass@1.65.1):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
@@ -10982,7 +11237,7 @@ packages:
       tinybench: 2.5.0
       tinypool: 0.3.1
       tinyspy: 1.1.1
-      vite: 4.4.6(@types/node@18.16.19)(terser@5.19.0)
+      vite: 4.4.9(@types/node@18.16.19)
       vite-node: 0.28.5(@types/node@18.16.19)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
Experimental but works 🚀

![image](https://github.com/solidjs/solid-start/assets/28441561/a988d2ac-7b59-4db4-aa5c-f940d1f27021)

## TODOs

- [x] `bun run --bun build`
- [x] `bun run --bun start`
- [x] `bun run --bun dev`
- [ ] Support clientIP (https://github.com/oven-sh/bun/pull/4559)

## Usage

The `--bun` flag is essential; otherwise, this server will be spawned by Node.

```bash
export START_ADAPTER="solid-start-bun"

bun run --bun build
bun run --bun start
```

## Benchmark

wrk command: `wrk -t8 -c500 -d10s --latency "http://localhost:3000"`
system: macOS 13.5.2, on Apple M1.

| Platform | Base RAM usage | Requests/sec | RAM usage after `wrk` |
| --- | --- | --- | --- |
| Node | 22.2MB | 3107.68 | 126.5MB |
| Bun | 16.8MB | 7057.49 | 112.2MB |