### PR TITLE
fix edge runtime errors reading formData and jsonData from request body

### DIFF
--- a/.changeset/neat-apricots-try.md
+++ b/.changeset/neat-apricots-try.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix formData and action issue for cloud runtimes

--- a/packages/start/config/server-handler.js
+++ b/packages/start/config/server-handler.js
@@ -92,9 +92,18 @@ async function handleServerFunction(h3Event) {
       contentType.startsWith("multipart/form-data") ||
       contentType.startsWith("application/x-www-form-urlencoded")
     ) {
-      parsed.push(await request.formData());
+      // workaround for https://github.com/unjs/nitro/issues/1721
+      // (issue only in edge runtimes)
+      parsed.push(await new Request(request, { ...request, body: event.node.req.body }).formData());
+      // what should work when #1721 is fixed 
+      // parsed.push(await request.formData);
     } else {
-      parsed = fromJSON(await request.json(), {
+      // workaround for https://github.com/unjs/nitro/issues/1721
+      // (issue only in edge runtimes)
+      const tmpReq = new Request(request, { ...request, body: event.node.req.body })
+      // what should work when #1721 is fixed
+      // just use request.json() here
+      parsed = fromJSON(await tmpReq.json(), {
         plugins: [
           CustomEventPlugin,
           DOMExceptionPlugin,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently when running solid-start in a edge runtime (cloudflare, netlify, vercel) the posting of data to the _server endpoint and `formData` to an action causes an error `A hanging Promise was canceled` (run in wrangler) that is coming from nitro -> https://github.com/unjs/nitro/issues/1721

## What is the new behavior?
Not causing this error any more

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
