### PR TITLE
fix auto import proposal

### DIFF
--- a/.changeset/hip-insects-ring.md
+++ b/.changeset/hip-insects-ring.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix: resolve the import path correctly (@solidjs/start/server vs @solidjs/start/./server)

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -33,13 +33,13 @@
       ".": [
         "./shared/index.tsx"
       ],
-      "./middleware": [
+      "middleware": [
         "./middleware/index.ts"
       ],
-      "./server": [
+      "server": [
         "./server/index.tsx"
       ],
-      "./client": [
+      "client": [
         "./client/index.tsx"
       ]
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [x] Other... Please describe:
module auto import fix (loosing the extra `./`)
![Screenshot 2024-02-19 at 17 11 29](https://github.com/solidjs/solid-start/assets/530789/7260b122-aaac-45cb-b86c-390974226275)

## What is the current behavior?
Currently the proposed import is showing e.g. `@solidjs/start/./server`

## What is the new behavior?
as in screenshot is showing the proper import `@solidjs/start/server`

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
