### PR TITLE
New prop serialization step

### DIFF
--- a/packages/start/islands/index.tsx
+++ b/packages/start/islands/index.tsx
@@ -1,8 +1,7 @@
-import { Component, ComponentProps, lazy, sharedConfig } from "solid-js";
+import { Component, ComponentProps, createUniqueId, lazy, sharedConfig } from "solid-js";
 import { Hydration, NoHydration } from "solid-js/web";
 import { useRequest } from "../server/ServerContext";
 import { IslandManifest } from "../server/types";
-import { splitProps } from "./utils";
 export { default as clientOnly } from "./clientOnly";
 
 declare module "solid-js" {
@@ -66,8 +65,12 @@ export function island<T extends Component<any>>(
         return <Component {...props} />;
       }
 
+      // FIXME Introduce a new ID generation scheme
+      // for islands
+      const id = createUniqueId();
+
       sharedConfig.context.serialize(
-        // TODO how to get the ID?
+        id,
         props,
       );
       
@@ -75,6 +78,7 @@ export function island<T extends Component<any>>(
       return (
         <Hydration>
           <solid-island
+            data-id={id}
             data-component={fpath!}
             data-island={path}
             data-when={(props as any)["client:idle"] ? "idle" : "load"}

--- a/packages/start/islands/mount.tsx
+++ b/packages/start/islands/mount.tsx
@@ -21,7 +21,7 @@ export function hydrateServerRouter() {
     if (!Component || !el.dataset.hk) return;
 
     let hk = el.dataset.hk;
-    _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
+    // _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
 
     let props = createStore({
       ...JSON.parse(el.dataset.props!),
@@ -38,7 +38,7 @@ export function hydrateServerRouter() {
     map.set(el, props);
 
     hydrate(() => createComponent(Component, props[0]), el, {
-      renderId: hk.slice(0, hk.length - 1) + `${1 + Number(el.dataset.offset)}-`,
+      renderId: el.dataset.id,
       owner: lookupOwner(el)
     });
 


### PR DESCRIPTION
# 🚧 WORK IN PROGRESS 🚧

This PR utilizes the new `sharedConfig.context.serialize`. The current prop serialization process is pretty limited and brings a lot of problems, mainly the deduping problem which the new `serialize` method solves. Of course this is all for consistency.

The challenge right now is how to generate the ID for both the `serialize` and the hydration's `renderId`. Currently, hydration step hack its way through by extracting the `renderId` from the `data-hk`. ID must now be known on the server so we can map the serialized props on the client (since the props is no longer in the `solid-island` element), as well as utilize it for `renderId`