### PR TITLE
Omit route components from non-SSR builds when `ssr: false`

### DIFF
--- a/.changeset/twenty-monkeys-marry.md
+++ b/.changeset/twenty-monkeys-marry.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Omit route components from non-SSR builds

--- a/packages/start/config/fs-router.js
+++ b/packages/start/config/fs-router.js
@@ -109,12 +109,13 @@ export class SolidStartServerFileRouter extends BaseFileSystemRouter {
     const hasAPIRoutes = exports.find(exp => HTTP_METHODS.includes(exp.n));
     if (hasDefault || hasAPIRoutes) {
       return {
-        $component: hasDefault
-          ? {
-              src: src,
-              pick: ["default", "$css"]
-            }
-          : undefined,
+        $component:
+          !this.config.dataOnly && hasDefault
+            ? {
+                src: src,
+                pick: ["default", "$css"]
+              }
+            : undefined,
         $$route: hasRouteConfig
           ? {
               src: src,

--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -30,7 +30,8 @@ function solidStartServerFsRouter(config) {
     new SolidStartServerFileRouter(
       {
         dir: resolve.absolute(config.dir, router.root),
-        extensions: config.extensions ?? DEFAULT_EXTENSIONS
+        extensions: config.extensions ?? DEFAULT_EXTENSIONS,
+        dataOnly: config.dataOnly
       },
       router,
       app
@@ -90,7 +91,7 @@ export function defineConfig(baseConfig = {}) {
         },
         handler: `${start.appRoot}/entry-server${entryExtension}`,
         middleware: start.middleware,
-        routes: solidStartServerFsRouter({ dir: routeDir, extensions }),
+        routes: solidStartServerFsRouter({ dir: routeDir, extensions, dataOnly: !start.ssr }),
         extensions,
         target: "server",
         plugins: async () => {
@@ -133,7 +134,9 @@ export function defineConfig(baseConfig = {}) {
               },
               cacheDir: "node_modules/.vinxi/server",
               define: {
-                "import.meta.env.START_APP": JSON.stringify(`${start.appRoot}/app${entryExtension}`),
+                "import.meta.env.START_APP": JSON.stringify(
+                  `${start.appRoot}/app${entryExtension}`
+                ),
                 "import.meta.env.START_ISLANDS": JSON.stringify(start.experimental.islands),
                 "import.meta.env.SSR": JSON.stringify(true),
                 "import.meta.env.START_SSR": JSON.stringify(start.ssr),
@@ -201,7 +204,9 @@ export function defineConfig(baseConfig = {}) {
               },
               cacheDir: "node_modules/.vinxi/client",
               define: {
-                "import.meta.env.START_APP": JSON.stringify(`${start.appRoot}/app${entryExtension}`),
+                "import.meta.env.START_APP": JSON.stringify(
+                  `${start.appRoot}/app${entryExtension}`
+                ),
                 "import.meta.env.START_ISLANDS": JSON.stringify(start.experimental.islands),
                 "import.meta.env.SSR": JSON.stringify(false),
                 "import.meta.env.START_SSR": JSON.stringify(start.ssr),
@@ -213,7 +218,6 @@ export function defineConfig(baseConfig = {}) {
           ];
         }
       },
-
       {
         name: "server-fns",
         type: "http",
@@ -223,7 +227,7 @@ export function defineConfig(baseConfig = {}) {
         ),
         middleware: start.middleware,
         target: "server",
-        routes: solidStartServerFsRouter({ dir: routeDir, extensions }),
+        routes: solidStartServerFsRouter({ dir: routeDir, extensions, dataOnly: !start.ssr }),
         plugins: async () => {
           const userConfig =
             typeof vite === "function" ? await vite({ router: "server-function" }) : { ...vite };
@@ -263,7 +267,9 @@ export function defineConfig(baseConfig = {}) {
                 }
               },
               define: {
-                "import.meta.env.START_APP": JSON.stringify(`${start.appRoot}/app${entryExtension}`),
+                "import.meta.env.START_APP": JSON.stringify(
+                  `${start.appRoot}/app${entryExtension}`
+                ),
                 "import.meta.env.START_ISLANDS": JSON.stringify(start.experimental.islands),
                 "import.meta.env.SSR": JSON.stringify(true),
                 "import.meta.env.START_SSR": JSON.stringify(start.ssr),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When building with `ssr: false`, the ssr + server-fn builds still transform + bundle all of the route components in filesystem routes.
This doesn't really make sense, since the ssr build will only ever be used during prerendering, which just renders `entry-server.tsx` and `app.tsx`, and `server-fn` only invokes `App` with `dataOnly` set on the router so none of the route components are actually used.

## What is the new behavior?

This PR adds a `dataOnly` config to `SolidStartServerFileRouter` which makes it omit the default exported component from all routes. Non-default exported components work the same and `export const route` is still included since it's needed on the server for SFM.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
