### PR TITLE
Fix server functions hanging on edge functions

### DIFF
--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -12,7 +12,7 @@
     "@solidjs/start": "^0.4.9",
     "@vinxi/plugin-mdx": "^3.6.7",
     "solid-js": "^1.8.11",
-    "vinxi": "^0.1.2",
+    "vinxi": "^0.1.3",
     "solid-mdx": "^0.0.7"
   },
   "engines": {

--- a/examples/with-solid-styled/package.json
+++ b/examples/with-solid-styled/package.json
@@ -12,7 +12,7 @@
     "@solidjs/start": "^0.4.9",
     "solid-js": "^1.8.11",
     "solid-styled": "^0.8.2",
-    "vinxi": "^0.1.2",
+    "vinxi": "^0.1.3",
     "vite-plugin-solid-styled": "^0.8.3"
   },
   "engines": {

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -21,7 +21,7 @@
     "jsdom": "^23.0.1",
     "solid-js": "^1.8.11",
     "typescript": "^5.3.3",
-    "vinxi": "^0.1.2",
+    "vinxi": "^0.1.3",
     "vite": "^4.4.9",
     "vite-plugin-solid": "^2.8.0",
     "vitest": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "turbo": "^1.10.7",
     "typescript": "4.7.4",
     "valibot": "0.24.1",
-    "vinxi": "^0.1.2",
+    "vinxi": "^0.1.3",
     "vite": "^4.4.6"
   },
   "dependencies": {

--- a/packages/start/server/middleware.ts
+++ b/packages/start/server/middleware.ts
@@ -1,11 +1,11 @@
 import {
-  EventHandlerRequest,
-  H3Event,
   defineMiddleware,
+  EventHandlerRequest,
   getRequestIP,
   getRequestURL,
-  getRequestWebStream,
-  sendWebResponse
+  H3Event,
+  sendWebResponse,
+  toWebRequest
 } from "vinxi/server";
 import { FetchEvent } from "./types";
 
@@ -17,39 +17,6 @@ const eventTraps = {
     return target[prop] ?? target[h3EventSymbol][prop];
   }
 };
-
-function toWebRequest(/** @type {H3Event} */ event) {
-  /**
-   * @type {ReadableStream | undefined}
-   */
-  let readableStream;
-
-  const url = getRequestURL(event);
-  const base = {
-    // @ts-ignore Undici option
-    duplex: "half",
-    method: event.method,
-    headers: event.headers
-  };
-
-  if (event.node.req.body instanceof ArrayBuffer) {
-    return new Request(url, {
-      ...base,
-      body: event.node.req.body
-    });
-  }
-
-  return new Request(getRequestURL(event), {
-    ...base,
-    get body() {
-      if (readableStream) {
-        return readableStream;
-      }
-      readableStream = getRequestWebStream(event);
-      return readableStream;
-    }
-  });
-}
 
 export function createFetchEvent(event: H3Event<EventHandlerRequest>): FetchEvent {
   event.web ||

--- a/packages/start/server/middleware.ts
+++ b/packages/start/server/middleware.ts
@@ -46,7 +46,6 @@ function toWebRequest(/** @type {H3Event} */ event) {
         return readableStream;
       }
       readableStream = getRequestWebStream(event);
-      console.log(readableStream);
       return readableStream;
     }
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When you call a server function when Solid Start is deployed on Deno or Vercel Edge Functions the entire function hangs.

Example page at `routes/index.ts` to demonstrate the issue:
```ts
const demoAction = async (name: string) => {
  "use server";

  return `Hello, ${name}`;
};

export default function Page() {
  return (
    <main class="text-center mx-auto text-gray-700 p-4 flex flex-col">
      <button onClick={() => demoAction("Oscar").then(console.log)}>
        Demo
      </button>
    </main>
  );
}
```

To test locally you can install Deno and use the following:
```
NITRO_PRESET=deno_deploy pnpm build && cd ./.output && deno run -A ./server/index.ts
```

The issue is the call to [`await request.json()` within handleServerFunction](https://github.com/solidjs/solid-start/blob/a670ffa3c498af6d16f44a4156edaca9d1fbc155/packages/start/config/server-handler.js#L94) freezes forever causing the request to hang until the function runtime (Eg. Vercel) times out.

It's worth noting nothing is special about this call to `request.json()`, it's just the place where the body is used. Any usages of the `request.body` will hang (including `.arrayBuffer()`, `.text()`, etc).

SolidStart calls Vinix [`toWebRequest`](https://github.com/nksaraf/vinxi/blob/bc0c2273cc2d39c45ff8725c1c06d74a93eb3ee3/packages/vinxi/runtime/server.js#L136) which in-turn calls H3's [`getRequestWebStream`](https://github.com/unjs/h3/blob/845eecaaaeffdb415321f76744e31d55074f37b8/src/utils/body.ts#L253).

Following along with the implementation of the`getRequestWebStream` function:

`event.web?.request?.body` is `undefined` so we go to the next condition,
`event._requestBody` is `undefined` so we go to the next condition,
We reach the "finally" condition and create a `ReadableStream` and call `event.node.req.on` to set up listeners to the body.

However, none of the `.on(...)` callbacks fire in these Edge environments so the promise hangs and the entire function freezes.

I noticed that `event.node.req.body` is an `ArrayBuffer` so we can bypass the `ReadableStream` and just use it as `body` property of the `Request` which is what this PR does.

This issue is related to:
 - #1165
 - nksaraf/vinxi/pull/118

## What is the new behavior?

The request returns correctly like it does when run using Node.js.
