### PR TITLE
Export types properly

### DIFF
--- a/.changeset/cool-eagles-eat.md
+++ b/.changeset/cool-eagles-eat.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Export types properly

--- a/packages/start/src/server/index.tsx
+++ b/packages/start/src/server/index.tsx
@@ -2,5 +2,17 @@
 export { StartServer } from "./StartServer";
 export { createHandler } from "./handler";
 export { getServerFunctionMeta } from "./serverFunction";
-export * from "./types";
+export type {
+  DocumentComponentProps,
+  Asset,
+  HandlerOptions,
+  ContextMatches,
+  ResponseStub,
+  FetchEvent,
+  RequestEventLocals,
+  PageEvent,
+  APIEvent,
+  APIHandler,
+  ServerFunctionMeta
+} from "./types";
 


### PR DESCRIPTION
Unfortunately `export * from "./types.ts"` doesn't not work when importing from moduleResolution `NodeNext` and `export type * from "./types.ts"` doesn't work either. But I really need the type in solid primitives where I cannot change to moduleResolution `node` therefore we need to export all types separately.

I have not really found any information on the internet why this doesn't work. ChatGPT meant that there is a proposal for a former typescript that should already be implement, but I neither found the proposal nor did it work with the latest dev version so I guess that was just a missinformation.