### PR TITLE
fix: server fn deserialization

### DIFF
--- a/packages/start/config/server-runtime.jsx
+++ b/packages/start/config/server-runtime.jsx
@@ -26,7 +26,18 @@ async function deserializeStream(id, response) {
     throw new Error('Unexpected end of body');
   }
   const serialized = new TextDecoder().decode(result.value);
-  const revived = deserialize(serialized);
+  let pending = true;
+  let revived;
+  const splits = serialized.split('\n');
+  for (const split of splits) {
+    if (split !== '') {
+      const current = deserialize(split);
+      if (pending) {
+        revived = current;
+        pending = false;
+      }
+    }
+  }
 
   pop().then(() => {
     delete self.$R[id];


### PR DESCRIPTION
It seems that ReadableStream writes are windowed, and so immediate Promises are getting batched alongside the sync output. I'm not sure if it's the server or the client that's doing the batching, but since we have a newline separator for the output we can safely extract the target value (the first line).

Example of a failing case:

```js
async function example() {
  'use server';
  // Our target here is the object, however since the output is batched,
  // the initial streamed output consists of two lines: the object and
  // the resolver call, the latter being the one captured as the target.
  return {
    immediate: Promise.resolve('foo');
  };
}
```