### PR TITLE
fix: Add baseURL to server-fns and server-runtime

### DIFF
--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -170,6 +170,7 @@ export function defineConfig(baseConfig = {}) {
               "import.meta.env.START_ISLANDS": JSON.stringify(start.islands),
               "import.meta.env.SSR": JSON.stringify(false),
               "import.meta.env.START_SSR": JSON.stringify(start.ssr),
+              "import.meta.env.SERVER_BASE_URL": JSON.stringify(server.baseURL),
               ...userConfig.define
             }
           })

--- a/packages/start/config/server-fns-runtime.jsx
+++ b/packages/start/config/server-fns-runtime.jsx
@@ -3,10 +3,11 @@ import { provideRequestEvent } from "solid-js/web/storage";
 import { cloneEvent } from "../server/middleware";
 
 export function createServerReference(fn, id, name) {
+  const baseURL = import.meta.env.SERVER_BASE_URL;
   return new Proxy(fn, {
     get(target, prop, receiver) {
       if (prop === "url") {
-        return `/_server?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
+        return `${baseURL}/_server?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
       }
     },
     apply(target, thisArg, args) {

--- a/packages/start/config/server-runtime.jsx
+++ b/packages/start/config/server-runtime.jsx
@@ -120,14 +120,15 @@ async function fetchServerFunction(base, id, args) {
 }
 
 export function createServerReference(fn, id, name) {
+  const baseURL = import.meta.env.SERVER_BASE_URL;
   return new Proxy(fn, {
     get(target, prop, receiver) {
       if (prop === "url") {
-        return `/_server?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
+        return `${baseURL}/_server?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
       }
     },
     apply(target, thisArg, args) {
-      return fetchServerFunction("/_server", `${id}#${name}`, args);
+      return fetchServerFunction(`${baseURL}/_server`, `${id}#${name}`, args);
     }
   });
 }


### PR DESCRIPTION
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?
There's no way of defining a base path for routeData. Navigation to a route with routeData fails as /_server returns 404.
https://discord.com/channels/722131463138705510/910635844119982080/1194290696341950464

## What is the new behavior?
Base path added to /_server requests.
