### PR TITLE
fix: dont use node request as body in handleServerFunction

### DIFF
--- a/.changeset/chilled-phones-sin.md
+++ b/.changeset/chilled-phones-sin.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed a regression that resulted in an `Response body object should not be disturbed or locked` error during form body parsing.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The changes from #1521 broke the form parsing in Node, it threw the error `[h3] [unhandled] TypeError: Response body object should not be disturbed or locked`.

## What is the new behavior?
This fixes the handling for Node, yet tries to keep the functional aspects from the edge runtime workarounds #1282 and #1521. **I couldn't test this fix on edge runtimes** - @supersoniko could you maybe check if your azure preset still works after this fix ☺️?