### PR TITLE
Reintroduce flat routing

### DIFF
--- a/.changeset/fifty-ways-think.md
+++ b/.changeset/fifty-ways-think.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Reintroduce flat routing

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -41,7 +41,7 @@ function defineRoutes(fileRoutes: Route[]) {
           .replace(/\/\([^)/]+\)/g, "")
           .replace(/\([^)/]+\)/g, "")
           // replace . with / for flat routes - e.g. foo.bar -> foo/bar
-          // lookahead for
+          // ensures that ... of splat routes is not replaced
           .replace(/(?<!\.)\.(?!\.)/g, "/")
       });
       return routes;

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -33,17 +33,17 @@ function defineRoutes(fileRoutes: Route[]) {
     });
 
     if (!parentRoute) {
-      routes.push({
-        ...route,
-        id,
-        path: id
-          // strip out escape group for escaping nested routes - e.g. foo(bar) -> foo
-          .replace(/\/\([^)/]+\)/g, "")
-          .replace(/\([^)/]+\)/g, "")
-          // replace . with / for flat routes - e.g. foo.bar -> foo/bar
-          // ensures that ... of splat routes is not replaced
-          .replace(/(?<!\.)\.(?!\.)/g, "/")
-      });
+      const path = id
+        // strip out escape group for escaping nested routes - e.g. foo(bar) -> foo
+        .replace(/\/\([^)/]+\)/g, "")
+        .replace(/\([^)/]+\)/g, "")
+        // replace . with / for flat routes - e.g. foo.bar -> foo/bar
+        .replace(/\./g, "/")
+        // converts any splat route ... that got replaced back from ///
+        // this could be avoided with a lookbehind regex but safar has only supported them since mid 2023
+        .replace("///", "...");
+
+      routes.push({ ...route, id, path });
       return routes;
     }
     processRoute(

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -41,7 +41,8 @@ function defineRoutes(fileRoutes: Route[]) {
           .replace(/\/\([^)/]+\)/g, "")
           .replace(/\([^)/]+\)/g, "")
           // replace . with / for flat routes - e.g. foo.bar -> foo/bar
-          .replace(/\./g, "/")
+          // lookahead for
+          .replace(/(?<!\.)\.(?!\.)/g, "/")
       });
       return routes;
     }

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -36,12 +36,7 @@ function defineRoutes(fileRoutes: Route[]) {
       const path = id
         // strip out escape group for escaping nested routes - e.g. foo(bar) -> foo
         .replace(/\/\([^)/]+\)/g, "")
-        .replace(/\([^)/]+\)/g, "")
-        // replace . with / for flat routes - e.g. foo.bar -> foo/bar
-        .replace(/\./g, "/")
-        // converts any splat route ... that got replaced back from ///
-        // this could be avoided with a lookbehind regex but safar has only supported them since mid 2023
-        .replace("///", "...");
+        .replace(/\([^)/]+\)/g, "");
 
       routes.push({ ...route, id, path });
       return routes;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Changes to nested route escaping in RC0 broke what was essentially flat routing, where files/folders named along the lines of `a.b.c` would have their path become `a/b/c`. This is useful for reducing folder nested. Whether it was an intentional behaviour previously I'm not sure, but I'd like it to be there.

## What is the new behavior?

Adds back the `. -> /` regex that was removed in RC0, bringing back flat route support.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

Having flat routing alongside nested routing does add the potential for multiple definitions of the same route, but IMO the convenience outweighs that risk
