### PR TITLE
fix(dev-overlay): Code view breaking if the file extension was mjs or cjs

### DIFF
--- a/.changeset/kind-mirrors-trade.md
+++ b/.changeset/kind-mirrors-trade.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix dev overlay's CodeView not working with `mjs` or `cjs` files

--- a/packages/start/shared/dev-overlay/CodeView.tsx
+++ b/packages/start/shared/dev-overlay/CodeView.tsx
@@ -58,11 +58,15 @@ export function CodeView(props: CodeViewProps): JSX.Element | null {
     .join('\n')
   ) ,async (value) => {
     const highlighter = await loadHighlighter();
-    const lang = props.fileName
+    const fileExtension = props.fileName
       .split(/[#?]/)[0]!
       .split('.')
       .pop()
-      ?.trim() as BuiltinLanguage;
+      ?.trim();
+    let lang = fileExtension as BuiltinLanguage;
+    if (fileExtension === 'mjs' || fileExtension === 'cjs') {
+      lang = 'js';
+    }
     return highlighter.codeToHtml(value, {
       theme: 'dark-plus',
       lang,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If a library used plain MJS for their code, or just plain CJS it ended up being
that the code view in the development overlay would not recognize the file type because
Shiki expects `mjs` and `cjs` to be passed into it as JavaScript.

## What is the new behavior?

Before actually passing in the language to the highlighter it checks if the file extension is
`mjs` or `cjs` and then assumes the language is `js` instead.

