### PR TITLE
Granular clean commands, build commands, util for using workspace package in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "clean:all": "pnpm run examples:clean && pnpm run packages:clean && pnpm run clean:root",
     "clean:root": "pnpx rimraf ./node_modules ./.vinxi/ ./.output/",
     
-    "docs:dev": "vinxi dev",
-    "docs:build": "vinxi build",
-    "docs:start": "node ./.output/server/index.mjs",
+    "docs:dev": "pnpm --filter solid-start-docs dev",
+    "docs:build": "pnpm --filter solid-start-docs build",
+    "docs:start": "pnpm --filter solid-start-docs start",
     "docs:clean": "pnpx rimraf ./docs/node_modules ./docs/.vinxi/ ./docs/.output/",
     
     "examples:build": "pnpm --filter './examples/*' --if-present build",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "coveralls": "^3.1.1",
     "cypress": "^14.0.0",
     "debug": "^4.3.4",
-    "graphql": "^16.7.1",
     "tinyglobby": "^0.2.2",
     "tippy.js": "^6.3.7",
     "typescript": "catalog:",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,32 @@
   },
   "private": true,
   "scripts": {
+    "bump": "node scripts/bump.js",
+    
+    "build": "pnpm run packages:build",
+    "build:all": "pnpm run packages:build && pnpm run examples:build && pnpm run docs:build",
+    
     "clean": "pnpm run clean:all",
-    "clean:root": "rimraf node_modules",
-    "clean:all": "rimraf ./node_modules ./*/**/node_modules",
-    "docs:dev": "pnpm --filter solid-start-docs dev",
-    "docs:build": "pnpm --filter solid-start-docs build",
-    "docs:start": "pnpm --filter solid-start-docs start",
+    "clean:all": "pnpm run examples:clean && pnpm run packages:clean && pnpm run clean:root",
+    "clean:root": "pnpx rimraf ./node_modules ./.vinxi/ ./.output/",
+    
+    "docs:dev": "vinxi dev",
+    "docs:build": "vinxi build",
+    "docs:start": "node ./.output/server/index.mjs",
     "docs:clean": "pnpx rimraf ./docs/node_modules ./docs/.vinxi/ ./docs/.output/",
-    "clean:test": "rimraf .tmp",
-    "build": "pnpm --filter @solidjs/start build",
-    "build:all": "pnpm run build && pnpm --filter './examples/*' --if-present build",
+    
+    "examples:build": "pnpm --filter './examples/*' --if-present build",
+    "examples:clean": "pnpx rimraf ./examples/*/node_modules/ ./examples/*/.vinxi/ ./examples/*/.output/",
+    "examples:use-workspace-package": "node ./util/use-workspace-package-in-examples.js",
+    
+    "packages:build": "pnpm --filter @solidjs/start build",
+    "packages:clean": "pnpx rimraf ./packages/*/node_modules/ ./packages/*/dist/",
+    
     "install:playwright": "pnpm --filter solid-start-tests run install:playwright",
+    "clean:test": "pnpx rimraf .tmp",
     "test:all": "pnpm run clean:test && cross-env START_ADAPTER=solid-start-node npm run test",
     "test": "pnpm run clean:test && pnpm --filter solid-start-tests test --",
-    "show:test-report": "pnpm --filter solid-start-tests show:test-report",
-    "bump": "node scripts/bump.js"
+    "show:test-report": "pnpm --filter solid-start-tests show:test-report"
   },
   "devDependencies": {
     "@changesets/cli": "^2.25.2",
@@ -34,7 +45,7 @@
     "coveralls": "^3.1.1",
     "cypress": "^14.0.0",
     "debug": "^4.3.4",
-    "rimraf": "^3.0.2",
+    "graphql": "^16.7.1",
     "tinyglobby": "^0.2.2",
     "tippy.js": "^6.3.7",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,9 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.7
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
+      graphql:
+        specifier: ^16.7.1
+        version: 16.9.0
       tinyglobby:
         specifier: ^0.2.2
         version: 0.2.10
@@ -118,6 +118,9 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.4.47
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       solid-js:
         specifier: ^1.9.2
         version: 1.9.3
@@ -4912,10 +4915,6 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
-    engines: {node: '>=14'}
-
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -5036,11 +5035,6 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  glob@10.3.15:
-    resolution: {integrity: sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==}
-    engines: {node: '>=16 || 14 >=14.18'}
-    hasBin: true
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
@@ -5446,10 +5440,6 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
-
-  jackspeak@2.3.6:
-    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
-    engines: {node: '>=14'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -6061,10 +6051,6 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.4:
-    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6079,10 +6065,6 @@ packages:
   minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
-
-  minipass@7.1.1:
-    resolution: {integrity: sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -12633,11 +12615,6 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  foreground-child@3.3.0:
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 4.1.0
-
   forever-agent@0.6.1: {}
 
   form-data@2.3.3:
@@ -12780,17 +12757,9 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.3.15:
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 2.3.6
-      minimatch: 9.0.4
-      minipass: 7.1.1
-      path-scurry: 1.11.1
-
   glob@10.4.5:
     dependencies:
-      foreground-child: 3.3.0
+      foreground-child: 3.1.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
       minipass: 7.1.2
@@ -13239,12 +13208,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@2.3.6:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@3.4.3:
     dependencies:
@@ -14023,10 +13986,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimatch@9.0.4:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -14038,8 +13997,6 @@ snapshots:
       yallist: 4.0.0
 
   minipass@5.0.0: {}
-
-  minipass@7.1.1: {}
 
   minipass@7.1.2: {}
 
@@ -15270,7 +15227,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       commander: 4.1.1
-      glob: 10.3.15
+      glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.7
-      graphql:
-        specifier: ^16.7.1
-        version: 16.9.0
       tinyglobby:
         specifier: ^0.2.2
         version: 0.2.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.4.47
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
       solid-js:
         specifier: ^1.9.2
         version: 1.9.3

--- a/util/use-workspace-package-in-examples.js
+++ b/util/use-workspace-package-in-examples.js
@@ -1,0 +1,34 @@
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const examplesDir = join(__dirname, '../examples');
+
+// Get all directories in examples folder
+const examples = readdirSync(examplesDir)
+  .filter(file => statSync(join(examplesDir, file)).isDirectory());
+
+// Process each example's package.json
+examples.forEach(example => {
+  const packagePath = join(examplesDir, example, 'package.json');
+  
+  if (existsSync(packagePath)) {
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+    
+    if (packageJson.dependencies && packageJson.dependencies['@solidjs/start']) {
+      packageJson.dependencies['@solidjs/start'] = 'workspace:*';
+      
+      writeFileSync(
+        packagePath, 
+        JSON.stringify(packageJson, null, 2) + '\n',
+        'utf8'
+      );
+      
+      console.log(`Updated ${packagePath}`);
+    }
+  }
+});
+


### PR DESCRIPTION
This split the clean command to examples, packages, root - to more granularly clean up `.vinxi/`, `.output/`, `node_modules/`, `dist/` 

Also, since the clean:root command removes the `./node_modules/` where rimraf is currently installed, I found it was better to use `pnpx rimraf` to always allow running the clean commands