### PR TITLE
Set title required and add placeholder

### DIFF
--- a/examples/notes/src/components/NoteEditor.tsx
+++ b/examples/notes/src/components/NoteEditor.tsx
@@ -38,6 +38,8 @@ export default function NoteEditor(props: {
           id="note-title-input"
           type="text"
           name="title"
+          placeholder="Title"
+          required={true}
           value={title()}
           onInput={e => {
             setTitle(e.currentTarget.value);

--- a/examples/notes/src/routes/new.tsx
+++ b/examples/notes/src/routes/new.tsx
@@ -1,5 +1,5 @@
 import NoteEditor from "~/components/NoteEditor";
 
 export default function NewPage() {
-  return <NoteEditor initialTitle="Untitled" initialBody="" />;
+  return <NoteEditor initialTitle="" initialBody="" />;
 }


### PR DESCRIPTION
I found it a bit annoying that the title was "Untitled", not as a placeholder but as the actual value. Now there is a "Title" placeholder instead, and it's a required field.

Before:

<img width="444" alt="Screenshot 2024-03-11 at 21 30 01" src="https://github.com/solidjs/solid-start/assets/74932975/f860fc92-e0df-4f84-9878-e99244262965">


After (if you click save without typing)
<img width="608" alt="Screenshot 2024-03-11 at 21 29 36" src="https://github.com/solidjs/solid-start/assets/74932975/2e9e720e-d328-4ed7-84cf-46d0229b64cf">
