### PR TITLE
fix: handle request body streaming with latest netlify preset

### DIFF
--- a/.changeset/violet-snakes-dress.md
+++ b/.changeset/violet-snakes-dress.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: handle request body streaming with latest netlify preset


### PR DESCRIPTION
See https://github.com/solidjs/solid-start/issues/1673.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

As described in https://github.com/solidjs/solid-start/issues/1673, submitting a Solid Action with the latest `netlify` nitro preset results in a 500 response from the `POST /server` with this error:

```
[nitro] [request error] [unhandled] Response body object should not be disturbed or locked
```

You can see this in the repro repo I shared in the issue or by clicking the button at https://672c1abc039334ad67383d7e--repro-solidstart-response-disturbed.netlify.app/.

## What is the new behavior?

Solid Actions work with the latest `netlify` nitro preset (i.e. a dummy handler results in a 200).

You can see this by linking this change into the repro repo I shared in the issue.

## Other information

I... admittedly don't really know what I'm doing here. This solution seems iffy, but it does fix Actions on the latest Netlify preset, so it may be worth it for now?