### PR TITLE
Allow . in Netlify edge function paths

### DIFF
--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -72,7 +72,7 @@ export default function ({ edge } = {}) {
   "functions": [
     {
       "function": "index",
-      "pattern": "^[^.]*$"
+      "path": "/*"
     }
   ],
   "version": 1


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When deploying as a Netlify edge function, it explicitly does not handle any paths containing a "." character.

These paths fall through to the default Netlify 404 page (not the project's own 404).

## What is the new behavior?

All requests are handled by the edge function. If the project has its own 404 page, we don't ever see the default Netlify 404.

## Other information

I've manually tested that this covers the following cases:
- static asset (with or without `.` in name)
- dynamic routes (with or without `.` in name)
- internal `fetch` of static asset (from `public`)
- internal `fetch` of dynamic route

If you'd like me to put together a test, let me know. It's not really specific to Netlify so I guess it doesn't belong in this package.