### PR TITLE
[vinxi] fix use server directive on windows

### DIFF
--- a/packages/start-new/config/server-components.js
+++ b/packages/start-new/config/server-components.js
@@ -9,6 +9,8 @@ import { SERVER_REFERENCES_MANIFEST } from "@vinxi/plugin-server-components/cons
 import { buildServerComponents } from "@vinxi/plugin-server-components/server";
 import { fileURLToPath } from "node:url";
 import { chunkify } from "vinxi/lib/chunks";
+import { normalize } from "vinxi/lib/path";
+
 function client() {
   return clientComponents({
     server: "ssr",
@@ -18,7 +20,7 @@ function client() {
 }
 
 function server() {
-  const runtime = fileURLToPath(new URL("./server-runtime.jsx", import.meta.url));
+  const runtime = normalize(fileURLToPath(new URL("./server-runtime.jsx", import.meta.url)));
   // export function serverComponents({
   // 	resolve = {
   // 		conditions: ["react-server"],


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fails to load `server-runtime.jsx` because the path is outputed with unescaped backslashes.

```console
21:42:37 [vite] Pre-transform error: Failed to load url C:UsersDavideDesktopsolid-startpackagesstart-newconfigserver-runtime.jsx (resolved id: C:UsersDavideDesktopsolid-startpackagesstart-newconfigserver-runtime.jsx) in C:/Users/Davide/Desktop/solid-start/examples/hackernews/src/lib/api.ts. Does the file exist?
21:42:37 [vite] Error when evaluating SSR module /src/lib/api.ts: failed to import "C:UsersDavideDesktopsolid-startpackagesstart-newconfigserver-runtime.jsx"
|- Error: Failed to load url C:UsersDavideDesktopsolid-startpackagesstart-newconfigserver-runtime.jsx (resolved id: C:UsersDavideDesktopsolid-startpackagesstart-newconfigserver-runtime.jsx) in C:/Users/Davide/Desktop/solid-start/examples/hackernews/src/lib/api.ts. Does the file exist?
    at loadAndTransform (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:55807:21)
```

## What is the new behavior?

Normalizing path to `/` forward slash.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
