### PR TITLE
fix unocss example

### DIFF
--- a/.changeset/wild-yaks-flash.md
+++ b/.changeset/wild-yaks-flash.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix unocss example

--- a/examples/with-unocss/package.json
+++ b/examples/with-unocss/package.json
@@ -12,7 +12,7 @@
     "@unocss/reset": "^0.58.3",
     "solid-js": "^1.8.12",
     "unocss": "^0.58.3",
-    "vinxi": "^0.1.6"
+    "vinxi": "^0.2.1"
   },
   "engines": {
     "node": ">=18"

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -22,7 +22,7 @@
     "solid-js": "^1.8.12",
     "typescript": "^5.3.3",
     "vinxi": "^0.2.1",
-    "vite": "^4.4.9",
+    "vite": "^4.5.0",
     "vite-plugin-solid": "^2.9.1",
     "vitest": "^1.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "4.7.4",
     "valibot": "0.24.1",
     "vinxi": "^0.2.1",
-    "vite": "^4.4.6"
+    "vite": "^4.5.0"
   },
   "dependencies": {
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 0.2.0
       '@decs/typeschema':
         specifier: ^0.12.1
-        version: 0.12.1(valibot@0.24.1)(vite@4.4.9)
+        version: 0.12.1(valibot@0.24.1)(vite@4.5.0)
       '@solidjs/meta':
         specifier: ^0.29.0
         version: 0.29.3(solid-js@1.8.12)
@@ -68,7 +68,7 @@ importers:
         version: 1.8.12
       solid-mdx:
         specifier: ^0.0.7
-        version: 0.0.7(solid-js@1.8.12)(vite@4.4.9)
+        version: 0.0.7(solid-js@1.8.12)(vite@4.5.0)
       solid-start-mdx:
         specifier: workspace:*
         version: link:packages/mdx
@@ -91,8 +91,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@types/node@20.10.1)(debug@4.3.4)(preact@10.19.3)
       vite:
-        specifier: ^4.4.6
-        version: 4.4.9
+        specifier: ^4.5.0
+        version: 4.5.0(@types/node@20.10.1)
 
   examples/bare:
     dependencies:
@@ -342,8 +342,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(postcss@8.4.33)(vite@4.5.0)
       vinxi:
-        specifier: ^0.1.6
-        version: 0.1.6(debug@4.3.4)(preact@10.19.3)
+        specifier: ^0.2.1
+        version: 0.2.1(@types/node@20.10.1)(debug@4.3.4)(preact@10.19.3)
 
   examples/with-vitest:
     devDependencies:
@@ -381,11 +381,11 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@testing-library/jest-dom@6.1.5)(debug@4.3.4)(preact@10.19.3)
       vite:
-        specifier: ^4.4.9
-        version: 4.4.9
+        specifier: ^4.5.0
+        version: 4.5.0(@types/node@20.10.1)
       vite-plugin-solid:
         specifier: ^2.9.1
-        version: 2.9.1(@testing-library/jest-dom@6.1.5)(solid-js@1.8.12)(vite@4.4.9)
+        version: 2.9.1(@testing-library/jest-dom@6.1.5)(solid-js@1.8.12)(vite@4.5.0)
       vitest:
         specifier: ^1.2.1
         version: 1.2.1(@vitest/ui@1.1.0)(jsdom@24.0.0)
@@ -1155,7 +1155,7 @@ packages:
       vite: 4.5.0(@types/node@20.10.1)
     dev: false
 
-  /@decs/typeschema@0.12.1(valibot@0.24.1)(vite@4.4.9):
+  /@decs/typeschema@0.12.1(valibot@0.24.1)(vite@4.5.0):
     resolution: {integrity: sha512-PhoCbaJ6T+9EfvUkemgYVnNfLmLoP2+Aa5yvQ3sIzH4fmIgDEFPGSRPuaTO04c99sqLeKuhHEY+WLzNubGABOA==}
     peerDependencies:
       '@deepkit/type': ^1.0.1-alpha.97
@@ -1209,7 +1209,7 @@ packages:
         optional: true
     dependencies:
       valibot: 0.24.1
-      vite: 4.4.9
+      vite: 4.5.0(@types/node@20.10.1)
     dev: true
 
   /@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19):
