### PR TITLE
Fix global `$R`

### DIFF
--- a/packages/start/config/server-handler.js
+++ b/packages/start/config/server-handler.js
@@ -1,5 +1,5 @@
 /// <reference types="vinxi/types/server" />
-import { crossSerializeStream, fromJSON } from "seroval";
+import { crossSerializeStream, fromJSON, getCrossReferenceHeader } from "seroval";
 import {
   CustomEventPlugin,
   DOMExceptionPlugin,
@@ -42,7 +42,7 @@ function serializeToStream(id, value) {
           URLPlugin,
         ],
         onSerialize(data, initial) {
-          const result = initial ? `((self.$R=self.$R||{})["${id}"]=[],${data})` : data;
+          const result = initial ? `(${getCrossReferenceHeader(id)},${data})` : data;
           controller.enqueue(new TextEncoder().encode(`${result};\n`));
         },
         onDone() {

--- a/packages/start/config/server-handler.js
+++ b/packages/start/config/server-handler.js
@@ -42,7 +42,7 @@ function serializeToStream(id, value) {
           URLPlugin,
         ],
         onSerialize(data, initial) {
-          const result = initial ? `($R["${id}"]=[],${data})` : data;
+          const result = initial ? `((self.$R=self.$R||{})["${id}"]=[],${data})` : data;
           controller.enqueue(new TextEncoder().encode(`${result};\n`));
         },
         onDone() {

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -49,8 +49,8 @@
     "@vinxi/server-components": "0.0.50",
     "@vinxi/server-functions": "0.0.51",
     "defu": "^6.1.2",
-    "seroval": "^1.0.0",
-    "seroval-plugins": "^1.0.1",
+    "seroval": "^1.0.2",
+    "seroval-plugins": "^1.0.2",
     "vite-plugin-inspect": "^0.7.33",
     "vite-plugin-solid": "^2.8.0"
   }

--- a/packages/start/server/StartServer.tsx
+++ b/packages/start/server/StartServer.tsx
@@ -52,7 +52,6 @@ export function StartServer(props: { document: Component<DocumentComponentProps>
         assets={
           <>
             <HydrationScript />
-            <script>$R = [];</script>
             {context.assets.map(m => renderAsset(m))}
           </>
         }

--- a/packages/start/server/spa/StartServer.tsx
+++ b/packages/start/server/spa/StartServer.tsx
@@ -12,7 +12,6 @@ export function StartServer(props) {
       <props.document
         assets={
           <>
-            <script>$R = [];</script>
             {context.assets.map(m => renderAsset(m))}
           </>
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,11 +444,11 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2
       seroval:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.2
+        version: 1.0.2
       seroval-plugins:
-        specifier: ^1.0.1
-        version: 1.0.1(seroval@1.0.0)
+        specifier: ^1.0.2
+        version: 1.0.2(seroval@1.0.2)
       vite-plugin-inspect:
         specifier: ^0.7.33
         version: 0.7.33(rollup@3.28.1)(vite@4.5.0)
@@ -6415,21 +6415,21 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
-  /seroval-plugins@1.0.1(seroval@1.0.0):
-    resolution: {integrity: sha512-NXeb6S2jh+sxFI8NMBpzyVWItblit9/j7B1q+vfxUccj0ycbqu4h3hzrrmb7GSy7b6WqTmo0apGBsLH5ei/VUg==}
+  /seroval-plugins@1.0.2(seroval@1.0.2):
+    resolution: {integrity: sha512-4G/G9dFOBfFhw3AO+sn5Y6jyxkpoBwqnN2wxWjl8cGffaW+2lsMJ4baIoJ+E8JHx8iPZd82lvaaBG5QN8JuKhA==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: '>=0.15'
     dependencies:
-      seroval: 1.0.0
+      seroval: 1.0.2
     dev: false
 
   /seroval@0.15.1:
     resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
     engines: {node: '>=10'}
 
-  /seroval@1.0.0:
-    resolution: {integrity: sha512-HA2BtUaLO6Gqpc1uc//v08DqvWKfGrD7wpsJSw+qkgBubJbYuKBVE2i2v09k5kwM6wA7R/dN37LCg+t48sBpCg==}
+  /seroval@1.0.2:
+    resolution: {integrity: sha512-buswWxRzf65ZGUk8MAf3qVtBJHbe5gq6hZyPeqlJCKEIl/tEhUZze0YJg7vB7tFRGgPeneRaP083OB/vDiYLvA==}
     engines: {node: '>=10'}
     dev: false
 


### PR DESCRIPTION
A mistake we made is that `$R` only generates if we are actually serializing any data on the server. The mistake here is that we won't know if a server function, which is dependent on the same variable, would be called on the client-side.

This fix ensures that server function responses are guaranteed to have `$R` to be initialized.

Fixes #1186 

edit:

This PR also fixes an issue with server function streaming responses (not necessarily for Promises but for AsyncIterators)