### PR TITLE
feat: new serialization

### DIFF
--- a/packages/start/islands/index.tsx
+++ b/packages/start/islands/index.tsx
@@ -1,15 +1,15 @@
-import { Component, ComponentProps, lazy, sharedConfig } from "solid-js";
+import { Component, ComponentProps, createUniqueId, lazy, sharedConfig } from "solid-js";
+import { HydrationContext } from "solid-js/types/render/hydration";
 import { Hydration, NoHydration } from "solid-js/web";
 import { useRequest } from "../server/ServerContext";
 import { IslandManifest } from "../server/types";
-import { splitProps } from "./utils";
 export { default as clientOnly } from "./clientOnly";
 
 declare module "solid-js" {
   namespace JSX {
     interface IntrinsicElements {
       "solid-island": {
-        "data-props": string;
+        "data-id": string;
         "data-component": string;
         "data-island": string;
         "data-when": "idle" | "load";
@@ -21,6 +21,11 @@ declare module "solid-js" {
     }
   }
 }
+
+
+interface HydrationContextWithSerialize extends HydrationContext {
+  serialize(id: string, value: unknown): void;
+};
 
 export function island<T extends Component<any>>(
   Comp:
@@ -45,11 +50,9 @@ export function island<T extends Component<any>>(
     );
   }
 
-  return ((compProps: ComponentProps<T>) => {
+  return ((props: ComponentProps<T>) => {
     if (import.meta.env.SSR) {
       const context = useRequest();
-      const [, props] = splitProps(compProps, ["children"] as any);
-      const [, spreadProps] = splitProps(compProps, [] as any);
 
       let fpath: string;
       let styles: string[] = [];
@@ -64,42 +67,36 @@ export function island<T extends Component<any>>(
         fpath = path;
       }
 
-      const serialize = (props: ComponentProps<T>) => {
-        let offset = 0;
-        let el = JSON.stringify(props, (key, value) => {
-          if (value && value.t) {
-            offset++;
-            return undefined;
-          }
-          return value;
-        });
-
-        return {
-          "data-props": el,
-          "data-offset": offset
-        };
-      };
-
       // @ts-expect-error
       if (!sharedConfig.context?.noHydrate) {
-        return <Component {...compProps} />;
+        return <Component {...props} />;
       }
+
+      // TODO islands ID
+      // Ideally we'd want to create a similar mechanism
+      // to createUniqueId except that we treat
+      // islands as their own tree rather than
+      // createUniqueId's ownership tree.
+      const id = createUniqueId();
+      (sharedConfig.context as HydrationContextWithSerialize).serialize(
+        id,
+        props,
+      );
 
       return (
         <Hydration>
           <solid-island
+            data-id={id}
             data-component={fpath!}
             data-island={path}
             data-when={(props as any)["client:idle"] ? "idle" : "load"}
             data-css={JSON.stringify(styles)}
-            {...serialize(props)}
           >
-            <IslandComponent {...spreadProps} />
+            <IslandComponent {...props} />
           </solid-island>
         </Hydration>
       );
-    } else {
-      return <Component {...compProps} />;
     }
+    return <Component {...props} />;
   }) as T;
 }

--- a/packages/start/islands/mount.tsx
+++ b/packages/start/islands/mount.tsx
@@ -1,4 +1,5 @@
 import { diff, Patch } from "micromorph";
+import { sharedConfig } from "solid-js";
 import { createStore } from "solid-js/store";
 import { createComponent, getHydrationKey, getOwner, hydrate } from "solid-js/web";
 
@@ -18,13 +19,13 @@ export function hydrateServerRouter() {
     }
 
     let Component = window._$HY.islandMap[el.dataset.island!];
-    if (!Component || !el.dataset.hk) return;
-
-    let hk = el.dataset.hk;
-    _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
+    let islandID = el.dataset.id;
+    if (!Component || !islandID || !sharedConfig.load) return;
+    // _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
 
     let props = createStore({
-      ...JSON.parse(el.dataset.props!),
+      ...sharedConfig.load(islandID),
+      // TODO children props,
       get children() {
         const p = el.getElementsByTagName("solid-children");
         getHydrationKey();
@@ -38,12 +39,9 @@ export function hydrateServerRouter() {
     map.set(el, props);
 
     hydrate(() => createComponent(Component, props[0]), el, {
-      renderId: hk.slice(0, hk.length - 1) + `${1 + Number(el.dataset.offset)}-`,
+      renderId: islandID,
       owner: lookupOwner(el)
     });
-
-    delete el.dataset.hk;
-    el.dataset.hkk = hk;
   }
 
   let queue: HTMLElement[] = [];

--- a/packages/start/islands/mount.tsx
+++ b/packages/start/islands/mount.tsx
@@ -1,5 +1,4 @@
 import { diff, Patch } from "micromorph";
-import { sharedConfig } from "solid-js";
 import { createStore } from "solid-js/store";
 import { createComponent, getHydrationKey, getOwner, hydrate } from "solid-js/web";
 
@@ -19,13 +18,13 @@ export function hydrateServerRouter() {
     }
 
     let Component = window._$HY.islandMap[el.dataset.island!];
-    let islandID = el.dataset.id;
-    if (!Component || !islandID || !sharedConfig.load) return;
-    // _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
+    if (!Component || !el.dataset.hk) return;
+
+    let hk = el.dataset.hk;
+    _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
 
     let props = createStore({
-      ...sharedConfig.load(islandID),
-      // TODO children props,
+      ...JSON.parse(el.dataset.props!),
       get children() {
         const p = el.getElementsByTagName("solid-children");
         getHydrationKey();
@@ -39,9 +38,12 @@ export function hydrateServerRouter() {
     map.set(el, props);
 
     hydrate(() => createComponent(Component, props[0]), el, {
-      renderId: islandID,
+      renderId: hk.slice(0, hk.length - 1) + `${1 + Number(el.dataset.offset)}-`,
       owner: lookupOwner(el)
     });
+
+    delete el.dataset.hk;
+    el.dataset.hkk = hk;
   }
 
   let queue: HTMLElement[] = [];

--- a/packages/start/islands/mount.tsx
+++ b/packages/start/islands/mount.tsx
@@ -1,6 +1,7 @@
 import { diff, Patch } from "micromorph";
+import { sharedConfig } from "solid-js";
 import { createStore } from "solid-js/store";
-import { createComponent, getHydrationKey, getOwner, hydrate } from "solid-js/web";
+import { createComponent, hydrate } from "solid-js/web";
 
 export function hydrateServerRouter() {
   const map = new WeakMap();
@@ -18,32 +19,28 @@ export function hydrateServerRouter() {
     }
 
     let Component = window._$HY.islandMap[el.dataset.island!];
-    if (!Component || !el.dataset.hk) return;
-
-    let hk = el.dataset.hk;
-    _$DEBUG("hydrating island", el.dataset.island, hk.slice(0, hk.length - 1) + `1-`, el);
+    let id = el.dataset.id;
+    if (!Component || !id || !sharedConfig.load) return;
+    _$DEBUG("hydrating island", el.dataset.island, id, el);
 
     let props = createStore({
-      ...JSON.parse(el.dataset.props!),
-      get children() {
-        const p = el.getElementsByTagName("solid-children");
-        getHydrationKey();
-        [...p].forEach(a => {
-          (a as any).__$owner = getOwner();
-        });
-        return;
-      }
+      ...sharedConfig.load(id),
+      // get children() {
+      //   const p = el.getElementsByTagName("solid-children");
+      //   getHydrationKey();
+      //   [...p].forEach(a => {
+      //     (a as any).__$owner = getOwner();
+      //   });
+      //   return;
+      // }
     });
 
     map.set(el, props);
 
     hydrate(() => createComponent(Component, props[0]), el, {
-      renderId: hk.slice(0, hk.length - 1) + `${1 + Number(el.dataset.offset)}-`,
+      renderId: id,
       owner: lookupOwner(el)
     });
-
-    delete el.dataset.hk;
-    el.dataset.hkk = hk;
   }
 
   let queue: HTMLElement[] = [];


### PR DESCRIPTION
# 🚧 WORK IN PROGRESS 🚧
- [ ] Changes prop serialization step for islands.
  -  This will utilize `sharedConfig.context.push` to serialize props and generate island ids. This unlocks reference deduping across the entire page, as well as make it so that the serialization mechanism is consistent to that of Solid.
  - Since the props are no longer inserted as a property to the island, we use `sharedConfig.load` to load the props data into the island during hydration.
- [x] Use `seroval` for server functions
  - Low priority. Intent is for server functions to utilize seroval for serialization rather than using JSON. This allows server functions to be consistent with data serialization.
