### PR TITLE
Allow customizing Vite plugins per router

### DIFF
--- a/packages/start/config/index.d.ts
+++ b/packages/start/config/index.d.ts
@@ -9,7 +9,14 @@ type SolidStartInlineConfig = Omit<InlineConfig, "router"> & {
         appRoot?: string,
         middleware?: string,
         islands?: boolean
+    },
+    plugins?: Plugins | {
+        client?: Plugins,
+        server?: Plugins,
+        serverFunctions?: Plugins
     }
 }
+
+type Plugins = InlineConfig["plugins"] | (() => Promise<InlineConfig["plugins"]> | InlineConfig["plugins"])
 
 export declare function defineConfig(baseConfig?: SolidStartInlineConfig)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Users only can apply the same kind of Vite plugins to all Vinxi routers

## What is the new behavior?
Users can customize which Vite plugins to apply per Vinxi router

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
