### PR TITLE
add support for @solidjs/meta ^0.29.0 peer dep

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -142,7 +142,7 @@
     "vitest": "^0.20.3"
   },
   "peerDependencies": {
-    "@solidjs/meta": "^0.28.0",
+    "@solidjs/meta": "^0.28.0  || ^0.29.0",
     "@solidjs/router": "^0.8.2",
     "solid-js": "^1.6.2",
     "solid-start-aws": "*",


### PR DESCRIPTION
solid-start 0.3.8 does not allow for @solidjs/meta ^0.29.0 peer dep.