### PR TITLE
Add `serverComponents.server()` to server-fns plugins when `experimental.islands` is enabled.

### DIFF
--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -252,6 +252,7 @@ export function defineConfig(baseConfig = {}) {
                 fileURLToPath(new URL("../dist/runtime/server-fns-runtime.js", import.meta.url))
               )
             }),
+            start.experimental.islands ? serverComponents.server() : null,
             solid({ ...start.solid, ssr: true, extensions: extensions.map(ext => `.${ext}`) }),
             config("app-server", {
               resolve: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Outlined in [1559](https://github.com/solidjs/solid-start/issues/1559)
TL;DR production builds are not adding server action chunks when `experimental.islands` are enabled

## What is the new behavior?
Chunks are generated as expected
## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
