### PR TITLE
fix: add nitro config type

### DIFF
--- a/packages/start/config/index.d.ts
+++ b/packages/start/config/index.d.ts
@@ -1,14 +1,15 @@
+import { AppOptions } from "vinxi";
 import { InlineConfig } from "vite";
 
 type SolidStartInlineConfig = Omit<InlineConfig, "router"> & {
     start?: {
         ssr?: boolean | "async",
         extensions?: string[],
-        server?: any,
+        server?: AppOptions['server'],
         appRoot?: string,
         middleware?: string,
         //islands?: boolean TODO: Get PROD bugs working probably missing release
     }
 }
 
-export declare function defineConfig(baseConfig: SolidStartInlineConfig)
+export declare function defineConfig(baseConfig?: SolidStartInlineConfig)


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Start server typed as any
{ start: { server: any}}

## What is the new behavior?
Start server config typed as NitroConfig

<img width="287" alt="image" src="https://github.com/solidjs/solid-start/assets/184235/45cd9920-f778-4eb5-a70b-eb849b2cd994">
