### PR TITLE
✨ Respect custom status-codes on redirects

### DIFF
--- a/.changeset/good-coins-suffer.md
+++ b/.changeset/good-coins-suffer.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Respect custom status-codes on redirects

--- a/packages/start/src/runtime/server-handler.ts
+++ b/packages/start/src/runtime/server-handler.ts
@@ -20,6 +20,7 @@ import { eventHandler, setHeader, setResponseStatus, type HTTPEvent } from "vinx
 import invariant from "vinxi/lib/invariant";
 import { cloneEvent, getFetchEvent, mergeResponseHeaders } from "../server/fetchEvent";
 import { createPageEvent } from "../server/pageEvent";
+import { getExpectedRedirectStatus } from "../server/handler";
 // @ts-ignore
 import { FetchEvent, PageEvent } from "../server";
 
@@ -181,14 +182,16 @@ async function handleServerFunction(h3Event: HTTPEvent) {
     if (!instance) {
       const isError = result instanceof Error;
       let redirectUrl = new URL(request.headers.get("referer")!).toString();
+      let statusCode = 302;
       if (result instanceof Response && result.headers.has("Location")) {
         redirectUrl = new URL(
           result.headers.get("Location")!,
           new URL(request.url).origin + import.meta.env.SERVER_BASE_URL
         ).toString();
+        statusCode = getExpectedRedirectStatus(result);
       }
       return new Response(null, {
-        status: 302,
+        status: statusCode,
         headers: {
           Location: redirectUrl,
           ...(result

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -11,7 +11,22 @@ import {
 import { matchAPIRoute } from "../router/routes";
 import { getFetchEvent } from "./fetchEvent";
 import { createPageEvent } from "./pageEvent";
-import type { APIEvent, FetchEvent, HandlerOptions, PageEvent } from "./types";
+import type { APIEvent, FetchEvent, HandlerOptions, PageEvent, ResponseStub } from "./types";
+
+// according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages
+const validRedirectStatuses = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Checks if user has set a redirect status in the response.
+ * If not, falls back to the 302 (temporary redirect)
+ */
+export function getExpectedRedirectStatus(response: ResponseStub): number {
+  if (response.status && validRedirectStatuses.has(response.status)) {
+    return response.status;
+  }
+
+  return 302;
+}
 
 export function createBaseHandler(
   fn: (context: PageEvent) => unknown,
@@ -54,7 +69,8 @@ export function createBaseHandler(
           }, resolvedOptions);
           context.complete = true;
           if (context.response && context.response.headers.get("Location")) {
-            return sendRedirect(e, context.response.headers.get("Location")!);
+            const status = getExpectedRedirectStatus(context.response);
+            return sendRedirect(e, context.response.headers.get("Location")!, status);
           }
           return html;
         }
@@ -77,7 +93,8 @@ export function createBaseHandler(
           return fn(context);
         }, resolvedOptions);
         if (context.response && context.response.headers.get("Location")) {
-          return sendRedirect(e, context.response.headers.get("Location")!);
+          const status = getExpectedRedirectStatus(context.response);
+          return sendRedirect(e, context.response.headers.get("Location")!, status);
         }
         if (mode === "async") return stream;
         // fix cloudflare streaming
@@ -92,7 +109,8 @@ export function createBaseHandler(
 function handleShellCompleteRedirect(context: PageEvent, e: HTTPEvent) {
   return () => {
     if (context.response && context.response.headers.get("Location")) {
-      setResponseStatus(e, 302);
+      const status = getExpectedRedirectStatus(context.response);
+      setResponseStatus(e, status);
       setHeader(e, "Location", context.response.headers.get("Location")!);
     }
   };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
solid-start detects, that "Location" header is specified and tells vinxi to execute redirect, but it always uses default 302 code.

## What is the new behavior?
After this patch, solid-start checks if app-developer specified custom HTTP-status code and if it is one of valid redirect codes.
