### PR TITLE
Fixes adapter AWS Edge.

### DIFF
--- a/packages/start-aws/entry-edge.mjs
+++ b/packages/start-aws/entry-edge.mjs
@@ -32,8 +32,8 @@ export async function handler(event) {
     responseHeaders[name] = [
       {
         key: name,
-        value: value,
-      },
+        value: value
+      }
     ];
   }
 
@@ -41,7 +41,7 @@ export async function handler(event) {
     status: response.status,
     statusDescription: "OK",
     headers: responseHeaders,
-    body: await response.text(),
+    body: await response.text()
   };
 }
 
@@ -49,19 +49,19 @@ function createRequest(event) {
   const record = event.Records[0].cf;
 
   // Build URL
-  const url = new URL(
-    record.request.uri,
-    `https://${record.config.distributionDomainName}`
-  );
+  const base = record.request.origin?.custom.domainName
+    ? `${record.request.origin.custom.protocol}://${record.request.origin.custom.domainName}`
+    : `https://${record.config.distributionDomainName}`;
+  const url = new URL(record.request.uri, base);
 
   // Build headers
   const headers = new Headers();
   for (const [key, value] of Object.entries(record.request.headers)) {
-    headers.append(key, value[0]);
+    headers.append(key, value[0].value);
   }
 
   return new Request(url, {
     method: record.request.method,
-    headers,
+    headers
   });
 }


### PR DESCRIPTION
- Fixes adapter AWS Lambda@Edge Headers from "[Object Object]" to the proper header value.
- Build URL will make use of custom.domainName if defined, fallback to distributionDomainName

## PR Checklist

Please check if your PR fulfills the following requirements:

NA, as the change can only be tested on AWS Lambda@Edge.
Verified that previous tests are all passing.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
- On Lambda@Edge the headers are set as [Object Object].
- Request URL always takes distributionDomainName.

## What is the new behavior?
- On Lambda@Edge the headers are set with the correct value.
- Request URL is set with origin.custom.domainName if available. Fallback to previous distributionDomainName.
- Style: Added trailing commas.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
