### PR TITLE
fix: bun project create command with solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pnpm install
 pnpm dev
 
 # or with Bun
-bunx create solid@latest
+bun create solid@latest
 bun install
 bun run dev
 ```

--- a/docs/routes/getting-started/project-setup.mdx
+++ b/docs/routes/getting-started/project-setup.mdx
@@ -17,7 +17,7 @@ npm init solid@latest
 # pnpm
 pnpm create solid
 # bun
-bunx create solid
+bun create solid
 ```
 
 You will get a list of templates from which to choose. You can view the code for each of these options in the [SolidStart repository](https://github.com/solidjs/solid-start/tree/main/examples).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The current project bootstrap command for solid with bun doesn't work as it errors out with.
```
$ bunx create solid
error: could not determine executable to run for package create 
```
Which is obvious as `bunx` technically is the same as npx/pnpx (execute an npm package executable (CLI), and automatically installing into a global shared cache if not found in `node_modules`). Currently it's looking for the package `create` rather than the `create command` which is causing that error.

Additional Info: I think it might be a issue with bun installation as when installed using a package manager such as (pnpm install -g bun), it doesn't create the correct symlinks of ``bun x`` to ``bunx`` rather `bunx` with `bun` itself, which unsurprisingly caused this error in the first place.

Using the installation `https://bun.sh/install` set ups the correct symlink (i.e `bun x` to `bunx` and not `bun`).

## What is the new behavior?

As we are now using `bun` for `bun create solid` not `bunx` or the symlink `bun x` it should work just fine for everyone regardless of how they installed bun.

## Other information
N/A
