### PR TITLE
fix missing hydration script when NODE_ENV is not dev or prod

### DIFF
--- a/packages/start/root/Scripts.tsx
+++ b/packages/start/root/Scripts.tsx
@@ -3,7 +3,6 @@ import { useRequest } from "../server/ServerContext";
 import { InlineStyles } from "./InlineStyles";
 
 const isDev = import.meta.env.MODE === "development";
-const isProd = import.meta.env.PROD;
 const isSSR = import.meta.env.START_SSR;
 const isIslands = import.meta.env.START_ISLANDS;
 
@@ -45,7 +44,7 @@ function DevScripts() {
 function ProdScripts() {
   const context = useRequest();
   return (
-    isProd && (
+    !isDev && (
       <>
         {isSSR && <HydrationScript />}
         <NoHydration>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Before https://github.com/solidjs/solid-start/commit/f351f42ba8566cbfa72b483dd63d4debcb386230 when NODE_ENV was set to something other than `development` or `production` you would get `ProdScripts`.
After that commit you get no hydration script in that case because `isProd` and `isDev` would both be false.

*Note: isDev is determined by checking import.meta.env.MODE and not import.meta.env.DEV* 

## What is the new behavior?

Return `ProdScripts` unless `isDev` is true. This restores the previous behavior and still prevents ending up with two hydration scripts in dev.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

Reference: [Discord](https://discord.com/channels/722131463138705510/910635844119982080/1170127171965173832)