### PR TITLE
fix(start): enable HEAD requests to API HEAD/GET routes

### DIFF
--- a/.changeset/perfect-clocks-repair.md
+++ b/.changeset/perfect-clocks-repair.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix(start): enable HEAD requests to API HEAD/GET routes

--- a/packages/start/config/fs-router.js
+++ b/packages/start/config/fs-router.js
@@ -58,7 +58,7 @@ export class SolidStartClientFileRouter extends BaseFileSystemRouter {
   }
 }
 
-const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+const HTTP_METHODS = ["HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"];
 function createHTTPHandlers(src, exports) {
   const handlers = {};
   for (const exp of exports) {
@@ -67,8 +67,15 @@ function createHTTPHandlers(src, exports) {
         src: src,
         pick: [exp.n]
       };
+      if (exp.n === "GET" && !exports.find(exp => exp.n === "HEAD")) {
+        handlers.$HEAD = {
+          src: src,
+          pick: [exp.n]
+        };
+      }
     }
   }
+
   return handlers;
 }
 

--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -7,6 +7,7 @@ interface Route {
   children?: Route[];
   page?: boolean;
   $component?: any;
+	$HEAD?: any;
   $GET?: any;
   $POST?: any;
   $PUT?: any;
@@ -57,7 +58,7 @@ function defineRoutes(fileRoutes: Route[]) {
 export function matchAPIRoute(path: string, method: string) {
   const match = router.lookup(path);
   if (match && match.route) {
-    const handler = match.route[`$${method}`];
+    const handler = method === "HEAD" ? match.route["$HEAD"] || match.route["$GET"] : match.route[`$${method}`];
     if (handler === undefined) return;
     return {
       handler,
@@ -67,7 +68,7 @@ export function matchAPIRoute(path: string, method: string) {
 }
 
 function containsHTTP(route: Route) {
-  return route["$GET"] || route["$POST"] || route["$PUT"] || route["$PATCH"] || route["$DELETE"];
+  return route["$HEAD"] || route["$GET"] || route["$POST"] || route["$PUT"] || route["$PATCH"] || route["$DELETE"];
 }
 
 const router = createRouter({

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -42,7 +42,7 @@ export function createBaseHandler(
         const match = matchAPIRoute(new URL(event.request.url).pathname, event.request.method);
         if (match) {
           const mod = await match.handler.import();
-          const fn = mod[event.request.method];
+          const fn = event.request.method === "HEAD" ? mod["HEAD"] || mod["GET"] : mod[event.request.method];
           (event as APIEvent).params = match.params || {};
           // @ts-ignore
           sharedConfig.context = { event };


### PR DESCRIPTION
Fixes #1657

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

HEAD requests to API endpoints fail, unable to define them manually

## What is the new behavior?

1. Allows `export const HEAD: APIHandler = async () => { … };` as API endpoints
2. Falls back on GET api methods if no HEAD function is defined.

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
