### PR TITLE
Avoid overwriting localStorage.debug

### DIFF
--- a/packages/start/entry-client/mount.tsx
+++ b/packages/start/entry-client/mount.tsx
@@ -11,7 +11,14 @@ declare global {
 }
 
 if (import.meta.env.DEV) {
-  localStorage.setItem("debug", import.meta.env.DEBUG ?? "start*");
+  // Append `start:*` to the list of debug namespaces
+  const existingDebug = localStorage.getItem("debug") || "";
+  const debugNamespaces = existingDebug.split(",").filter(Boolean);
+  if (!debugNamespaces.includes("start:*")) {
+    debugNamespaces.push("start:*");
+    localStorage.setItem("debug", debugNamespaces.join(","));
+  }
+
   // const { default: createDebugger } = await import("debug");
   // window._$DEBUG = createDebugger("start:client");
   window._$DEBUG = console.log as unknown as any;

--- a/packages/start/fs-router/router.js
+++ b/packages/start/fs-router/router.js
@@ -8,7 +8,7 @@ import fs from "fs";
 import path, { join } from "path";
 import { toPath } from "./path-utils.js";
 
-const log = debug("solid-start");
+const log = debug("start:fs-router:router");
 
 // Available HTTP methods / verbs for api routes
 // `delete` is a reserved word in JS, so we use `del` instead

--- a/packages/start/fs-router/router.js
+++ b/packages/start/fs-router/router.js
@@ -135,14 +135,15 @@ export class Router {
   processFile(path) {
     // if its a route data function
     if (path.match(this.pageDataRegex)) {
+      log("processFile: pageDataRegex matched", { path });
       let id = this.getRouteId(path.replace(this.pageDataRegex, ""));
       this.setRouteData(id, path);
       return;
     }
 
-    // if its a possible page due to its extension
+    // if it's a possible page due to its extension
     if (this.isRoute(path)) {
-      log("processing", path);
+      log("processFile: isRoute() matched", { path });
       let routeConfig = this.createRouteConfig(path);
 
       // renamed index should have a trailing slash like index files


### PR DESCRIPTION
- Avoid overwriting existing debug namespaces
- Use "start:" prefix for debug messages in router
- Log both route-matches and route-data matches

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

see #1083

## What is the new behavior?

Existing value of `localStorage.debug` is maintained, `'start:*'` is added to it, if needed.
