### PR TITLE
feat(start/node): Don't `Object.assign` on Bun

### DIFF
--- a/packages/start/node/globals.js
+++ b/packages/start/node/globals.js
@@ -1,7 +1,14 @@
 import crypto from "crypto";
 import Streams from "stream/web";
 
-Object.assign(globalThis, Streams);
+// Bun does not support this assignment.
+// We only assign globalThis if the runtime
+// is not Bun.
+//
+// https://bun.sh/guides/util/detect-bun
+if (!process.versions.bun) {
+  Object.assign(globalThis, Streams);
+}
 
 if (globalThis.crypto != crypto.webcrypto) {
   // @ts-ignore


### PR DESCRIPTION
```
3 | 
4 | // FIXME: Bun does not support this assignment.
5 | // We only assign if the runtime is not Bun.
6 | //
7 | // https://bun.sh/guides/util/detect-bun
8 | Object.assign(globalThis, Streams);
   ^
TypeError: Attempted to assign to readonly property.
      at /private/tmp/solid/test/node_modules/solid-start/node/globals.js:8:0
      at processTicksAndRejections (:1:2602)
```

Ready for #1059