### PR TITLE
add omitNestedClosingTags to types

### DIFF
--- a/packages/start/vite/plugin.d.ts
+++ b/packages/start/vite/plugin.d.ts
@@ -20,6 +20,7 @@ export type Options = Omit<import("vite-plugin-solid").Options, "ssr"> & {
   rootEntry: string;
   serverEntry: string;
   clientEntry: string;
+  omitNestedClosingTags: boolean;
   router: import("../fs-router/router").Router;
 };
 


### PR DESCRIPTION
Typescript is complaining about [omitNestedClosingTags](https://github.com/solidjs/solid/blob/main/CHANGELOG.md#smaller-templates) missing in vite config.

This PR might not be needed if https://github.com/solidjs/vite-plugin-solid/pull/122 is merged.

