### PR TITLE
Omit some keys from Vite server config

### DIFF
--- a/.changeset/clever-jars-explode.md
+++ b/.changeset/clever-jars-explode.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Omit some keys from Vite server config

--- a/packages/start/config/index.d.ts
+++ b/packages/start/config/index.d.ts
@@ -3,9 +3,14 @@ import type { CustomizableConfig } from "vinxi/dist/types/lib/vite-dev";
 import { InlineConfig } from "vite";
 import type { Options } from "vite-plugin-solid";
 
-// atleast until we sort which server options are good to use
+// should probably be maintained by Vinxi
+type VinxiViteServerOptions = Omit<
+  InlineConfig["server"],
+  "port" | "strictPort" | "host" | "middlewareMode" | "open"
+>;
+
 type ViteCustomizableConfig = CustomizableConfig & {
-  server?: InlineConfig["server"];
+  server?: VinxiViteServerOptions;
 };
 
 type SolidStartInlineConfig = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The types for `config.vite.server` currently allow all of Vite's `server` options, many of which are irrelevant since Vinxi overrides or disables them. This can lead to confusion (#1435) around where to configure things like dev server host and port.

## What is the new behavior?

I've changes the type of `config.vite.server` to omit some entries that don't do anything in Solid Start (and Vinxi for that matter):

- `middlewareMode`: Hardcoded to `true` by Vinxi. This stops Vite from spawning HTTP servers, making all the below options unnecessary:
- `port`: Should be provided with `--port` or `PORT`
- `strictPort`
- `host`: Should be provided with `--host` or `HOST`
- `open`: No HTTP servers = no Vite URLs to open in browser


## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

The `VinxiViteServerOptions` should probably be upstreamed to Vinxi so that the list of omitted properties can be more accurate.