### PR TITLE
Use proper types for response middlewares

### DIFF
--- a/packages/start/server/middleware.ts
+++ b/packages/start/server/middleware.ts
@@ -43,11 +43,15 @@ export function getFetchEvent(h3Event: H3Event): FetchEvent {
 export type MiddlewareFn = (event: FetchEvent) => Promise<unknown> | unknown;
 /** This composes an array of Exchanges into a single ExchangeIO function */
 
-type RequestMiddleware = (event: FetchEvent) => Response | Promise<Response> | void | Promise<void>;
+export type RequestMiddleware = (event: FetchEvent) => Response | Promise<Response> | void | Promise<void>;
 
-type ResponseMiddleware = (
+// copy-pasted from h3/dist/index.d.ts
+type EventHandlerResponse<T = any> = T | Promise<T>;
+type ResponseMiddlewareResponseParam = { body?: Awaited<EventHandlerResponse> };
+
+export type ResponseMiddleware = (
   event: FetchEvent,
-  response: { body: any }
+  response: ResponseMiddlewareResponseParam
 ) => Response | Promise<Response> | void | Promise<void>;
 
 function wrapRequestMiddleware(onRequest: RequestMiddleware) {
@@ -63,7 +67,7 @@ function wrapRequestMiddleware(onRequest: RequestMiddleware) {
 }
 
 function wrapResponseMiddleware(onBeforeResponse: ResponseMiddleware) {
-  return async (h3Event: H3Event, response: Response) => {
+  return async (h3Event: H3Event, response: ResponseMiddlewareResponseParam) => {
     const fetchEvent = getFetchEvent(h3Event);
     const mwResponse = await onBeforeResponse(fetchEvent, response);
     if (!mwResponse) {


### PR DESCRIPTION
1. second parameter is not a usual Response object. Only body is
   guaranteed to be present on it.
2. export types for middlewares, so that apps can use them


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Current before-response middlewares are told to treat second parameter as a usual Response object, which does not reflect reality

## What is the new behavior?
New behaviour copies types from H3, thus guaranteeing that the only "public" property of response is a body

