### PR TITLE
Pass event to getResponseStatus in set statusCode

### DIFF
--- a/.changeset/fifty-shrimps-cross.md
+++ b/.changeset/fifty-shrimps-cross.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Pass event to getResponseStatus in set statusCode

--- a/packages/start/src/server/fetchEvent.ts
+++ b/packages/start/src/server/fetchEvent.ts
@@ -1,112 +1,112 @@
 import {
-  H3Event,
-  appendResponseHeader,
-  getRequestIP,
-  getResponseHeader,
-  getResponseHeaders,
-  getResponseStatus,
-  getResponseStatusText,
-  getWebRequest,
-  removeResponseHeader,
-  setResponseHeader,
-  setResponseStatus
+	H3Event,
+	appendResponseHeader,
+	getRequestIP,
+	getResponseHeader,
+	getResponseHeaders,
+	getResponseStatus,
+	getResponseStatusText,
+	getWebRequest,
+	removeResponseHeader,
+	setResponseHeader,
+	setResponseStatus
 } from "vinxi/http";
 import type { FetchEvent, ResponseStub } from "./types";
 
 const fetchEventSymbol = Symbol("fetchEvent");
 
 export function createFetchEvent(event: H3Event): FetchEvent {
-  return {
-    request: getWebRequest(event),
-    response: createResponseStub(event),
-    clientAddress: getRequestIP(event),
-    locals: {},
-    nativeEvent: event
-  };
+	return {
+		request: getWebRequest(event),
+		response: createResponseStub(event),
+		clientAddress: getRequestIP(event),
+		locals: {},
+		nativeEvent: event
+	};
 }
 
 export function cloneEvent<T extends FetchEvent>(fetchEvent: T): T {
-  return {
-    ...fetchEvent
-  };
+	return {
+		...fetchEvent
+	};
 }
 
 export function getFetchEvent(h3Event: H3Event): FetchEvent {
-  if (!(h3Event as any)[fetchEventSymbol]) {
-    const fetchEvent = createFetchEvent(h3Event);
-    (h3Event as any)[fetchEventSymbol] = fetchEvent;
-  }
+	if (!(h3Event as any)[fetchEventSymbol]) {
+		const fetchEvent = createFetchEvent(h3Event);
+		(h3Event as any)[fetchEventSymbol] = fetchEvent;
+	}
 
-  return (h3Event as any)[fetchEventSymbol];
+	return (h3Event as any)[fetchEventSymbol];
 }
 
 export function mergeResponseHeaders(h3Event: H3Event, headers: Headers) {
-  for (const [key, value] of headers.entries()) {
-    appendResponseHeader(h3Event, key, value);
-  }
+	for (const [key, value] of headers.entries()) {
+		appendResponseHeader(h3Event, key, value);
+	}
 }
 
 class HeaderProxy {
-  constructor(private event: H3Event) {}
-  get(key: string) {
-    const h = getResponseHeader(this.event, key);
-    return Array.isArray(h) ? h.join(", ") : (h as string) || null;
-  }
-  has(key: string) {
-    return this.get(key) !== undefined;
-  }
-  set(key: string, value: string) {
-    return setResponseHeader(this.event, key, value);
-  }
-  delete(key: string) {
-    return removeResponseHeader(this.event, key);
-  }
-  append(key: string, value: string) {
-    appendResponseHeader(this.event, key, value);
-  }
-  getSetCookie() {
-    const cookies = getResponseHeader(this.event, "Set-Cookie");
-    return Array.isArray(cookies) ? cookies : [cookies as string];
-  }
-  forEach(fn: (value: string, key: string, object: Headers) => void) {
-    return Object.entries(getResponseHeaders(this.event)).forEach(([key, value]) =>
-      fn(Array.isArray(value) ? value.join(", ") : (value as string), key, this)
-    );
-  }
-  entries() {
-    return Object.entries(getResponseHeaders(this.event))
-      .map(
-        ([key, value]) => [key, Array.isArray(value) ? value.join(", ") : value] as [string, string]
-      )
-      [Symbol.iterator]();
-  }
-  keys() {
-    return Object.keys(getResponseHeaders(this.event))[Symbol.iterator]();
-  }
-  values() {
-    return Object.values(getResponseHeaders(this.event))
-      .map(value => (Array.isArray(value) ? value.join(", ") : (value as string)))
-      [Symbol.iterator]();
-  }
-  [Symbol.iterator]() {
-    return this.entries()[Symbol.iterator]();
-  }
+	constructor(private event: H3Event) {}
+	get(key: string) {
+		const h = getResponseHeader(this.event, key);
+		return Array.isArray(h) ? h.join(", ") : (h as string) || null;
+	}
+	has(key: string) {
+		return this.get(key) !== undefined;
+	}
+	set(key: string, value: string) {
+		return setResponseHeader(this.event, key, value);
+	}
+	delete(key: string) {
+		return removeResponseHeader(this.event, key);
+	}
+	append(key: string, value: string) {
+		appendResponseHeader(this.event, key, value);
+	}
+	getSetCookie() {
+		const cookies = getResponseHeader(this.event, "Set-Cookie");
+		return Array.isArray(cookies) ? cookies : [cookies as string];
+	}
+	forEach(fn: (value: string, key: string, object: Headers) => void) {
+		return Object.entries(getResponseHeaders(this.event)).forEach(([key, value]) =>
+			fn(Array.isArray(value) ? value.join(", ") : (value as string), key, this)
+		);
+	}
+	entries() {
+		return Object.entries(getResponseHeaders(this.event))
+			.map(
+				([key, value]) => [key, Array.isArray(value) ? value.join(", ") : value] as [string, string]
+			)
+			[Symbol.iterator]();
+	}
+	keys() {
+		return Object.keys(getResponseHeaders(this.event))[Symbol.iterator]();
+	}
+	values() {
+		return Object.values(getResponseHeaders(this.event))
+			.map(value => (Array.isArray(value) ? value.join(", ") : (value as string)))
+			[Symbol.iterator]();
+	}
+	[Symbol.iterator]() {
+		return this.entries()[Symbol.iterator]();
+	}
 }
 
 function createResponseStub(event: H3Event): ResponseStub {
-  return {
-    get status() {
-      return getResponseStatus(event);
-    },
-    set status(v) {
-      setResponseStatus(event, v);
-    },
-    get statusText() {
-      return getResponseStatusText(event);
-    },
-    set statusText(v) {
-      setResponseStatus(event, getResponseStatus(), v);
-    },
-    headers: new HeaderProxy(event)
-  };
+	return {
+		get status() {
+			return getResponseStatus(event);
+		},
+		set status(v) {
+			setResponseStatus(event, v);
+		},
+		get statusText() {
+			return getResponseStatusText(event);
+		},
+		set statusText(v) {
+			setResponseStatus(event, getResponseStatus(event), v);
+		},
+		headers: new HeaderProxy(event)
+	};
 }


### PR DESCRIPTION
Makes behaviour of HttpStatusCode and fetchEvent a bit more consistent

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Setting `event.response.statusCode` in non-AsyncLocalStorage environments currently throws an error from deep inside FetchEvent.

## What is the new behavior?

HTTPStatusCode will now throw when calling `getRequestEvent` rather than while setting `statusCode`, which is a bit more understandable imo.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
