### PR TITLE
Make dev overlay lazy

### DIFF
--- a/packages/start/src/shared/dev-overlay/index.tsx
+++ b/packages/start/src/shared/dev-overlay/index.tsx
@@ -4,12 +4,12 @@ import {
   Show,
   createEffect,
   createSignal,
+  lazy,
   onCleanup,
   resetErrorBoundaries,
   type JSX
 } from "solid-js";
 import { HttpStatusCode } from "../HttpStatusCode";
-import clientOnly from "../clientOnly";
 
 export interface DevOverlayProps {
   children?: JSX.Element;
@@ -20,7 +20,7 @@ const DevOverlayDialog =
     ? () => {
         return <></>;
       }
-    : /* #__PURE__ */ clientOnly(() => import("./DevOverlayDialog"));
+    : /* #__PURE__ */ lazy(() => import("./DevOverlayDialog"));
 
 export function DevOverlay(props: DevOverlayProps): JSX.Element {
   const [errors, setErrors] = createSignal<unknown[]>([]);


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [X] Other... Please describe:

## What is the current behavior?
The current behavior is that the syntax highligher always loads with the pages even when there is no error

<img width="1188" alt="image" src="https://github.com/user-attachments/assets/08c1cb17-fbb9-4349-a25f-b28336ee40b7">

## What is the new behavior?
The new behavior makes the dev overlay lazy so it only loads the syntax highlighting when their is an actual error.

I may be misunderstanding something, and this won't work but seems like it would.

<img width="411" alt="image" src="https://github.com/user-attachments/assets/a74c9e5c-5cf6-4225-b0fd-1ed68fc229c9">