@@ -3145,28 +3145,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  /@vinxi/devtools@0.1.1(@babel/core@7.23.9)(preact@10.19.3)(vite@4.5.0):
-    resolution: {integrity: sha512-/A7X1hoNBsgC2n7nKOWbIa4cTt9dJq9nehyLGdNxgjEcGzbsaJrofUDrFLt+0YJlyb7OOhFEPYHRCat3tsrytw==}
-    dependencies:
-      '@preact/preset-vite': 2.8.1(@babel/core@7.23.9)(preact@10.19.3)(vite@4.5.0)
-      '@solidjs/router': 0.8.4(solid-js@1.8.12)
-      birpc: 0.2.15
-      solid-js: 1.8.12
-      vite-plugin-inspect: 0.7.42(vite@4.5.0)
-      vite-plugin-solid: 2.9.1(@testing-library/jest-dom@6.1.5)(solid-js@1.8.12)(vite@4.5.0)
-      ws: 8.16.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - bufferutil
-      - preact
-      - rollup
-      - supports-color
-      - utf-8-validate
-      - vite
-    dev: false
 
   /@vinxi/devtools@0.2.0(@babel/core@7.23.9)(@testing-library/jest-dom@6.1.5)(preact@10.19.3)(vite@4.5.0):
     resolution: {integrity: sha512-LpQp5zbiBhV4eo2w6AiJFtpZZj4LaRBOnzggIPTeSJYvgrxRMAqe/34Har3vVo+b7sPOjxFbE1zHZhLzaAcidw==}
@@ -5371,19 +5349,6 @@ packages:
       ufo: 1.3.2
       uncrypto: 0.1.3
       unenv: 1.9.0
-
-  /h3@1.9.0:
-    resolution: {integrity: sha512-+F3ZqrNV/CFXXfZ2lXBINHi+rM4Xw3CDC5z2CDK3NMPocjonKipGLLDSkrqY9DOrioZNPTIdDMWfQKm//3X2DA==}
-    dependencies:
-      cookie-es: 1.0.0
-      defu: 6.1.4
-      destr: 2.0.2
-      iron-webcrypto: 1.0.0
-      radix3: 1.1.0
-      ufo: 1.3.2
-      uncrypto: 0.1.3
-      unenv: 1.9.0
-    dev: false
 
   /har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -8502,16 +8467,6 @@ packages:
       seroval: 1.0.4
       seroval-plugins: 1.0.4(seroval@1.0.4)
 
-  /solid-mdx@0.0.7(solid-js@1.8.12)(vite@4.4.9):
-    resolution: {integrity: sha512-dYKGOu5ZiaX3sfEMZYtfyXm30u33kF+T/pr67CMeyHzENDkWD3st4XEJ12Akp0J0PG9jzyHe5sAAKEXSnEcDEw==}
-    peerDependencies:
-      solid-js: ^1.2.6
-      vite: '*'
-    dependencies:
-      solid-js: 1.8.12
-      vite: 4.4.9
-    dev: true
-
   /solid-mdx@0.0.7(solid-js@1.8.12)(vite@4.5.0):
     resolution: {integrity: sha512-dYKGOu5ZiaX3sfEMZYtfyXm30u33kF+T/pr67CMeyHzENDkWD3st4XEJ12Akp0J0PG9jzyHe5sAAKEXSnEcDEw==}
     peerDependencies:
@@ -8520,7 +8475,6 @@ packages:
     dependencies:
       solid-js: 1.8.12
       vite: 4.5.0(@types/node@20.10.1)
-    dev: false
 
   /solid-refresh@0.6.3(solid-js@1.8.12):
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -9638,86 +9592,6 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /vinxi@0.1.6(debug@4.3.4)(preact@10.19.3):
-    resolution: {integrity: sha512-UFhlZzfAYZIXbFngDOSAr9cdMm547gEweW/fjRr/KzkysLiXPYGIE3LPiXw7SPF/he2F9pDP9gb55+Jj32pdQQ==}
-    hasBin: true
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.9)
-      '@types/micromatch': 4.0.6
-      '@types/serve-static': 1.15.5
-      '@types/ws': 8.5.10
-      '@vinxi/devtools': 0.1.1(@babel/core@7.23.9)(preact@10.19.3)(vite@4.5.0)
-      '@vinxi/listhen': 1.5.6
-      boxen: 7.1.1
-      c12: 1.6.1
-      chokidar: 3.5.3
-      citty: 0.1.5
-      consola: 3.2.3
-      defu: 6.1.2
-      dts-buddy: 0.2.5
-      es-module-lexer: 1.4.1
-      esbuild: 0.18.20
-      fast-glob: 3.3.2
-      get-port: 6.1.2
-      get-port-please: 3.1.2
-      h3: 1.9.0
-      hookable: 5.5.3
-      http-proxy: 1.18.1(debug@4.3.4)
-      iron-webcrypto: 1.0.0
-      micromatch: 4.0.5
-      mri: 1.2.0
-      nitropack: 2.8.1
-      node-fetch-native: 1.6.1
-      path-to-regexp: 6.2.1
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      radix3: 1.1.0
-      resolve: 1.22.8
-      rollup-plugin-visualizer: 5.12.0(rollup@4.9.6)
-      serve-placeholder: 2.0.1
-      serve-static: 1.15.0
-      ufo: 1.3.2
-      uncrypto: 0.1.3
-      unenv: 1.9.0
-      unimport: 3.7.1(rollup@4.9.6)
-      unstorage: 1.10.1
-      vite: 4.5.0(@types/node@20.10.1)
-      ws: 8.16.0
-      zod: 3.22.4
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@netlify/blobs'
-      - '@nuxt/kit'
-      - '@planetscale/database'
-      - '@testing-library/jest-dom'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - bufferutil
-      - debug
-      - encoding
-      - idb-keyval
-      - less
-      - lightningcss
-      - preact
-      - rollup
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - utf-8-validate
-      - xml2js
-    dev: false
-
   /vinxi@0.2.1(@testing-library/jest-dom@6.1.5)(debug@4.3.4)(preact@10.19.3):
     resolution: {integrity: sha512-zrgFO2XuKpdoW5VwlbieeQ0YhzMuuYCJyFWFyj41h9BnymHZ5dnKElALvFQn5JVzHhyrsdmlm8GU7tIuH786hw==}
     hasBin: true
