### PR TITLE
Redirect helper component

### DIFF
--- a/docs/routes/api/Redirect.md
+++ b/docs/routes/api/Redirect.md
@@ -26,13 +26,13 @@ import { Redirect } from "@solidjs/start";
 
 ### Using permanent redirects
 
-`Redirect` defaults to a temporary redirect (HTTP status code 307), but can be made permanent, sending a 308 status instead:
-
 ```tsx twoslash
 import { Redirect } from "@solidjs/start";
 // ---cut---
 <Redirect to="/some-other-page" permanent />;
 ```
+
+`Redirect` defaults to a temporary redirect (HTTP status code 307), but can be made permanent, sending a 308 status instead.
 
 ### Redirecting to start page on 404
 

--- a/docs/routes/api/Redirect.md
+++ b/docs/routes/api/Redirect.md
@@ -31,5 +31,17 @@ import { Redirect } from "@solidjs/start";
 ```tsx twoslash
 import { Redirect } from "@solidjs/start";
 // ---cut---
-<Redirect to="/" permanent />;
+<Redirect to="/some-other-page" permanent />;
 ```
+
+### Redirecting to start page on 404
+
+```tsx twoslash filename="routes/*404.tsx"
+import { Redirect } from "@solidjs/start";
+
+export default function NotFound() {
+  return <Redirect to="/" />;
+}
+```
+
+A custom 404 page may not be necessary for every website, in that case a simple redirect to the start page can implemented using `Redirect`.

--- a/docs/routes/api/Redirect.md
+++ b/docs/routes/api/Redirect.md
@@ -1,0 +1,35 @@
+---
+section: api
+title: Redirect
+order: 12
+subsection: Document
+active: true
+---
+
+# Redirect
+
+##### `Redirect` is a component that redirects the user while server-side rendering.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { Redirect } from "@solidjs/start";
+// ---cut---
+<Redirect to="/" />;
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Using permanent redirects
+
+`Redirect` defaults to a temporary redirect (HTTP status code 307), but can be made permanent, sending a 308 status instead:
+
+```tsx twoslash
+import { Redirect } from "@solidjs/start";
+// ---cut---
+<Redirect to="/" permanent />;
+```

--- a/packages/start/shared/Redirect.tsx
+++ b/packages/start/shared/Redirect.tsx
@@ -1,0 +1,6 @@
+export default function Redirect(props: { to: string, permanent: boolean }) {
+  return <>
+    <HttpHeader name="location" value={props.to} />
+    <HttpStatusCode code={props.permanent ? 308 : 307} />
+  </>
+}

--- a/packages/start/shared/index.tsx
+++ b/packages/start/shared/index.tsx
@@ -2,5 +2,5 @@ export { FileRoutes } from "./FileRoutes";
 export { GET } from "./GET";
 export { HttpHeader } from "./HttpHeader";
 export { HttpStatusCode } from "./HttpStatusCode";
+export { Redirect } from "./Redirect";
 export { default as clientOnly } from "./clientOnly";
-


### PR DESCRIPTION
## Scenario

While implementing a catch-all 404 redirect I noticed there's no built-in way for redirecting, so one has to be aware of the `location` header name and the correct HTTP status codes. This Redirect component is supposed to simplify that, and simply wraps the existing `HttpHeader` and `HttpStatusCode` components.

```tsx
// [...404].tsx

import { HttpHeader, HttpStatusCode } from "@solidjs/start";

export default function NotFound() {
  return (
    <>
      <HttpHeader name="location" value="/" />
      <HttpStatusCode code={307} />
    </>
  );
}
```

becomes

```tsx
// [...404].tsx

import { Redirect } from "@solidjs/start";

export default function NotFound() {
  return <Redirect to="/" />;
}
```

## Considerations

### Maybe allow setting the status code to 301 | 302 | 303 | 307 | 308 like Next.JS does.

The component could default to 307, allow `permanent` for 308 (these two should cover 99% of use cases), but the user could instead use `<Redirect to="/" statusCode={301} />` for specific status codes if required.
