### PR TITLE
fix: ensure nonce is passed to all assets

### DIFF
--- a/.changeset/fifty-nails-repair.md
+++ b/.changeset/fifty-nails-repair.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Ensure `nonce` is passed to all assets when rendering from the server.

--- a/packages/start/src/server/StartServer.tsx
+++ b/packages/start/src/server/StartServer.tsx
@@ -3,12 +3,12 @@
 import App from "#start/app";
 import type { Component, JSX } from "solid-js";
 import {
-    Hydration,
-    HydrationScript,
-    NoHydration,
-    getRequestEvent,
-    ssr,
-    useAssets
+  Hydration,
+  HydrationScript,
+  NoHydration,
+  getRequestEvent,
+  ssr,
+  useAssets
 } from "solid-js/web";
 import { ErrorBoundary } from "../shared/ErrorBoundary";
 import { renderAsset } from "./renderAsset";
@@ -72,7 +72,7 @@ export function StartServer(props: { document: Component<DocumentComponentProps>
         assets={
           <>
             <HydrationScript />
-            {context.assets.map((m: any) => renderAsset(m))}
+            {context.assets.map((m: any) => renderAsset(m, nonce))}
           </>
         }
         scripts={

--- a/packages/start/src/server/renderAsset.tsx
+++ b/packages/start/src/server/renderAsset.tsx
@@ -17,7 +17,7 @@ const assetMap = {
   }
 };
 
-export function renderAsset(asset: Asset) {
+export function renderAsset(asset: Asset, nonce?: string) {
   let { tag, attrs: { key, ...attrs } = { key: undefined }, children } = asset as any;
-  return (assetMap as any)[tag]({ attrs, key, children });
+  return (assetMap as any)[tag]({ attrs: { ...attrs, nonce }, key, children });
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Assets rendered to the head of the document do not include the `nonce` if set, eg:

```js
export default createHandler((context) => (
  <StartServer document={{ assets, children, scripts }}>
    <html>
      <head>
        {assets}
      </head>
      <body>
        {children}
        {scripts}
      </body>
    </html>
  </StartServer>
), (context) => ({ nonce: 'some-random-nonce' }));
```

Results in:

```html
<html>
  <head>
    <!-- These assets are missing the nonce! -->
    <link rel="stylesheet" href="…" />
    <script type="module" src="/_build/@vite/client" id="vite-client" />
  </head>
  <body>
    <!-- children -->
    <script type="module" nonce="some-random-nonce" src="...entry-cleint.tsx" />
  </body>
</html>
```

## What is the new behavior?

```html
<html>
  <head>
    <!-- These assets now have the nonce! -->
    <link rel="stylesheet" nonce="some-random-nonce" href="…" />
    <script type="module" nonce="some-random-nonce" src="/_build/@vite/client" id="vite-client" />
  </head>
  <body>
    <!-- children -->
    <script type="module" nonce="some-random-nonce" src="...entry-cleint.tsx" />
  </body>
</html>
```

## Other information

It's possible to provide nonce's for most types of assets, including but not limited to scripts, as well as stylesheets. This ensures that _all_ assets, including those coming from the solid-meta receive the nonce, not just the scripts at the end.