@@ -9736,7 +9610,7 @@ packages:
       citty: 0.1.5
       consola: 3.2.3
       cookie-es: 1.0.0
-      defu: 6.1.2
+      defu: 6.1.4
       dts-buddy: 0.2.5
       es-module-lexer: 1.4.1
       esbuild: 0.18.20
@@ -9817,7 +9691,7 @@ packages:
       citty: 0.1.5
       consola: 3.2.3
       cookie-es: 1.0.0
-      defu: 6.1.2
+      defu: 6.1.4
       dts-buddy: 0.2.5
       es-module-lexer: 1.4.1
       esbuild: 0.18.20
@@ -9957,29 +9831,6 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-solid@2.9.1(@testing-library/jest-dom@6.1.5)(solid-js@1.8.12)(vite@4.4.9):
-    resolution: {integrity: sha512-RC4hj+lbvljw57BbMGDApvEOPEh14lwrr/GeXRLNQLcR1qnOdzOwwTSFy13Gj/6FNIZpBEl0bWPU+VYFawrqUw==}
-    peerDependencies:
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: ^1.7.2
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.9
-      '@testing-library/jest-dom': 6.1.5(vitest@1.2.1)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.8.12(@babel/core@7.23.9)
-      merge-anything: 5.1.7
-      solid-js: 1.8.12
-      solid-refresh: 0.6.3(solid-js@1.8.12)
-      vite: 4.4.9
-      vitefu: 0.2.5(vite@4.4.9)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /vite-plugin-solid@2.9.1(@testing-library/jest-dom@6.1.5)(solid-js@1.8.12)(vite@4.5.0):
     resolution: {integrity: sha512-RC4hj+lbvljw57BbMGDApvEOPEh14lwrr/GeXRLNQLcR1qnOdzOwwTSFy13Gj/6FNIZpBEl0bWPU+VYFawrqUw==}
     peerDependencies:
@@ -10001,41 +9852,6 @@ packages:
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  /vite@4.4.9:
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.33
-      rollup: 3.29.4
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
 
   /vite@4.5.0(@types/node@20.10.1):
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
@@ -10105,17 +9921,6 @@ packages:
       rollup: 4.9.6
     optionalDependencies:
       fsevents: 2.3.3
-
-  /vitefu@0.2.5(vite@4.4.9):
-    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 4.4.9
-    dev: true
 
   /vitefu@0.2.5(vite@4.5.0):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}


### PR DESCRIPTION
I couldn't build the unocss example - it was because it wasn't bumped to vinxi 0.2.x like the rest of the example. Also set vite consistently to 4.5.x (like vinxi), where currently both 4.4.6 and 4.4.9 are used.