### PR TITLE
fix: api and inlineServerFunctions middleware being called twice on page request

### DIFF
--- a/packages/start/server/render.ts
+++ b/packages/start/server/render.ts
@@ -1,9 +1,7 @@
 import { JSX } from "solid-js";
 import { renderToStream, renderToString, renderToStringAsync } from "solid-js/web";
-import { apiRoutes } from "../api/middleware";
-import { inlineServerFunctions } from "../server/middleware";
 import { redirect } from "../server/responses";
-import { FetchEvent, FETCH_EVENT, PageEvent } from "../server/types";
+import { FETCH_EVENT, FetchEvent, PageEvent } from "../server/types";
 
 export function renderSync(
   fn: (context: PageEvent) => JSX.Element,
@@ -12,37 +10,33 @@ export function renderSync(
     renderId?: string;
   }
 ) {
-  return () => apiRoutes({
-    forward: inlineServerFunctions({
-      async forward(event: FetchEvent): Promise<Response> {
-        if (
-          !import.meta.env.DEV &&
-          !import.meta.env.START_SSR &&
-          !import.meta.env.START_INDEX_HTML
-        ) {
-          return (
-            (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
-          );
-        }
+  return () => async (event: FetchEvent) => {
+    if (
+      !import.meta.env.DEV &&
+      !import.meta.env.START_SSR &&
+      !import.meta.env.START_INDEX_HTML
+    ) {
+      return (
+        (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
+      );
+    }
 
-        let pageEvent = createPageEvent(event);
+    let pageEvent = createPageEvent(event);
 
-        let markup = renderToString(() => fn(pageEvent), options);
-        if (pageEvent.routerContext && pageEvent.routerContext.url) {
-          return redirect(pageEvent.routerContext.url, {
-            headers: pageEvent.responseHeaders
-          });
-        }
+    let markup = renderToString(() => fn(pageEvent), options);
+    if (pageEvent.routerContext && pageEvent.routerContext.url) {
+      return redirect(pageEvent.routerContext.url, {
+        headers: pageEvent.responseHeaders
+      });
+    }
 
-        markup = handleIslandsRouting(pageEvent, markup);
+    markup = handleIslandsRouting(pageEvent, markup);
 
-        return new Response(markup, {
-          status: pageEvent.getStatusCode(),
-          headers: pageEvent.responseHeaders
-        });
-      }
-    })
-  });
+    return new Response(markup, {
+      status: pageEvent.getStatusCode(),
+      headers: pageEvent.responseHeaders
+    });
+  }
 }
 
 export function renderAsync(
@@ -53,38 +47,34 @@ export function renderAsync(
     renderId?: string;
   }
 ) {
-  return () => apiRoutes({
-    forward: inlineServerFunctions({
-      async forward(event: FetchEvent): Promise<Response> {
-        if (
-          !import.meta.env.DEV &&
-          !import.meta.env.START_SSR &&
-          !import.meta.env.START_INDEX_HTML
-        ) {
-          return (
-            (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
-          );
-        }
+  return () => async (event: FetchEvent) => {
+    if (
+      !import.meta.env.DEV &&
+      !import.meta.env.START_SSR &&
+      !import.meta.env.START_INDEX_HTML
+    ) {
+      return (
+        (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
+      );
+    }
 
-        let pageEvent = createPageEvent(event);
+    let pageEvent = createPageEvent(event);
 
-        let markup = await renderToStringAsync(() => fn(pageEvent), options);
+    let markup = await renderToStringAsync(() => fn(pageEvent), options);
 
-        if (pageEvent.routerContext && pageEvent.routerContext.url) {
-          return redirect(pageEvent.routerContext.url, {
-            headers: pageEvent.responseHeaders
-          }) as Response;
-        }
+    if (pageEvent.routerContext && pageEvent.routerContext.url) {
+      return redirect(pageEvent.routerContext.url, {
+        headers: pageEvent.responseHeaders
+      }) as Response;
+    }
 
-        markup = handleIslandsRouting(pageEvent, markup);
+    markup = handleIslandsRouting(pageEvent, markup);
 
-        return new Response(markup, {
-          status: pageEvent.getStatusCode(),
-          headers: pageEvent.responseHeaders
-        });
-      }
-    })
-  });
+    return new Response(markup, {
+      status: pageEvent.getStatusCode(),
+      headers: pageEvent.responseHeaders
+    });
+  }
 }
 
 export function renderStream(
@@ -96,68 +86,64 @@ export function renderStream(
     onCompleteAll?: (info: { write: (v: string) => void }) => void;
   } = {}
 ) {
-  return () => apiRoutes({
-    forward: inlineServerFunctions({
-      async forward(event: FetchEvent): Promise<Response> {
-        if (
-          !import.meta.env.DEV &&
-          !import.meta.env.START_SSR &&
-          !import.meta.env.START_INDEX_HTML
-        ) {
-          return (
-            (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
-          );
-        }
+  return () => async (event: FetchEvent) => {
+    if (
+      !import.meta.env.DEV &&
+      !import.meta.env.START_SSR &&
+      !import.meta.env.START_INDEX_HTML
+    ) {
+      return (
+        (await event.env.getStaticHTML?.("/index")) ?? new Response("Not Found", { status: 404 })
+      );
+    }
 
-        let pageEvent = createPageEvent(event);
+    let pageEvent = createPageEvent(event);
 
-        // Hijack after navigation with islands router to be async
-        // Todo streaming into HTML
-        if (import.meta.env.START_ISLANDS_ROUTER && event.request.headers.get("x-solid-referrer")) {
-          let markup = await renderToStringAsync(() => fn(pageEvent), baseOptions);
+    // Hijack after navigation with islands router to be async
+    // Todo streaming into HTML
+    if (import.meta.env.START_ISLANDS_ROUTER && event.request.headers.get("x-solid-referrer")) {
+      let markup = await renderToStringAsync(() => fn(pageEvent), baseOptions);
 
-          if (pageEvent.routerContext && pageEvent.routerContext.url) {
-            return redirect(pageEvent.routerContext.url, {
-              headers: pageEvent.responseHeaders
-            }) as Response;
-          }
-
-          markup = handleIslandsRouting(pageEvent, markup);
-
-          return new Response(markup, {
-            status: pageEvent.getStatusCode(),
-            headers: pageEvent.responseHeaders
-          });
-        }
-
-        const options = { ...baseOptions };
-        if (options.onCompleteAll) {
-          const og = options.onCompleteAll;
-          options.onCompleteAll = options => {
-            handleStreamingRedirect(pageEvent)(options);
-            og(options);
-          };
-        } else options.onCompleteAll = handleStreamingRedirect(pageEvent);
-        const { readable, writable } = new TransformStream();
-        const stream = renderToStream(() => fn(pageEvent), options);
-
-        if (pageEvent.routerContext && pageEvent.routerContext.url) {
-          return redirect(pageEvent.routerContext.url, {
-            headers: pageEvent.responseHeaders
-          });
-        }
-
-        handleStreamingIslandsRouting(pageEvent, writable);
-
-        stream.pipeTo(writable);
-
-        return new Response(readable, {
-          status: pageEvent.getStatusCode(),
+      if (pageEvent.routerContext && pageEvent.routerContext.url) {
+        return redirect(pageEvent.routerContext.url, {
           headers: pageEvent.responseHeaders
-        });
+        }) as Response;
       }
-    })
-  });
+
+      markup = handleIslandsRouting(pageEvent, markup);
+
+      return new Response(markup, {
+        status: pageEvent.getStatusCode(),
+        headers: pageEvent.responseHeaders
+      });
+    }
+
+    const options = { ...baseOptions };
+    if (options.onCompleteAll) {
+      const og = options.onCompleteAll;
+      options.onCompleteAll = options => {
+        handleStreamingRedirect(pageEvent)(options);
+        og(options);
+      };
+    } else options.onCompleteAll = handleStreamingRedirect(pageEvent);
+    const { readable, writable } = new TransformStream();
+    const stream = renderToStream(() => fn(pageEvent), options);
+
+    if (pageEvent.routerContext && pageEvent.routerContext.url) {
+      return redirect(pageEvent.routerContext.url, {
+        headers: pageEvent.responseHeaders
+      });
+    }
+
+    handleStreamingIslandsRouting(pageEvent, writable);
+
+    stream.pipeTo(writable);
+
+    return new Response(readable, {
+      status: pageEvent.getStatusCode(),
+      headers: pageEvent.responseHeaders
+    });
+  }
 }
 
 function handleStreamingIslandsRouting(pageEvent: PageEvent, writable: WritableStream<any>) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When requesting a page the `api` and `inlineServerFunctions` middleware gets called twice.
This happens because this two middlewares are called again inside the render middleware.

https://github.com/solidjs/solid-start/blob/043577a6400b8461baa2345e70b665f86da9692f/packages/start/entry-server/index.ts#L40

https://github.com/solidjs/solid-start/blob/043577a6400b8461baa2345e70b665f86da9692f/packages/start/server/render.ts#L15-L17

Created by the big merge. 
`server/render.ts` = original (before merge)
`entry-server/index.tsx` = new (after merge)

## What is the new behavior?

On page request the two middlewares get only called once.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

Decided to keep the new code.