### PR TITLE
update bump script and add option to update vinxi packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@trpc/client": "^9.27.4",
     "@trpc/server": "^9.27.4",
     "@vinxi/plugin-mdx": "^3.6.7",
+    "citty": "^0.1.5",
     "coveralls": "^3.1.1",
     "debug": "^4.3.4",
     "fast-glob": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@vinxi/plugin-mdx':
         specifier: ^3.6.7
         version: 3.6.7(@mdx-js/mdx@2.3.0)
+      citty:
+        specifier: ^0.1.5
+        version: 0.1.5
       coveralls:
         specifier: ^3.1.1
         version: 3.1.1

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -1,53 +1,74 @@
-import { execSync, spawnSync } from "child_process";
+import { exec, spawnSync } from "child_process";
+import { defineCommand, runMain } from "citty";
 import glob from "fast-glob";
 import fs from "fs/promises";
 import semver from 'semver';
+import { promisify } from "util";
 
-const version = process.argv[2];
+const command = defineCommand({
+  args: {
+    version: {
+      type: "positional",
+      description: "solid-start version to set (Must be a valid SemVer)",
+      required: true
+    },
+    vinxi: {
+      description: "Bump vinxi packages to latest version",
+    }
+  },
+  async run({ args }) {
+    if(!semver.valid(args.version)) {
+      console.error(`Invalid SemVer version provided: "${args.version}". Please provide a valid SemVer version as the second argument`);
+      process.exit(1);
+    }
 
-if (!version || version === "") {
-  console.log("Please provide a version as the second argument");
-  process.exit(1);
-}
+    const extPackageNames = ["solid-js"];
 
-if (!semver.valid(version)) {
-  console.error(`Invalid SemVer version provided: "${version}". Please provide a valid SemVer version as the second argument`);
-  process.exit(1);
-}
+    if (args.vinxi) {
+      extPackageNames.push(...[
+        "vinxi",
+        "@vinxi/plugin-directives",
+        "@vinxi/server-components",
+        "@vinxi/server-functions",
+        "@vinxi/plugin-mdx"
+      ]);
+    }
 
-let solidJsVersion = execSync("npm view solid-js version").toString().trim();
+    const execAsync = promisify(exec);
+    const packages = await Promise.all(extPackageNames.map(async name => {
+      const proc = await execAsync(`npm view ${name} version`);
+      return { name, version: proc.stdout.toString().trim() };
+    }));
 
-const packages = await glob("packages/*/package.json");
-const packageNames = await Promise.all(packages.map(async packagePath => {
-  const packageJson = JSON.parse(await fs.readFile(packagePath));
-  packageJson.version = version;
-  await fs.writeFile(packagePath, JSON.stringify(packageJson, null, 2) + "\n");
-  return packageJson.name;
-}));
+    const startPackages = await Promise.all(
+      glob.globSync("packages/*/package.json").map(async path => {
+        const packageJson = JSON.parse(await fs.readFile(path));
+        packageJson.version = args.version;
+        await fs.writeFile(path, JSON.stringify(packageJson, null, 2) + "\n");
+        return { name: packageJson.name, version: args.version };
+      }
+    ));
+    
+    packages.push(...startPackages);
 
-const targets = await glob("examples/*/package.json");
-const solidJsOnlyTargets = ["package.json", "packages/start/package.json"];
-// const solidJsOnlyTargets = ["package.json", "packages/start/package.json", "test/template/package.json"];
-targets.push(...solidJsOnlyTargets);
+    await Promise.all(glob.globSync(["package.json", "packages/*/package.json", "examples/*/package.json"])
+      .map(async path => {
+        const packageJson = JSON.parse(await fs.readFile(path));
+        let deps = packages;
+        if (packageJson.name === "solid-start-monorepo") {
+          deps = deps.filter(dep => !startPackages.find(pkg => pkg.name === dep.name))
+        }
+        for (const dep of deps) {
+          packageJson.dependencies?.[dep.name] && (packageJson.dependencies[dep.name] = `^${dep.version}`);
+          packageJson.devDependencies?.[dep.name] && (packageJson.devDependencies[dep.name] = `^${dep.version}`);
+        }
+        await fs.writeFile(path, JSON.stringify(packageJson, null, 2) + "\n");
+      })
+    );
 
-await Promise.all(targets.map(async packagePath => {
-  const packageJson = JSON.parse(await fs.readFile(packagePath));
-
-  if (solidJsOnlyTargets.find(target => target === packagePath)) {
-    packageJson.dependencies?.["solid-js"] && (packageJson.dependencies["solid-js"] = `^${solidJsVersion}`);
-    packageJson.devDependencies?.["solid-js"] && (packageJson.devDependencies["solid-js"] = `^${solidJsVersion}`);
+    console.log("Updating lock file...\n");
+    spawnSync("pnpm i", { shell: true, stdio: "inherit" });
   }
-  else {
-    packageNames.forEach(packageName => {
-      packageJson.dependencies?.[packageName] && (packageJson.dependencies[packageName] = `^${version}`);
-      packageJson.devDependencies?.[packageName] && (packageJson.devDependencies[packageName] = `^${version}`);
-    });
-    packageJson.dependencies?.["solid-js"] && (packageJson.dependencies["solid-js"] = `^${solidJsVersion}`);
-    packageJson.devDependencies?.["solid-js"] && (packageJson.devDependencies["solid-js"] = `^${solidJsVersion}`);
-  }
+});
 
-  await fs.writeFile(packagePath, JSON.stringify(packageJson, null, 2) + "\n");
-}));
-
-console.log("Updating lock file...\n");
-spawnSync("pnpm i", { shell: true, stdio: "inherit" });
+runMain(command);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

vinxi packages not covered.

## What is the new behavior?

Should behave as before.

- Added cli builder [citty](https://github.com/unjs/citty)
- Added option `--vinxi` to also bump vinxi packages
- Refactor bump process

```sh
pnpm bump 0.4.2 --vinxi
```

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

If vinxi should always be updated like it's done for solid-js let me know. In that case I would remove citty. No point in adding an extra package.
