### PR TITLE
fix: make vite-plugin-solid options optional

### DIFF
--- a/packages/start/config/index.d.ts
+++ b/packages/start/config/index.d.ts
@@ -11,7 +11,7 @@ type SolidStartInlineConfig = Omit<InlineConfig, "router"> & {
          * async: ssr is in async mode
          */
         ssr?: boolean | "async",
-        solid: Options,
+        solid?: Options,
         extensions?: string[],
         server?: AppOptions['server'],
         appRoot?: string,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
vite-plugin-solid options are not optional

## What is the new behavior?
vite-plugin-solid options are optional

## Other information
I assume that it was probably marked not optional by mistake.