### PR TITLE
feat: seroval 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # SolidStart
 
+### Start has just entered a new Beta Phase ###
+
+v0.4.x marks a significant change in the project. Please check the updated docs and example projects to see how things have changed. A summary of the chances can be found in the [RFC](https://github.com/solidjs/solid-start/discussions/1052).
+
+------------------------------------
+
 This is the home of the Solid app framework. This is still a **work in progress**. Many features are missing or incomplete. Experimental status does not even mean beta status. Patch releases will break everything.
 
 ## Features

--- a/docs/components/tooltip.tsx
+++ b/docs/components/tooltip.tsx
@@ -1,21 +1,22 @@
 import { createEffect } from "solid-js";
-import { isServer } from "solid-js/web";
+
 let tippy;
-if (!isServer) {
-  import("tippy.js").then(mod => tippy = mod);
+
+function applyTippy(id) {
+  tippy.default(`[data-template="${id}"]`, {
+    content() {
+      const template = document.getElementById(id);
+      return template.innerHTML;
+    },
+    allowHTML: true
+  });
 }
 
 export default function Tooltip(props) {
-  createEffect(() => {
-    if (!isServer) {
-      tippy.default(`[data-template="${props.id}"]`, {
-        content() {
-          const template = document.getElementById(props.id);
-          return template.innerHTML;
-        },
-        allowHTML: true
-      });
-    }
+  createEffect(async () => {
+    const id = props.id;
+    tippy || (tippy = await import("tippy.js"));
+    applyTippy(id);
   });
   return (
     <span class={`data-lsp`} data-template={props.id}>

--- a/docs/routes/api/vite.md
+++ b/docs/routes/api/vite.md
@@ -58,6 +58,30 @@ export default defineConfig({
 });
 ```
 
+#### Special Note
+
+SolidStart uses Async Local Storage. Not all non-node platforms support it out of the box. Netlify, Vercel, and Deno should just work. But for Cloudflare you will need specific config:
+
+```js
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  start: {
+    server: {
+      preset: "cloudflare_module",
+      rollupConfig: {
+        external: ["__STATIC_CONTENT_MANIFEST", "node:async_hooks"]
+      }
+    }
+  }
+});
+```
+
+And enable node compat in your wrangler.toml.
+```
+compatibility_flags = [ "nodejs_compat" ]
+```
+
 ## Reference
 
 ### `@solidjs/start/config`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     appRoot: "./docs",
     extensions: ["mdx", "md"],
     server: {
+      preset: "cloudflare",
+      rollupConfig: {
+        external: ["__STATIC_CONTENT_MANIFEST", "node:async_hooks"]
+      },
       prerender: {
         crawlLinks: true
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     appRoot: "./docs",
     extensions: ["mdx", "md"],
     server: {
-      preset: "cloudflare",
+      preset: "cloudflare_module",
       rollupConfig: {
         external: ["__STATIC_CONTENT_MANIFEST", "node:async_hooks"]
       },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,15 @@
 name = "solid-start"
-compatibility_date = "2022-08-05"
+compatibility_date = "2022-09-10"
 account_id = "fa2a5e3787deead800c822a0e1171763"
 zone_id = "9258b29d3b22bdba0666469e82d18225"
-main = "./dist/server.js"
+main = "./.output/server/index.mjs"
 type = "javascript"
 route = "start.solidjs.com/*"
+compatibility_flags = [ "nodejs_compat" ]
+
+rules = [
+  { type = "ESModule", globs = ["**/*.js", "**/*.mjs"]},
+]
 
 [site]
-bucket = "./dist/public"
+bucket = ".output/public"


### PR DESCRIPTION
Reopened from #1140 and #1147 

This PR updates seroval to 1.0, where Web API have been moved out of the core serialization in the form of the plugins. This release is also important for deserialization (which Start relies on in client-to-server communication) so that kinda fixes potential issues in the future, the biggest being string deserialization.