### PR TITLE
fix(matchAPIRoute): Strip baseURL from path

### DIFF
--- a/packages/start/shared/routes.ts
+++ b/packages/start/shared/routes.ts
@@ -33,7 +33,7 @@ export const pageRoutes = defineRoutes((fileRoutes as unknown as Route[]).filter
 const apiRoutes = defineAPIRoutes((fileRoutes as unknown as Route[]).filter(o => o.type === "api"));
 
 export function matchAPIRoute(path: string, method: HTTPMethod) {
-  const segments = path.split("/").filter(Boolean);
+  const segments = path.replace(import.meta.env.SERVER_BASE_URL, "").split("/").filter(Boolean);
 
   routeLoop: for (const route of apiRoutes) {
     const matchSegments = route.matchSegments;


### PR DESCRIPTION
## PR Type
- [X] Bugfix

## What is the current behavior?
When having a baseURL, API routes 404.

## What is the new behavior?
API routes work with base path.


________


baseURL is removed before matching API routes. 

```
export default defineConfig({
  start: {
    server: {
      baseURL: "/asd",
    },
  },
});

```
