### PR TITLE
fix: store fetchEvent in h3 context

### DIFF
--- a/.changeset/quiet-mirrors-judge.md
+++ b/.changeset/quiet-mirrors-judge.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed fetchEvent flakyness by storing the event in h3 context.

--- a/packages/start/src/server/fetchEvent.ts
+++ b/packages/start/src/server/fetchEvent.ts
@@ -13,7 +13,7 @@ import {
 } from "vinxi/http";
 import type { FetchEvent, ResponseStub } from "./types";
 
-const fetchEventSymbol = Symbol("fetchEvent");
+const fetchEventContext = "solidFetchEvent";
 
 export function createFetchEvent(event: H3Event): FetchEvent {
 	return {
@@ -32,12 +32,12 @@ export function cloneEvent<T extends FetchEvent>(fetchEvent: T): T {
 }
 
 export function getFetchEvent(h3Event: H3Event): FetchEvent {
-	if (!(h3Event as any)[fetchEventSymbol]) {
+	if (!h3Event.context[fetchEventContext]) {
 		const fetchEvent = createFetchEvent(h3Event);
-		(h3Event as any)[fetchEventSymbol] = fetchEvent;
+		h3Event.context[fetchEventContext] = fetchEvent;
 	}
 
-	return (h3Event as any)[fetchEventSymbol];
+	return h3Event.context[fetchEventContext];
 }
 
 export function mergeResponseHeaders(h3Event: H3Event, headers: Headers) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
`getFetchEvent` is flaky, creating & storing multiple `fetchEvents` per `h3Event`. The reason for this is vinxi duplicating the code including the `fetchEventSymbol` per router (https://github.com/nksaraf/vinxi/issues/51), e.g. if you console.log the symbol https://github.com/solidjs/solid-start/blob/23b01da59b2e6a0e0139686605a7cbf8d723be97/packages/start/src/server/fetchEvent.ts#L16 you will notice that the console.log is executed twice during startup. Also if you log `Object.getOwnPropertySymbols(h3Event)` in `getFetchEvent` you get `[ Symbol(fetchEvent), Symbol(fetchEvent) ]` on requests that affect multiple vinxi routers.

## What is the new behavior?
`getFetchEvent` will maximally create one `fetchEvent` per `h3Event` by storing the `fetchEvent` in `h3Event.context`. `h3Event` is stable across multiple routers and `h3Event.context` is specifically made for situations like this as @pi0 already confirmed in an other thread (https://github.com/solidjs/solid-start/pull/1203#issuecomment-1889036169).

