### PR TITLE
fix: rename 'Home' route component to 'About'

### DIFF
--- a/examples/basic/src/routes/about.tsx
+++ b/examples/basic/src/routes/about.tsx
@@ -1,6 +1,6 @@
 import { Title } from "@solidjs/meta";
 
-export default function Home() {
+export default function About() {
   return (
     <main>
       <Title>About</Title>


### PR DESCRIPTION
... in about.tsx

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [x] Other... Please describe: Minor fix for the basic starter template

## What is the current behavior?
When using the *basic* starter template the *about.tsx* file contains a `Home` component, although it should be `About`

## What is the new behavior?
The *basic* starter template the *about.tsx* file contains a `About` component