### PR TITLE
Fix dev overlay

### DIFF
--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -79,7 +79,17 @@ export function defineConfig(baseConfig = {}) {
         extensions,
         target: "server",
         plugins: async () => [
-          config("user", userConfig),
+          config("user", {
+            ...userConfig,
+            optimizeDeps: {
+              ...(userConfig.optimizeDeps || {}),
+              include: [
+                ...(userConfig.optimizeDeps?.include || []),
+                '@solidjs/start > source-map-js',
+                '@solidjs/start > error-stack-parser',
+              ],
+            },
+          }),
           ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
 
           serverTransform({
@@ -121,7 +131,17 @@ export function defineConfig(baseConfig = {}) {
         extensions,
         target: "browser",
         plugins: async () => [
-          config("user", userConfig),
+          config("user", {
+            ...userConfig,
+            optimizeDeps: {
+              ...(userConfig.optimizeDeps || {}),
+              include: [
+                ...(userConfig.optimizeDeps?.include || []),
+                '@solidjs/start > source-map-js',
+                '@solidjs/start > error-stack-parser',
+              ],
+            },
+          }),
           ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
           serverFunctions.client({
             runtime: normalize(fileURLToPath(new URL("./server-runtime.jsx", import.meta.url)))
@@ -161,7 +181,17 @@ export function defineConfig(baseConfig = {}) {
         runtime: normalize(fileURLToPath(new URL("./server-fns-runtime.jsx", import.meta.url))),
         // routes: solidStartServerFsRouter({ dir: `${start.appRoot}/routes`, extensions }),
         plugins: async () => [
-          config("user", userConfig),
+          config("user", {
+            ...userConfig,
+            optimizeDeps: {
+              ...(userConfig.optimizeDeps || {}),
+              include: [
+                ...(userConfig.optimizeDeps?.include || []),
+                '@solidjs/start > source-map-js',
+                '@solidjs/start > error-stack-parser',
+              ],
+            },
+          }),
           ...(typeof plugins === "function" ? [...(await plugins())] : plugins),
 
           solid({ ...start.solid, ssr: true, extensions: extensions.map(ext => `.${ext}`) }),

--- a/packages/start/shared/dev-overlay/styles.css
+++ b/packages/start/shared/dev-overlay/styles.css
@@ -27,6 +27,8 @@
   margin-bottom: 2rem;
   z-index: 10;
   gap: 0.5rem;
+  color: rgb(17 24 39);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .dev-overlay-navbar {
@@ -87,7 +89,6 @@
 }
 
 .dev-overlay-page-counter {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 600;
@@ -120,7 +121,6 @@
   border-radius: 9999px;
   background-color: rgb(249 250 251);
   padding: 0.25rem 0.5rem;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 600;
@@ -146,7 +146,6 @@
 }
 
 .dev-overlay-error-info {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -208,7 +207,6 @@
 }
 
 .dev-overlay-stack-frame-function {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-weight: 700;
 }
 
@@ -245,7 +243,6 @@
 .dev-overlay-stack-frames-code-source {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   color: rgb(249 250 251);
 }
 


### PR DESCRIPTION
- It seems that `error-stack-parser` and `source-map-js` are not being transformed by Vite and so this PR fixes it so that they are included in `optimizeDeps` by default.
- This PR also fixes some style issues.

- Fixes #1219 