### PR TITLE
[DOCS] Remove app folder creation command because it's included

### DIFF
--- a/docs/routes/getting-started/project-setup.mdx
+++ b/docs/routes/getting-started/project-setup.mdx
@@ -13,13 +13,10 @@ To create your first SolidStart application, create a directory, change into tha
 
 ```bash
 # npm
-mkdir my-app && cd my-app
 npm init solid@latest
 # pnpm
-mkdir my-app && cd my-app
 pnpm create solid
 # bun
-mkdir my-app && cd my-app
 bunx create-solid
 ```
 


### PR DESCRIPTION
… it for you

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The documentation has a command to create a my-app folder before running `create solid`, but the tool will ask you for your folder name already. If you follow the current docs you will end up with solid start installed in my-app/my-app

## What is the new behavior?
Docs don't include this step, and rely on the create solid command to guide you through the process.

## Other information
<img width="1185" alt="image" src="https://github.com/solidjs/solid-start/assets/16902309/13a651cf-dee2-4a43-94cf-e9dfb483b361">
