### PR TITLE
Add clean:all command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "clean": "pnpm run clean:root",
     "clean:root": "rimraf node_modules",
+    "clean:all": "rimraf ./node_modules ./*/**/node_modules",
     "docs:dev": "vinxi dev",
     "docs:build": "vinxi build",
     "docs:start": "node ./.output/server/index.mjs",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "scripts": {
-    "clean": "pnpm run clean:root",
+    "clean": "pnpm run clean:all",
     "clean:root": "rimraf node_modules",
     "clean:all": "rimraf ./node_modules ./*/**/node_modules",
     "docs:dev": "vinxi dev",


### PR DESCRIPTION
There are many node_modules folders, and the current clean:root only takes out one.

The folders are located in:
16 examples
2 packages
1 root

Potentially more will come, such as a ./docs/node_modules, or additional examples

This cleans all of them, root and nested, and makes that the default behavior.