### PR TITLE
Don't return user.id from session updates

### DIFF
--- a/examples/with-auth/src/lib/index.ts
+++ b/examples/with-auth/src/lib/index.ts
@@ -1,6 +1,13 @@
 import { action, cache, redirect } from "@solidjs/router";
 import { db } from "./db";
-import { getSession, login, logout as logoutSession, register, validatePassword, validateUsername } from "./server";
+import {
+  getSession,
+  login,
+  logout as logoutSession,
+  register,
+  validatePassword,
+  validateUsername
+} from "./server";
 
 export const getUser = cache(async () => {
   "use server";
@@ -30,7 +37,9 @@ export const loginOrRegister = action(async (formData: FormData) => {
       ? register(username, password)
       : login(username, password));
     const session = await getSession();
-    await session.update(d => (d.userId = user!.id));
+    await session.update(d => {
+      d.userId = user.id;
+    });
   } catch (err) {
     return err as Error;
   }

--- a/examples/with-auth/src/lib/server.ts
+++ b/examples/with-auth/src/lib/server.ts
@@ -21,7 +21,9 @@ export async function login(username: string, password: string) {
 
 export async function logout() {
   const session = await getSession();
-  await session.update(d => (d.userId = undefined));
+  await session.update(d => {
+    d.userId = undefined;
+  });
 }
 
 export async function register(username: string, password: string) {

--- a/examples/with-drizzle/src/api/server.ts
+++ b/examples/with-drizzle/src/api/server.ts
@@ -24,23 +24,14 @@ async function login(username: string, password: string) {
 }
 
 async function register(username: string, password: string) {
-  const existingUser = db
-    .select()
-    .from(Users)
-    .where(eq(Users.username, username))
-    .get();
+  const existingUser = db.select().from(Users).where(eq(Users.username, username)).get();
   if (existingUser) throw new Error("User already exists");
-  return db
-    .insert(Users)
-    .values({ username, password })
-    .returning()
-    .get();
+  return db.insert(Users).values({ username, password }).returning().get();
 }
 
 function getSession() {
   return useSession({
-    password:
-      process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace",
+    password: process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace"
   });
 }
 
@@ -56,7 +47,9 @@ export async function loginOrRegister(formData: FormData) {
       ? register(username, password)
       : login(username, password));
     const session = await getSession();
-    await session.update(d => (d.userId = user!.id));
+    await session.update(d => {
+      d.userId = user.id;
+    });
   } catch (err) {
     return err as Error;
   }
@@ -65,7 +58,7 @@ export async function loginOrRegister(formData: FormData) {
 
 export async function logout() {
   const session = await getSession();
-  await session.update((d) => (d.userId = undefined));
+  await session.update(d => (d.userId = undefined));
   throw redirect("/login");
 }
 

--- a/examples/with-prisma/src/lib/index.ts
+++ b/examples/with-prisma/src/lib/index.ts
@@ -1,6 +1,13 @@
 import { action, cache, redirect } from "@solidjs/router";
 import { db } from "./db";
-import { getSession, login, logout as logoutSession, register, validatePassword, validateUsername } from "./server";
+import {
+  getSession,
+  login,
+  logout as logoutSession,
+  register,
+  validatePassword,
+  validateUsername
+} from "./server";
 
 export const getUser = cache(async () => {
   "use server";
@@ -30,7 +37,9 @@ export const loginOrRegister = action(async (formData: FormData) => {
       ? register(username, password)
       : login(username, password));
     const session = await getSession();
-    await session.update(d => (d.userId = user!.id));
+    await session.update(d => {
+      d.userId = user.id;
+    });
   } catch (err) {
     return err as Error;
   }

--- a/examples/with-prisma/src/lib/server.ts
+++ b/examples/with-prisma/src/lib/server.ts
@@ -21,7 +21,9 @@ export async function login(username: string, password: string) {
 
 export async function logout() {
   const session = await getSession();
-  await session.update(d => (d.userId = undefined));
+  await session.update(d => {
+    d.userId = undefined;
+  });
 }
 
 export async function register(username: string, password: string) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Session updates in the examples were returning `user.id` from the updater function, which was being spread into the session data.

## What is the new behavior?

`userId` is the only property on sessions.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->

Closes #1536 