### PR TITLE
encode api url components

### DIFF
--- a/.changeset/thin-swans-yell.md
+++ b/.changeset/thin-swans-yell.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+encode api url components

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -73,7 +73,7 @@ function containsHTTP(route: Route) {
 const router = createRouter({
   routes: (fileRoutes as unknown as Route[]).reduce((memo, route) => {
     if (!containsHTTP(route)) return memo;
-    let path = route.path.replace(/\/\([^)/]+\)/g, "").replace(/\([^)/]+\)/g, "").replace(/\*([^/]*)/g, (_, m) => `**:${m}`);
+    let path = route.path.replace(/\/\([^)/]+\)/g, "").replace(/\([^)/]+\)/g, "").replace(/\*([^/]*)/g, (_, m) => `**:${m}`).split('/').map(s => (s.startsWith(':') || s.startsWith('*')) ? s : encodeURIComponent(s)).join('/');
     if (/:[^/]*\?/g.test(path)) {
       throw new Error(`Optional parameters are not supported in API routes: ${path}`);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
API routes with paths containing international characters are never matched and do not work.

## What is the new behavior?
API routes containing international characters match and work as expected, consistent with other file routes.

## Other information
For example an API route "/api/거" will never be matched currently. I don't think even naming the file/directory "%EA%B1%B0" (which would be an ugly workaround regardless) works here, so there is no way to accomplish this with the current broken behavior.

Normal file routes like "/거" match and work correctly, so this change makes API routes behave consistently with other routes.