### PR TITLE
Typecheck CI triggers every time and skips internally

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,20 +8,32 @@ on:
       - release-*
     tags-ignore:
       - v*
-    paths-ignore:
-      - "docs/**"
-      - "docs.root.tsx"
-      - "components/**"
-      - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+  workflow_dispatch:
 
 jobs:
+  filter-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.changes.outputs.landing_page }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            landing_page:
+              - 'docs/**'
+              - "docs.root.tsx"
+              - "components/**"
+              - "**/README.md"
   typecheck:
     name: "👀 Typecheck"
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.changed_files != 0)
+    needs: filter-changes
+    if: needs.filter-changes.outputs.should_skip != 'true'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Typecheck must run every time because it is a required task.
This PR also adds `workflow_dispatch` so it can be triggered manually as a escape hatch until we're sure we covered all workflow cases.