### PR TITLE
fix: pass errorless ErrorEvent to dev overlay

### DIFF
--- a/.changeset/long-pumpkins-behave.md
+++ b/.changeset/long-pumpkins-behave.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Show proper dev overlay for ErrorEvent with no error property.

--- a/packages/start/src/shared/dev-overlay/DevOverlayDialog.tsx
+++ b/packages/start/src/shared/dev-overlay/DevOverlayDialog.tsx
@@ -21,15 +21,25 @@ interface ErrorInfoProps {
 }
 
 function ErrorInfo(props: ErrorInfoProps): JSX.Element {
+  const error = createMemo(() => {
+    const e = props.error;
+
+    if (e instanceof Error) {
+      return { name: e.name, message: e.message };
+    }
+
+    if (e instanceof ErrorEvent) {
+      return { message: e.message };
+    }
+
+    return { message: (e as Error).toString() };
+  });
+
   return (
-    <Show when={props.error instanceof Error && props.error} keyed fallback={<span>{(props.error as Error).toString()}</span>}>
-      {(current) => (
-        <span class="dev-overlay-error-info">
-          <span class="dev-overlay-error-info-name">{current.name}</span>
-          <span class="dev-overlay-error-info-message">{current.message}</span>
-        </span>
-      )}
-    </Show>
+    <span class="dev-overlay-error-info">
+      <span class="dev-overlay-error-info-name">{error().name}</span>
+      <span class="dev-overlay-error-info-message">{error().message}</span>
+    </span>
   );
 }
 

--- a/packages/start/src/shared/dev-overlay/index.tsx
+++ b/packages/start/src/shared/dev-overlay/index.tsx
@@ -37,7 +37,7 @@ export function DevOverlay(props: DevOverlayProps): JSX.Element {
 
   createEffect(() => {
     const onErrorEvent = (error: ErrorEvent) => {
-      pushError(error.error);
+      pushError(error.error ?? error);
     };
 
     window.addEventListener("error", onErrorEvent);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Certain `ErrorEvent`s triggered on `window` do not have an `.error` property. One of such is the `ResizeObserver loop completed with undelivered notifications.` error, caused by `ResizeObserver` ([Details](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors)). These errors are not handled properly by the dev overlay, as can be seen in the attachments. They also are console logged as `null`.

## What is the new behavior?
`ErrorEvent` with no `.error` property are passed directly to the dev overlay and handled there as good as possible (sadly they do not include a stacktrace). Also instead of console logging `null`, such `ErrorEvents` are logged directly.

## Other information
Before fix:
![Bildschirmfoto vom 2024-10-05 16-32-59](https://github.com/user-attachments/assets/bf0d7a64-c3e4-4baa-961d-5d93693d721c)

After fix:
![Bildschirmfoto vom 2024-10-05 16-32-00](https://github.com/user-attachments/assets/0e7d5d3a-9c4f-4410-ae58-885cf0e2b28e)
