### PR TITLE
Fix 'Failed to resolve import' crash during ssr

### DIFF
--- a/.changeset/mighty-teachers-guess.md
+++ b/.changeset/mighty-teachers-guess.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix 'Failed to resolve import' crash during ssr

--- a/packages/start/src/router/lazyRoute.ts
+++ b/packages/start/src/router/lazyRoute.ts
@@ -12,11 +12,10 @@ export default function lazyRoute<T>(component: any, clientManifest: any, server
 
       // import() throws if a module doesn't exist, which includes any
       // modules loaded by the route itself, so it's important we catch here
-      const mod = await manifest.inputs[component.src].import().catch(() => null);
-      if (!mod) console.error(`Module ${component.src} not found`);
+      const mod = await manifest.inputs[component.src].import().catch(() => ({}));
       if (!mod[exported]) console.error(`Module ${component.src} does not export ${exported}`);
-      const Component = mod[exported];
-      let assets = await clientManifest.inputs?.[component.src].assets();
+      const Component = mod[exported] ?? (() => {}); // fallback to an empty component, import errors show up in the overlay
+      let assets = await clientManifest.inputs?.[component.src]?.assets();
       const styles = assets.filter((asset: Asset) => asset.tag === "style");
 
       if (typeof window !== "undefined" && import.meta.hot) {

--- a/packages/start/src/router/lazyRoute.ts
+++ b/packages/start/src/router/lazyRoute.ts
@@ -12,9 +12,12 @@ export default function lazyRoute<T>(component: any, clientManifest: any, server
 
       // import() throws if a module doesn't exist, which includes any
       // modules loaded by the route itself, so it's important we catch here
-      const mod = await manifest.inputs[component.src].import().catch(() => ({}));
+      const mod = await manifest.inputs[component.src].import().catch(() => null);
+      // fallback to an empty component as any errors will surface in the vite overlay
+      if(!mod) return { default: () => [] };
+
       if (!mod[exported]) console.error(`Module ${component.src} does not export ${exported}`);
-      const Component = mod[exported] ?? (() => {}); // fallback to an empty component, import errors show up in the overlay
+      const Component = mod[exported]
       let assets = await clientManifest.inputs?.[component.src]?.assets();
       const styles = assets.filter((asset: Asset) => asset.tag === "style");
 

--- a/packages/start/src/router/lazyRoute.ts
+++ b/packages/start/src/router/lazyRoute.ts
@@ -10,7 +10,10 @@ export default function lazyRoute<T>(component: any, clientManifest: any, server
     if (import.meta.env.DEV) {
       let manifest = import.meta.env.SSR ? serverManifest : clientManifest;
 
-      const mod = await manifest.inputs[component.src].import();
+      // import() throws if a module doesn't exist, which includes any
+      // modules loaded by the route itself, so it's important we catch here
+      const mod = await manifest.inputs[component.src].import().catch(() => null);
+      if (!mod) console.error(`Module ${component.src} not found`);
       if (!mod[exported]) console.error(`Module ${component.src} does not export ${exported}`);
       const Component = mod[exported];
       let assets = await clientManifest.inputs?.[component.src].assets();

--- a/packages/start/src/server/StartServer.tsx
+++ b/packages/start/src/server/StartServer.tsx
@@ -36,7 +36,7 @@ export function StartServer(props: { document: Component<DocumentComponentProps>
   // @ts-ignore
   const nonce = context.nonce;
 
-  let assets: Asset[];
+  let assets: Asset[]  = [];
   Promise.resolve().then(async () => {
     let assetPromises: Promise<Asset[]>[] = [];
     // @ts-ignore


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If during SSR a vite error is encountered (such as a module not existing after a rename), vinxi's `import` function will throw, leading to the dev server crashing instead of being shown on the error overlay.

## What is the new behavior?

The error is now caught, the dev server no longer crashes, and the error is shown in the overlay.
When the module isn't found, `lazyRoute` will just return a no-op component so that the route can continue to resolve essentially as a no-op, since the error will surface itself in the Vite overlay anyway (not sure how to make it appear in the SS error overlay). 

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

This solves at least part of https://github.com/nksaraf/vinxi/issues/119