### PR TITLE
Skip typecheck when changing ignored files

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   typecheck:
     name: "👀 Typecheck"
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.changed_files != 0)
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
PRs to docs are unable to merge because typecheck CI is not skipping and not running when the paths are ignored.