### PR TITLE
allow sending plugins fn (to get different instances for each router)

### DIFF
--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -80,9 +80,10 @@ export function defineConfig(baseConfig = {}) {
         routes: solidStartServerFsRouter({ dir: `${start.appRoot}/routes`, extensions }),
         extensions,
         target: "server",
-        plugins: () => [
+        plugins: async () => [
           config("user", userConfig),
-          ...plugins,
+          ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
+
           serverTransform({
             runtime: normalize(fileURLToPath(new URL("./server-fns-runtime.jsx", import.meta.url)))
           }),
@@ -121,9 +122,9 @@ export function defineConfig(baseConfig = {}) {
             }),
         extensions,
         target: "browser",
-        plugins: () => [
+        plugins: async () => [
           config("user", userConfig),
-          ...plugins,
+          ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
           serverFunctions.client({
             runtime: normalize(fileURLToPath(new URL("./server-runtime.jsx", import.meta.url)))
           }),
@@ -161,9 +162,10 @@ export function defineConfig(baseConfig = {}) {
         handler: normalize(fileURLToPath(new URL("./server-handler.js", import.meta.url))),
         runtime: normalize(fileURLToPath(new URL("./server-fns-runtime.jsx", import.meta.url))),
         // routes: solidStartServerFsRouter({ dir: `${start.appRoot}/routes`, extensions }),
-        plugins: () => [
+        plugins: async () => [
           config("user", userConfig),
-          ...plugins,
+          ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
+
           solid({ ...start.solid, ssr: true, extensions: extensions.map(ext => `.${ext}`) }),
           config("app-server", {
             resolve: {


### PR DESCRIPTION
no other way of cloning plugins without their scope right now

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Fixes https://github.com/solidjs/solid-start/issues/1195

Right now the user sends a list of plugins in the `plugins` option. If these plugins depend on keeping some scope that they use to decide what to, there will be issues as we use the same plugins list for multiple router. I want to encourage people to use the fn version of the plugins config, but its a deviation from the default vite API, but only by the slightest and actually provides powerful pattern.

This adds support for the `plugins: () => [....]` format, while keeping the array format intact.

This was important for example for the `imagetools` plugin because it adds something to the vite dev server (a middleware) so its needs to be unique for each vinxi router.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
