### PR TITLE
fix: Add `ChunkReader`

### DIFF
--- a/packages/start/config/server-runtime.jsx
+++ b/packages/start/config/server-runtime.jsx
@@ -25,7 +25,6 @@ class ChunkReader {
     if (first === '') {
       // if there's no chunk, read again
       const chunk = await this.reader.read();
-      console.log(chunk);
       if (chunk.done) {
         return { done: true, value: undefined };
       }
@@ -47,7 +46,6 @@ class ChunkReader {
       } catch (error) {
         // otherwise, retry again with a new chunk
         const chunk = await this.reader.read();
-        console.log(chunk);
         if (chunk.done) {
           return null;
         }

--- a/packages/start/config/server-runtime.jsx
+++ b/packages/start/config/server-runtime.jsx
@@ -21,9 +21,6 @@ class ChunkReader {
   }
 
   async readChunk() {
-    if (this.done) {
-      return;
-    }
     // if there's no chunk, read again
     const chunk = await this.reader.read();
     if (!chunk.done) {
@@ -35,16 +32,21 @@ class ChunkReader {
   }
 
   async nextValue() {
+    // Check if the buffer is empty
     if (this.buffer === '') {
+      // if we are already one...
       if (this.done) {
         return {
           done: true,
           value: undefined,
         };
       }
+      // Otherwise, read a new chunk
       await this.readChunk();
     }
+    // Get the first valid seroval chunk
     const [first, ...rest] = this.buffer.split('\n');
+    // Deserialize the seroval chunk
     const result = {
       done: false,
       value: deserialize(first),
@@ -57,9 +59,20 @@ class ChunkReader {
 
   async next() {
     try {
+      // Attempt to read a valid seroval chunk
       return await this.nextValue();
     } catch (error) {
+      // If it happens that there's an error again
+      // and we are done reading the buffer
+      // then the whole stream is invalid.
+      if (this.done) {
+        throw new Error('Malformed server function stream.');
+      }
+      // Since it's invalid (some syntax-related issue)
+      // we read a new chunk, and hope there's a valid
+      // seroval chunk there
       await this.readChunk();
+      // Retry again
       return await this.next();
     }
   }


### PR DESCRIPTION
- This PR adds the `ChunkReader` utility class.
  - The purpose of this class is for proper consumption of chunks that are being streamed by the server functions request. Previously, we only deserialize the first valid seroval chunk with the assumption that the first response chunk is a valid seroval chunk. However the browser interprets it differently, that is, if the chunk size is too large, the browser will split the "valid chunk" into smaller chunks, leading into a deserialization error.
  - `ChunkReader` ensures that the first chunk is a valid chunk. If it's invalid, it will attempt to read a new chunk, and check if part of the chunk is a valid seroval chunk. This process repeats until the stream is drained.
- Fixes #1243 

Test app:

```js
// @refresh reload
import { createEffect, createResource, createSignal } from "solid-js";
import "./app.css";

export default function App() {
  const [count, setCount] = createSignal(0);

  const [data] = createResource(count, async (value) => {
    "use server";

    return {
      data: new Promise((resolve) => {
        const giantData = [];
        for (let i = 0; i < 1000000; i++) {
          giantData.push(`index: ${i} value: ${value}`);
        }
        setTimeout(resolve, 1000, giantData);
      }),
    };
  });

  createEffect(() => {
    console.log(data()?.data);
  });

  return (
    <main>
      <h1>Hello world!</h1>
      <button class="increment" onClick={() => setCount(count() + 1)}>
        Clicks: {count()}
      </button>
      <p>
        Visit{" "}
        <a href="https://start.solidjs.com" target="_blank">
          start.solidjs.com
        </a>{" "}
        to learn how to build SolidStart apps.
      </p>
    </main>
  );
}
```

> [!NOTE]
> In my test, the maximum chunk size is around 2097152 bytes. Tested in latest Arc (Chromium browser) on Mac OS