### PR TITLE
fix: add app.tsx assets to page event in dev env

### DIFF
--- a/.changeset/wise-avocados-lay.md
+++ b/.changeset/wise-avocados-lay.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix: add app.tsx assets to page event in dev env

--- a/packages/start/src/server/pageEvent.ts
+++ b/packages/start/src/server/pageEvent.ts
@@ -30,6 +30,7 @@ export async function createPageEvent(ctx: FetchEvent) {
     manifest: await clientManifest.json(),
     assets: [
       ...(await clientManifest.inputs[clientManifest.handler]!.assets()),
+      ...(import.meta.env.DEV ? await clientManifest.inputs['src/app.tsx']!.assets(): []),
       ...(import.meta.env.START_ISLANDS
         ? (await serverManifest.inputs[serverManifest.handler]!.assets()).filter(
             s => (s as any).attrs.rel !== "modulepreload"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
During development `app.css` is only loaded in the browser via javascript, resulting in a flash of unstyled content.

## What is the new behavior?
`app.tsx` is registered for asset collection in the pageEvent on the server. This way `app.css` and other potential css assets of `app.tsx` are added to the document head, during server side rendering.

## Open Question
I am not 100% happy with the inlined `src/app.tsx`, do we have a proper way to access the path to `app.tsx`?

## Other information
How it currently looks in a browser with disabled js:
![IS](https://github.com/solidjs/solid-start/assets/4012401/d63dc0f7-807e-4c21-aeb0-741d72d26b15)

How it should look:
![SHOULD](https://github.com/solidjs/solid-start/assets/4012401/f0ac2196-86a1-485c-b527-6f542fe3a9df)
owser with disabled js:

### Credits

@nksaraf helped me to find the proper place to debug the issue 🙏.




