### PR TITLE
fix: dev overlay stuff

### DIFF
--- a/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
+++ b/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
@@ -190,7 +190,7 @@ export default function DevOverlayDialog(props: DevOverlayDialogProps): JSX.Elem
     if (current) {
       htmlToImage.toPng(current, {
         style: {
-          transform: 'scale(1)',
+          transform: 'scale(0.75)',
         },
       }).then((url) => {
         download(url, 'start-screenshot.png');

--- a/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
+++ b/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
@@ -216,59 +216,61 @@ export default function DevOverlayDialog(props: DevOverlayDialogProps): JSX.Elem
       <Dialog class="dev-overlay" isOpen>
         <div>
           <DialogOverlay class="dev-overlay-background"/>
-          <DialogPanel ref={setPanel} class="dev-overlay-panel">
-            <div class="dev-overlay-navbar">
-              <div class="dev-overlay-navbar-left">
-                <div class="dev-overlay-version">
-                  <div>
-                    <SolidStartIcon title="Solid Start Version" />
-                  </div>
-                  <span>{info.version as string}</span>
-                </div>
-                <Show when={props.errors.length > 1}>
-                  <div class="dev-overlay-pagination">
-                    <button class="dev-overlay-button" onClick={goPrev} type="button">
-                      <ArrowLeftIcon title="Go Previous" />
-                    </button>
-                    <div class="dev-overlay-page-counter">
-                      {`${truncated()} of ${props.errors.length}`}
+          <DialogPanel ref={setPanel} class="dev-overlay-panel-container">
+            <div class="dev-overlay-panel">
+              <div class="dev-overlay-navbar">
+                <div class="dev-overlay-navbar-left">
+                  <div class="dev-overlay-version">
+                    <div>
+                      <SolidStartIcon title="Solid Start Version" />
                     </div>
-                    <button class="dev-overlay-button" onClick={goNext} type="button">
-                      <ArrowRightIcon title="Go Next" />
-                    </button>
+                    <span>{info.version as string}</span>
                   </div>
-                </Show>
-              </div>
-              <div class="dev-overlay-controls">
-                <button class="dev-overlay-button" onClick={redirectToGithub} type="button">
-                  <GithubIcon title="Create an issue thread on Github" />
-                </button>
-                <button class="dev-overlay-button" onClick={redirectToDiscord} type="button">
-                  <DiscordIcon title="Join our Discord Channel" />
-                </button>
-                <button class="dev-overlay-button" onClick={downloadScreenshot} type="button">
-                  <CameraIcon title="Capture Error Overlay" />
-                </button>
-                <button class="dev-overlay-button" onClick={toggleIsCompiled} type="button">
-                  <Show when={isCompiled()} fallback={(
-                    <ViewOriginalIcon title="View Original Source" />
-                  )}>
-                    <ViewCompiledIcon title="View Compiled Source" />
+                  <Show when={props.errors.length > 1}>
+                    <div class="dev-overlay-pagination">
+                      <button class="dev-overlay-button" onClick={goPrev} type="button">
+                        <ArrowLeftIcon title="Go Previous" />
+                      </button>
+                      <div class="dev-overlay-page-counter">
+                        {`${truncated()} of ${props.errors.length}`}
+                      </div>
+                      <button class="dev-overlay-button" onClick={goNext} type="button">
+                        <ArrowRightIcon title="Go Next" />
+                      </button>
+                    </div>
                   </Show>
-                </button>
-                <button class="dev-overlay-button" onClick={props.resetError} type="button">
-                  <RefreshIcon title="Reset Error" />
-                </button>
-              </div>
-            </div>
-            <Show when={props.errors[truncated() - 1]} keyed>
-              {(current) => (
-                <div class="dev-overlay-content">
-                  <ErrorInfo error={current} />
-                  <StackFrames error={current} isCompiled={isCompiled()} />
                 </div>
-              )}
-            </Show>
+                <div class="dev-overlay-controls">
+                  <button class="dev-overlay-button" onClick={redirectToGithub} type="button">
+                    <GithubIcon title="Create an issue thread on Github" />
+                  </button>
+                  <button class="dev-overlay-button" onClick={redirectToDiscord} type="button">
+                    <DiscordIcon title="Join our Discord Channel" />
+                  </button>
+                  <button class="dev-overlay-button" onClick={downloadScreenshot} type="button">
+                    <CameraIcon title="Capture Error Overlay" />
+                  </button>
+                  <button class="dev-overlay-button" onClick={toggleIsCompiled} type="button">
+                    <Show when={isCompiled()} fallback={(
+                      <ViewOriginalIcon title="View Original Source" />
+                    )}>
+                      <ViewCompiledIcon title="View Compiled Source" />
+                    </Show>
+                  </button>
+                  <button class="dev-overlay-button" onClick={props.resetError} type="button">
+                    <RefreshIcon title="Reset Error" />
+                  </button>
+                </div>
+              </div>
+              <Show when={props.errors[truncated() - 1]} keyed>
+                {(current) => (
+                  <div class="dev-overlay-content">
+                    <ErrorInfo error={current} />
+                    <StackFrames error={current} isCompiled={isCompiled()} />
+                  </div>
+                )}
+              </Show>
+            </div>
           </DialogPanel>
         </div>
       </Dialog>

--- a/packages/start/shared/dev-overlay/createStackFrame.ts
+++ b/packages/start/shared/dev-overlay/createStackFrame.ts
@@ -9,6 +9,13 @@ export interface StackFrameSource {
   column: number;
 }
 
+function getActualFileSource(path: string): string {
+  if (path.startsWith('file://')) {
+    return '/_build/@fs' + path.substring('file://'.length);
+  }
+  return path;
+}
+
 export function createStackFrame(
   stackframe: StackFrame,
   isCompiled: () => boolean,
@@ -24,7 +31,7 @@ export function createStackFrame(
       if (!source.fileName) {
         return null;
       }
-      const response = await fetch(source.fileName);
+      const response = await fetch(getActualFileSource(source.fileName));
       if (!response.ok) {
         return null;
       }
@@ -51,6 +58,7 @@ export function createStackFrame(
         line: source.line,
         column: source.column,
       });
+      console.log('sourcemap', result);
 
       return {
         ...result,

--- a/packages/start/shared/dev-overlay/styles.css
+++ b/packages/start/shared/dev-overlay/styles.css
@@ -25,10 +25,14 @@
   width: 75vw;
   margin-top: 2rem;
   margin-bottom: 2rem;
-  z-index: 10;
   gap: 0.5rem;
   color: rgb(17 24 39);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.dev-overlay-panel-container {
+  margin: 2rem;
+  z-index: 10;
 }
 
 .dev-overlay-navbar {


### PR DESCRIPTION
- Fix source to point to the exact file, which allows the code view to actually show the preview of the code rather than showing a fallback UI.
![Start Screenshot (12)](https://github.com/solidjs/solid-start/assets/4783372/b6b6db3d-e5ee-4f2f-9d55-ed1d238a7722)

- Fix screenshot generation