### PR TITLE
Polyfill process.env on Netlify edge

### DIFF
--- a/packages/start-netlify/README.md
+++ b/packages/start-netlify/README.md
@@ -18,6 +18,8 @@ export default defineConfig({
 });
 ```
 
+Environment variables can be accessed via `process.env` (we install a polyfill that calls [`Netlify.env.toObject()`](https://docs.netlify.com/edge-functions/api/#netlify-global-object)). Note that only `env` reads are supported, not any other uses of `process`.
+
 ## Configuration
 
 You will be prompted on deploy to choose a publish directory. Type in "netlify".

--- a/packages/start-netlify/entry-edge.js
+++ b/packages/start-netlify/entry-edge.js
@@ -1,3 +1,9 @@
+if (!process) {
+  globalThis.process = {
+    env: Netlify.env.toObject()
+  };
+}
+
 import manifest from "../../netlify/route-manifest.json";
 import handler from "./entry-server.js";
 

--- a/packages/start-netlify/entry-edge.js
+++ b/packages/start-netlify/entry-edge.js
@@ -1,8 +1,4 @@
-if (!process) {
-  globalThis.process = {
-    env: Netlify.env.toObject()
-  };
-}
+import "./prefix-edge.js";
 
 import manifest from "../../netlify/route-manifest.json";
 import handler from "./entry-server.js";

--- a/packages/start-netlify/index.js
+++ b/packages/start-netlify/index.js
@@ -33,6 +33,12 @@ export default function ({ edge } = {}) {
         await builder.server(join(config.root, ".solid", "server"));
       }
 
+      if (edge) {
+        copyFileSync(
+          join(__dirname, "prefix-edge.js"),
+          join(config.root, ".solid", "server", "prefix-edge.js")
+        );
+      }
       copyFileSync(
         join(__dirname, edge ? "entry-edge.js" : "entry.js"),
         join(config.root, ".solid", "server", "index.js")

--- a/packages/start-netlify/prefix-edge.js
+++ b/packages/start-netlify/prefix-edge.js
@@ -1,0 +1,5 @@
+if (!process) {
+  globalThis.process = {
+    env: Netlify.env.toObject()
+  };
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The only way to read environment variables at runtime on Netlify edge is via their [`Netlify.env.get`](https://docs.netlify.com/edge-functions/api/#netlify-global-object) function. As well as being Netlify-specific, this is awkward to use from TypeScript as it doesn't seem to have correct type declarations.

## What is the new behavior?

Environment variables can be read via `process.env`.

This matches the default behavior on [Vercel's edge](https://vercel.com/docs/functions/edge-functions/edge-runtime#environment-variables), and the [Next.js middleware on Netlify edge](https://docs.netlify.com/functions/environment-variables/#edge-functions-2).

## Other information

I haven't included a test in this PR, but I made a test site in a separate repo (https://github.com/iainmerrick/solid-start-edge-test/). Here's a route that reads `process.env` (using this PR):
- https://deploy-preview-1--solid-start-edge-test.netlify.app/env-test
