### PR TITLE
Fix refresh pragma

### DIFF
--- a/.changeset/neat-avocados-teach.md
+++ b/.changeset/neat-avocados-teach.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix refresh pragma

--- a/examples/bare/src/app.tsx
+++ b/examples/bare/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { createSignal } from "solid-js";
 import "./app.css";
 

--- a/examples/bare/src/entry-client.tsx
+++ b/examples/bare/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/bare/src/entry-server.tsx
+++ b/examples/bare/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";

--- a/examples/basic/src/entry-client.tsx
+++ b/examples/basic/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/basic/src/entry-server.tsx
+++ b/examples/basic/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/experiments/src/app.tsx
+++ b/examples/experiments/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";

--- a/examples/experiments/src/entry-client.tsx
+++ b/examples/experiments/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/experiments/src/entry-server.tsx
+++ b/examples/experiments/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { StartServer, createHandler } from "@solidjs/start/server";
 
 declare module "@solidjs/start/server" {

--- a/examples/hackernews/src/app.tsx
+++ b/examples/hackernews/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/hackernews/src/entry-client.tsx
+++ b/examples/hackernews/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/hackernews/src/entry-server.tsx
+++ b/examples/hackernews/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/notes/src/app.tsx
+++ b/examples/notes/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/notes/src/entry-client.tsx
+++ b/examples/notes/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/notes/src/entry-server.tsx
+++ b/examples/notes/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/todomvc/src/app.tsx
+++ b/examples/todomvc/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/todomvc/src/entry-client.tsx
+++ b/examples/todomvc/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/todomvc/src/entry-server.tsx
+++ b/examples/todomvc/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-auth/src/entry-client.tsx
+++ b/examples/with-auth/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-auth/src/entry-server.tsx
+++ b/examples/with-auth/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-mdx/src/app.tsx
+++ b/examples/with-mdx/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/with-mdx/src/entry-client.tsx
+++ b/examples/with-mdx/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-mdx/src/entry-server.tsx
+++ b/examples/with-mdx/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-prisma/src/app.tsx
+++ b/examples/with-prisma/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/with-prisma/src/entry-client.tsx
+++ b/examples/with-prisma/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-prisma/src/entry-server.tsx
+++ b/examples/with-prisma/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-solid-styled/src/app.tsx
+++ b/examples/with-solid-styled/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { MetaProvider } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";

--- a/examples/with-solid-styled/src/entry-client.tsx
+++ b/examples/with-solid-styled/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-solid-styled/src/entry-server.tsx
+++ b/examples/with-solid-styled/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-tailwindcss/src/app.tsx
+++ b/examples/with-tailwindcss/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/with-tailwindcss/src/entry-client.tsx
+++ b/examples/with-tailwindcss/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-tailwindcss/src/entry-server.tsx
+++ b/examples/with-tailwindcss/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-trpc/src/app.tsx
+++ b/examples/with-trpc/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";

--- a/examples/with-trpc/src/entry-client.tsx
+++ b/examples/with-trpc/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-trpc/src/entry-server.tsx
+++ b/examples/with-trpc/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-unocss/src/app.tsx
+++ b/examples/with-unocss/src/app.tsx
@@ -1,7 +1,6 @@
-import "virtual:uno.css";
 import "@unocss/reset/tailwind.css";
+import "virtual:uno.css";
 
-// @refresh reload
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";
 import { Suspense } from "solid-js";

--- a/examples/with-unocss/src/entry-client.tsx
+++ b/examples/with-unocss/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-unocss/src/entry-server.tsx
+++ b/examples/with-unocss/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/examples/with-vitest/src/app.tsx
+++ b/examples/with-vitest/src/app.tsx
@@ -1,4 +1,3 @@
-// @refresh reload
 import { MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start";

--- a/examples/with-vitest/src/entry-client.tsx
+++ b/examples/with-vitest/src/entry-client.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
 mount(() => <StartClient />, document.getElementById("app")!);

--- a/examples/with-vitest/src/entry-server.tsx
+++ b/examples/with-vitest/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @refresh reload
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/packages/start/client/StartClient.tsx
+++ b/packages/start/client/StartClient.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 // @ts-ignore
 import App from "#start/app";
 import type { JSX } from "solid-js";

--- a/packages/start/client/index.tsx
+++ b/packages/start/client/index.tsx
@@ -1,3 +1,6 @@
+// @refresh skip
+// TODO rename to index.tsx?
 import "vinxi/client";
 export { StartClient } from "./StartClient";
 export { mount } from "./mount";
+

--- a/packages/start/client/islands.tsx
+++ b/packages/start/client/islands.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import "vinxi/client";
 export function StartClient() {
   return null;

--- a/packages/start/client/spa/index.tsx
+++ b/packages/start/client/spa/index.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import type { JSX } from "solid-js";
 import { render, type MountableElement } from "solid-js/web";
 import "vinxi/client";

--- a/packages/start/index.tsx
+++ b/packages/start/index.tsx
@@ -1,1 +1,3 @@
+// @refresh skip
+// TODO rename to index.ts?
 export * from "./shared/index";

--- a/packages/start/server/StartServer.tsx
+++ b/packages/start/server/StartServer.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 // @ts-ignore
 import App from "#start/app";
 import type { Component, JSX } from "solid-js";

--- a/packages/start/server/index.tsx
+++ b/packages/start/server/index.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to index.ts?
 export { StartServer } from "./StartServer";
 export { createHandler } from "./handler";
 export * from "./types";

--- a/packages/start/server/islands/index.tsx
+++ b/packages/start/server/islands/index.tsx
@@ -1,5 +1,6 @@
-import { type Component, type ComponentProps, lazy, sharedConfig } from "solid-js";
-import { getRequestEvent, Hydration, NoHydration } from "solid-js/web";
+// @refresh skip
+import { lazy, sharedConfig, type Component, type ComponentProps } from "solid-js";
+import { Hydration, NoHydration, getRequestEvent } from "solid-js/web";
 // import { IslandManifest } from "./types";
 import { splitProps } from "./utils";
 

--- a/packages/start/server/islands/utils.tsx
+++ b/packages/start/server/islands/utils.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to utils.ts?
 // @ts-nocheck
 import { $PROXY } from "solid-js";
 

--- a/packages/start/server/renderAsset.tsx
+++ b/packages/start/server/renderAsset.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to renderAsset.ts?
 import type { JSX } from "solid-js";
 import type { Asset } from "./types";
 

--- a/packages/start/server/spa/StartServer.tsx
+++ b/packages/start/server/spa/StartServer.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 // @ts-ignore
 import type { Component } from "solid-js";
 import { NoHydration, getRequestEvent, ssr } from "solid-js/web";

--- a/packages/start/server/spa/index.tsx
+++ b/packages/start/server/spa/index.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to index.ts?
 export * from "../types";
 export { StartServer } from "./StartServer";
 export { createHandler } from "./handler";

--- a/packages/start/shared/ErrorBoundary.tsx
+++ b/packages/start/shared/ErrorBoundary.tsx
@@ -1,23 +1,23 @@
+// @refresh skip
 import { ErrorBoundary as DefaultErrorBoundary, type ParentProps } from "solid-js";
 import { isServer } from "solid-js/web";
 import { HttpStatusCode } from "./HttpStatusCode";
 import { DevOverlay } from "./dev-overlay";
 
-export function ErrorBoundary(props: ParentProps) {
-  if (import.meta.env.DEV && import.meta.env.START_DEV_OVERLAY) {
-    return <DevOverlay>{props.children}</DevOverlay>;
-  }
-  const message = isServer ? "500 | Internal Server Error" : "Error | Uncaught Client Exception";
-  return (
-    <DefaultErrorBoundary
-      fallback={
-        <>
-          <span style="font-size:1.5em;text-align:center;position:fixed;left:0px;bottom:55%;width:100%;">{message}</span>
-          <HttpStatusCode code={500} />
-        </>
-      }
-    >
-      {props.children}
-    </DefaultErrorBoundary>
-  );
-}
+export const ErrorBoundary = import.meta.env.DEV && import.meta.env.START_DEV_OVERLAY
+  ? (props: ParentProps) => <DevOverlay>{props.children}</DevOverlay>
+  : (props: ParentProps) => {
+    const message = isServer ? "500 | Internal Server Error" : "Error | Uncaught Client Exception";
+    return (
+      <DefaultErrorBoundary
+        fallback={
+          <>
+            <span style="font-size:1.5em;text-align:center;position:fixed;left:0px;bottom:55%;width:100%;">{message}</span>
+            <HttpStatusCode code={500} />
+          </>
+        }
+      >
+        {props.children}
+      </DefaultErrorBoundary>
+    )
+  };

--- a/packages/start/shared/FileRoutes.tsx
+++ b/packages/start/shared/FileRoutes.tsx
@@ -30,6 +30,6 @@ export function createRoutes() {
 }
 
 let routes: any[];
-export const FileRoutes = () => {
-  return isServer ? (getRequestEvent() as PageEvent).routes : routes || (routes = createRoutes());
-};
+export const FileRoutes = isServer 
+  ? () => (getRequestEvent() as PageEvent).routes
+  : () => routes || (routes = createRoutes());

--- a/packages/start/shared/HttpHeader.tsx
+++ b/packages/start/shared/HttpHeader.tsx
@@ -1,9 +1,16 @@
+// @refresh skip
 import { onCleanup } from "solid-js";
 import { getRequestEvent, isServer } from "solid-js/web";
 import type { PageEvent } from "../server/types";
 
-export function HttpHeader(props: { name: string; value: string; append?: boolean }) {
-  if (isServer) {
+export interface HttpHeaderProps {
+  name: string;
+  value: string;
+  append?: boolean;
+}
+
+export const HttpHeader = isServer
+  ? (props: HttpHeaderProps) => {
     const event = getRequestEvent() as PageEvent;
 
     if (props.append) event.response.headers.append(props.name, props.value);
@@ -23,7 +30,6 @@ export function HttpHeader(props: { name: string; value: string; append?: boolea
       if (values.length) event.response.headers.set(props.name, values.join(","));
       else event.response.headers.delete(props.name);
     });
+    return null;
   }
-
-  return null;
-}
+  : (_props: HttpHeaderProps) => null;

--- a/packages/start/shared/HttpStatusCode.tsx
+++ b/packages/start/shared/HttpStatusCode.tsx
@@ -1,13 +1,19 @@
+// @refresh skip
 import { onCleanup } from "solid-js";
 import { getRequestEvent, isServer } from "solid-js/web";
 import type { PageEvent } from "../server/types";
 
-export function HttpStatusCode(props: { code: number, text?: string }) {
-  if (isServer) {
+export interface HttpStatusCodeProps {
+  code: number;
+  text?: string;
+}
+
+export const HttpStatusCode = isServer
+  ? (props: HttpStatusCodeProps) => {
     const event = getRequestEvent() as PageEvent;
     event.response.status = props.code;
     event.response.statusText = props.text;
     onCleanup(() => !event.nativeEvent.handled && (event.response.status = 200));
+    return null;
   }
-  return null;
-}
+  : (_props: HttpStatusCodeProps) => null;

--- a/packages/start/shared/clientOnly.tsx
+++ b/packages/start/shared/clientOnly.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import type { Component, ComponentProps, JSX } from "solid-js";
 import { createMemo, createSignal, onMount, sharedConfig, splitProps, untrack } from "solid-js";
 import { isServer } from "solid-js/web";

--- a/packages/start/shared/dev-overlay/CodeView.tsx
+++ b/packages/start/shared/dev-overlay/CodeView.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import type { BuiltinLanguage, Highlighter } from 'shikiji';
 import { getHighlighterCore, loadWasm } from 'shikiji/core';
 import { createEffect, createResource, type JSX } from 'solid-js';

--- a/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
+++ b/packages/start/shared/dev-overlay/DevOverlayDialog.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import ErrorStackParser from 'error-stack-parser';
 import * as htmlToImage from 'html-to-image';
 import type { JSX } from 'solid-js';

--- a/packages/start/shared/dev-overlay/icons.tsx
+++ b/packages/start/shared/dev-overlay/icons.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import type { JSX } from 'solid-js';
 
 export function ArrowRightIcon(

--- a/packages/start/shared/dev-overlay/index.tsx
+++ b/packages/start/shared/dev-overlay/index.tsx
@@ -1,3 +1,4 @@
+// @refresh skip
 import {
   ErrorBoundary,
   Show,

--- a/packages/start/shared/index.tsx
+++ b/packages/start/shared/index.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to index.ts?
 export { FileRoutes } from "./FileRoutes";
 export { GET } from "./GET";
 export { HttpHeader } from "./HttpHeader";

--- a/packages/start/shared/lazyRoute.tsx
+++ b/packages/start/shared/lazyRoute.tsx
@@ -1,3 +1,5 @@
+// @refresh skip
+// TODO rename to lazyRoute.ts?
 /// <reference types="vinxi/types/client" />
 import { createComponent, lazy, onCleanup, type Component, type JSX } from "solid-js";
 import { appendStyles, cleanupStyles, preloadStyles, updateStyles } from "vinxi/css";


### PR DESCRIPTION
- Fixes the examples to use the `@refresh reload` pragma at the correct place (the entry files)
- Fixes tsx files in the core package to use `@refresh skip`.
- Bonus: fixes components that use isServer to use the variable at module-level so that the bundler can perform dead-code elimination properly.