### PR TITLE
update `@auth/core`

### DIFF
--- a/examples/with-authjs/package.json
+++ b/examples/with-authjs/package.json
@@ -15,7 +15,7 @@
     "vite": "^5.1.6"
   },
   "dependencies": {
-    "@auth/core": "^0.28.0",
+    "@auth/core": "^0.29.0",
     "@babel/core": "7.24.0",
     "@solid-mediakit/auth": "^2.0.2",
     "@solidjs/meta": "^0.29.3",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently when `pnpm install` is ran, there is the following peer dependency warning:
![image](https://github.com/solidjs/solid-start/assets/71586988/2ff264e0-2c44-4810-8691-2df3b94f19bf)

On `npm`, this errors, and prevents the user from running the example.
## What is the new behavior?
Updates `@auth/core`, which is depended upon by `@solid-mediakit/auth` so that this error/warning doesn't occur
