### PR TITLE
fix: script invocation error for "create-solid@latest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pnpm install
 pnpm dev
 
 # or with Bun
-bunx create-solid@latest
+bunx create solid@latest
 bun install
 bun run dev
 ```

--- a/docs/routes/getting-started/project-setup.mdx
+++ b/docs/routes/getting-started/project-setup.mdx
@@ -17,7 +17,7 @@ npm init solid@latest
 # pnpm
 pnpm create solid
 # bun
-bunx create-solid
+bunx create solid
 ```
 
 You will get a list of templates from which to choose. You can view the code for each of these options in the [SolidStart repository](https://github.com/solidjs/solid-start/tree/main/examples).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

```
$ bunx create-solid@latest
error: Script not found "create-solid@latest"
```

## What is the new behavior?

The corrected bunx command for "create-solid@latest" has been updated in the project's README and documentation, resolving the "Script not found" error.


## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
N/A
