### PR TITLE
fix(SerovalChunk): incorrect buffer length on special chars

### DIFF
--- a/packages/start/src/runtime/server-handler.ts
+++ b/packages/start/src/runtime/server-handler.ts
@@ -24,10 +24,16 @@ import { createPageEvent } from "../server/pageEvent";
 import { FetchEvent, PageEvent } from "../server";
 
 function createChunk(data: string) {
-  const bytes = data.length;
+  const encodeData = new TextEncoder().encode(data);
+  const bytes = encodeData.length;
   const baseHex = bytes.toString(16);
   const totalHex = "00000000".substring(0, 8 - baseHex.length) + baseHex; // 32-bit
-  return new TextEncoder().encode(`;0x${totalHex};${data}`);
+  const head = new TextEncoder().encode(`;0x${totalHex};`);
+
+  const chunk = new Uint8Array(12 + bytes);
+  chunk.set(head);
+  chunk.set(encodeData, 12);
+  return chunk;
 }
 
 function serializeToStream(id: string, value: any) {

--- a/packages/start/src/runtime/server-runtime.ts
+++ b/packages/start/src/runtime/server-runtime.ts
@@ -17,10 +17,12 @@ import { createIslandReference } from "../server/islands/index";
 class SerovalChunkReader {
   reader: ReadableStreamDefaultReader<Uint8Array>;
   buffer: string;
+  bufferSize: number;
   done: boolean;
   constructor(stream: ReadableStream<Uint8Array>) {
     this.reader = stream.getReader();
     this.buffer = "";
+    this.bufferSize = 0;
     this.done = false;
   }
 
@@ -30,6 +32,7 @@ class SerovalChunkReader {
     if (!chunk.done) {
       // repopulate the buffer
       this.buffer += new TextDecoder().decode(chunk.value);
+      this.bufferSize += chunk.value.length;
     } else {
       this.done = true;
     }
@@ -55,7 +58,7 @@ class SerovalChunkReader {
     // deserialize the data
     const bytes = Number.parseInt(this.buffer.substring(1, 11), 16); // ;0x00000000;
     // Check if the buffer has enough bytes to be parsed
-    while (bytes > this.buffer.length - 12) {
+    while (bytes > this.bufferSize - 12) {
       // If it's not enough, and the reader is done
       // then the chunk is invalid.
       if (this.done) {


### PR DESCRIPTION
node.js returns incorrect string length on occuring of special charaters. Use encoded data length instead.

fixing #1408 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
data.length in `createChunk` is less than the `(new TextEncoder().encode(data)).length`

## What is the new behavior?
not use data.length for buffer process

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->


