### PR TITLE
fix: ensure ParentProps is declared as a type import

### DIFF
--- a/.changeset/many-eggs-move.md
+++ b/.changeset/many-eggs-move.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed an issue with TypeScript based projects throwing client side errors regarding a type input in the `ErrorBoundary`.wq

--- a/packages/start/shared/ErrorBoundary.tsx
+++ b/packages/start/shared/ErrorBoundary.tsx
@@ -1,24 +1,13 @@
-import {
-  ErrorBoundary as DefaultErrorBoundary,
-  ParentProps,
-} from "solid-js";
+import { ErrorBoundary as DefaultErrorBoundary, type ParentProps } from "solid-js";
 import { HttpStatusCode } from "./HttpStatusCode";
 import { DevOverlay } from "./dev-overlay";
 
 export function ErrorBoundary(props: ParentProps) {
   if (import.meta.env.DEV) {
-    return (
-      <DevOverlay>
-        {props.children}
-      </DevOverlay>
-    );
+    return <DevOverlay>{props.children}</DevOverlay>;
   }
   return (
-    <DefaultErrorBoundary
-      fallback={(
-        <HttpStatusCode code={500} />
-      )}
-    >
+    <DefaultErrorBoundary fallback={<HttpStatusCode code={500} />}>
       {props.children}
     </DefaultErrorBoundary>
   );


### PR DESCRIPTION
Fixes #1311

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

```sh
yarn dlx create-solid
//... (I picked Tailwind + TypeScript)

yarn dev --open
```

In the console, the following error appears:

```
Uncaught SyntaxError: The requested module '/_build/node_modules/.vite/deps/solid-js.js?v=0fd153d1' does not provide an export named 'ParentProps' (at ErrorBoundary.tsx:2:49)
```

The error prevents client-side interaction other than navigation.

Building the application and running production mode does _not_ have the error.

## What is the new behavior?

No more syntax error in browser.

I verified this works by manually modifying the code from NPM when creating my application.

> [!NOTE]
> This was not reproducible within the solid-start repository. I suspect it has to do with local tsc compiling/configs?

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
