### PR TITLE
Add externalization test to server function suite 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,12 +628,18 @@ importers:
 
   tests/server-function:
     dependencies:
+      '@solidjs/meta':
+        specifier: ^0.29.4
+        version: 0.29.4(solid-js@1.9.4)
+      '@solidjs/router':
+        specifier: ^0.15.3
+        version: 0.15.3(solid-js@1.9.4)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../packages/start
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.0(solid-js@1.9.4))(solid-js@1.9.4)
+        version: 0.8.10(@solidjs/router@0.15.3(solid-js@1.9.4))(solid-js@1.9.4)
       '@testing-library/jest-dom':
         specifier: ^6.6.2
         version: 6.6.2
@@ -646,6 +652,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       solid-js:
         specifier: 'catalog:'
         version: 1.9.4
@@ -661,7 +670,10 @@ importers:
     devDependencies:
       '@cypress/code-coverage':
         specifier: ^3.13.10
-        version: 3.13.10(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1))(cypress@14.0.0)(webpack@5.97.1)
+        version: 3.13.10(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19)))(cypress@14.0.0)(webpack@5.97.1(esbuild@0.17.19))
+      '@types/lodash':
+        specifier: ^4.17.14
+        version: 4.17.14
       cypress:
         specifier: ^14.0.0
         version: 14.0.0
@@ -3083,6 +3095,11 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
+  '@solidjs/router@0.15.3':
+    resolution: {integrity: sha512-iEbW8UKok2Oio7o6Y4VTzLj+KFCmQPGEpm1fS3xixwFBdclFVBvaQVeibl1jys4cujfAK5Kn6+uG2uBm3lxOMw==}
+    peerDependencies:
+      solid-js: ^1.8.6
+
   '@solidjs/start@1.0.11':
     resolution: {integrity: sha512-ZkrHtwxnmaVGItah13BtmST6rh3PtATcj0RyXM19Shj6MK/cIpDBBsDTsgwqCbZoa/AT8/JLM5xUHFjQyBjRCA==}
 
@@ -3185,6 +3202,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.14':
+    resolution: {integrity: sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==}
 
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -9081,12 +9101,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@cypress/code-coverage@3.13.10(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1))(cypress@14.0.0)(webpack@5.97.1)':
+  '@cypress/code-coverage@3.13.10(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19)))(cypress@14.0.0)(webpack@5.97.1(esbuild@0.17.19))':
     dependencies:
       '@babel/core': 7.25.9
       '@babel/preset-env': 7.26.0(@babel/core@7.25.9)
-      '@cypress/webpack-preprocessor': 6.0.2(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1))(webpack@5.97.1)
-      babel-loader: 9.2.1(@babel/core@7.25.9)(webpack@5.97.1)
+      '@cypress/webpack-preprocessor': 6.0.2(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19)))(webpack@5.97.1(esbuild@0.17.19))
+      babel-loader: 9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19))
       chalk: 4.1.2
       cypress: 14.0.0
       dayjs: 1.11.13
@@ -9096,7 +9116,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       js-yaml: 4.1.0
       nyc: 15.1.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - supports-color
 
@@ -9121,15 +9141,15 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1))(webpack@5.97.1)':
+  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.25.9)(@babel/preset-env@7.26.0(@babel/core@7.25.9))(babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19)))(webpack@5.97.1(esbuild@0.17.19))':
     dependencies:
       '@babel/core': 7.25.9
       '@babel/preset-env': 7.26.0(@babel/core@7.25.9)
-      babel-loader: 9.2.1(@babel/core@7.25.9)(webpack@5.97.1)
+      babel-loader: 9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19))
       bluebird: 3.7.1
       debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - supports-color
 
@@ -10320,6 +10340,10 @@ snapshots:
     dependencies:
       solid-js: 1.9.3
 
+  '@solidjs/meta@0.29.4(solid-js@1.9.4)':
+    dependencies:
+      solid-js: 1.9.4
+
   '@solidjs/router@0.14.10(solid-js@1.9.3)':
     dependencies:
       solid-js: 1.9.3
@@ -10328,10 +10352,9 @@ snapshots:
     dependencies:
       solid-js: 1.9.3
 
-  '@solidjs/router@0.15.0(solid-js@1.9.4)':
+  '@solidjs/router@0.15.3(solid-js@1.9.4)':
     dependencies:
       solid-js: 1.9.4
-    optional: true
 
   '@solidjs/start@1.0.11(@testing-library/jest-dom@6.6.2)(solid-js@1.9.3)(vinxi@0.4.3(@opentelemetry/api@1.9.0)(@types/node@20.17.4)(better-sqlite3@11.5.0)(debug@4.3.7)(drizzle-orm@0.31.4(@opentelemetry/api@1.9.0)(@prisma/client@5.21.1(prisma@5.21.1))(@types/better-sqlite3@7.6.11)(better-sqlite3@11.5.0)(prisma@5.21.1)(react@18.3.1))(ioredis@5.4.1)(lightningcss@1.27.0)(terser@5.36.0))(vite@5.4.10(@types/node@20.17.4)(lightningcss@1.27.0)(terser@5.36.0))':
     dependencies:
@@ -10409,12 +10432,12 @@ snapshots:
     optionalDependencies:
       '@solidjs/router': 0.15.0(solid-js@1.9.3)
 
-  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.0(solid-js@1.9.4))(solid-js@1.9.4)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.3(solid-js@1.9.4))(solid-js@1.9.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       solid-js: 1.9.4
     optionalDependencies:
-      '@solidjs/router': 0.15.0(solid-js@1.9.4)
+      '@solidjs/router': 0.15.3(solid-js@1.9.4)
 
   '@swc/counter@0.1.3': {}
 
@@ -10532,6 +10555,8 @@ snapshots:
       '@types/node': 20.17.4
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lodash@4.17.14': {}
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -11419,12 +11444,12 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1):
+  babel-loader@9.2.1(@babel/core@7.25.9)(webpack@5.97.1(esbuild@0.17.19)):
     dependencies:
       '@babel/core': 7.25.9
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.17.19)
 
   babel-plugin-jsx-dom-expressions@0.37.20(@babel/core@7.24.4):
     dependencies:
@@ -15376,14 +15401,16 @@ snapshots:
       solid-js: 1.9.4
       solid-use: 0.9.0(solid-js@1.9.4)
 
-  terser-webpack-plugin@5.3.11(webpack@5.97.1):
+  terser-webpack-plugin@5.3.11(esbuild@0.17.19)(webpack@5.97.1(esbuild@0.17.19)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.17.19)
+    optionalDependencies:
+      esbuild: 0.17.19
 
   terser@5.36.0:
     dependencies:
@@ -16260,7 +16287,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.1: {}
 
-  webpack@5.97.1:
+  webpack@5.97.1(esbuild@0.17.19):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -16282,7 +16309,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(esbuild@0.17.19)(webpack@5.97.1(esbuild@0.17.19))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/tests/server-function/cypress/e2e/server-function.cy.ts
+++ b/tests/server-function/cypress/e2e/server-function.cy.ts
@@ -1,6 +1,6 @@
 describe("server-function", () => {
   it("should isServer false on the client and true in the server function", () => {
     cy.visit("/");
-    cy.get("#server-fn-test").contains(`{"client":false,"serverFn":true}`);
+    cy.get("#server-fn-test").contains(`{"clientWithIsServer":false,"serverFnWithIsServer":true,"serverFnWithNodeBuiltin":"can/externalize"}`);
   })
 });

--- a/tests/server-function/cypress/e2e/server-function.cy.ts
+++ b/tests/server-function/cypress/e2e/server-function.cy.ts
@@ -1,6 +1,18 @@
 describe("server-function", () => {
-  it("should isServer false on the client and true in the server function", () => {
+  it("should isServer false on the client", () => {
     cy.visit("/");
-    cy.get("#server-fn-test").contains(`{"clientWithIsServer":false,"serverFnWithIsServer":true,"serverFnWithNodeBuiltin":"can/externalize"}`);
+    cy.get("#server-fn-test").contains('{"clientWithIsServer":false}');
+  })
+  it("should isServer true in the server function", () => {
+    cy.visit("/is-server");
+    cy.get("#server-fn-test").contains('{"serverFnWithIsServer":true}');
+  })
+  it("should externalize node builtin in server function", () => {
+    cy.visit("/node-builtin");
+    cy.get("#server-fn-test").contains('{"serverFnWithNodeBuiltin":"can/externalize"}');
+  })
+  it("should externalize npm module in server function", () => {
+    cy.visit("npm-module");
+    cy.get("#server-fn-test").contains('{"serverFnWithNpmModule":[2,4,6]}');
   })
 });

--- a/tests/server-function/cypress/e2e/server-function.cy.ts
+++ b/tests/server-function/cypress/e2e/server-function.cy.ts
@@ -1,9 +1,9 @@
 describe("server-function", () => {
-  it("should isServer false on the client", () => {
+  it("should have isServer false in the client", () => {
     cy.visit("/");
     cy.get("#server-fn-test").contains('{"clientWithIsServer":false}');
   })
-  it("should isServer true in the server function", () => {
+  it("should have isServer true in the server function", () => {
     cy.visit("/is-server");
     cy.get("#server-fn-test").contains('{"serverFnWithIsServer":true}');
   })

--- a/tests/server-function/package.json
+++ b/tests/server-function/package.json
@@ -13,12 +13,15 @@
     "test": "pnpm run dev & cypress run"
   },
   "dependencies": {
+    "@solidjs/meta": "^0.29.4",
+    "@solidjs/router": "^0.15.3",
     "@solidjs/start": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.6.2",
     "@testing-library/user-event": "^14.5.2",
     "@vitest/ui": "^2.1.4",
     "jsdom": "^25.0.1",
+    "lodash": "^4.17.21",
     "solid-js": "catalog:",
     "vinxi": "catalog:",
     "vite-plugin-solid": "catalog:",
@@ -31,9 +34,10 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "cypress-vite": "^1.6.0",
     "@cypress/code-coverage": "^3.13.10",
+    "@types/lodash": "^4.17.14",
     "cypress": "^14.0.0",
-    "cypress-plugin-tab": "^1.0.5"
+    "cypress-plugin-tab": "^1.0.5",
+    "cypress-vite": "^1.6.0"
   }
 }

--- a/tests/server-function/src/app.tsx
+++ b/tests/server-function/src/app.tsx
@@ -1,40 +1,24 @@
-import { join } from 'path';
-import { createEffect, createSignal } from "solid-js";
-import { isServer } from "solid-js/web";
-
+import { MetaProvider, Title } from "@solidjs/meta";
+import { Router } from "@solidjs/router";
+import { FileRoutes } from "@solidjs/start/router";
+import { Suspense } from "solid-js";
 import "./app.css";
 
-function serverFnWithIsServer() {
-  "use server";
-
-  return isServer;
-}
-
-function serverFnWithNodeBuiltin() {
-  "use server";
-
-  return join('can','externalize');
-}
-
 export default function App() {
-  const [output, setOutput] = createSignal<{ clientWithIsServer?: boolean; serverFnWithIsServer?: boolean, serverFnWithNodeBuiltin?: string }>({});
-
-  setOutput(prev => ({ ...prev, clientWithIsServer: isServer }));
-
-  createEffect(async () => {
-    const restult = await serverFnWithIsServer();
-    setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
-  });
-
-  createEffect(async () => {
-    const restult = await serverFnWithNodeBuiltin();
-    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: restult }));
-  });
-
   return (
-    <main>
-      <h1>Hello world!</h1>
-      <span id="server-fn-test">{JSON.stringify(output())}</span>
-    </main>
+    <Router
+      root={props => (
+        <MetaProvider>
+          <Title>SolidStart - Basic</Title>
+          <a href="/">Client</a>
+          <a href="/is-server">isserver</a>
+          <a href="/node-builtin">node builtin</a>
+          <a href="/npm-module">npm module (lodash)</a>
+          <Suspense>{props.children}</Suspense>
+        </MetaProvider>
+      )}
+    >
+      <FileRoutes />
+    </Router>
   );
 }

--- a/tests/server-function/src/app.tsx
+++ b/tests/server-function/src/app.tsx
@@ -1,19 +1,34 @@
+import { join } from 'path';
 import { createEffect, createSignal } from "solid-js";
 import { isServer } from "solid-js/web";
+
 import "./app.css";
 
-function useServer() {
+function serverFnWithIsServer() {
   "use server";
+
   return isServer;
 }
-export default function App() {
-  const [output, setOutput] = createSignal<{ client?: boolean; serverFn?: boolean }>({});
 
-  setOutput(prev => ({ ...prev, client: isServer }));
+function serverFnWithNodeBuiltin() {
+  "use server";
+
+  return join('can','externalize');
+}
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ clientWithIsServer?: boolean; serverFnWithIsServer?: boolean, serverFnWithNodeBuiltin?: string }>({});
+
+  setOutput(prev => ({ ...prev, clientWithIsServer: isServer }));
 
   createEffect(async () => {
-    const restult = await useServer();
-    setOutput(prev => ({ ...prev, serverFn: restult }));
+    const restult = await serverFnWithIsServer();
+    setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+  });
+
+  createEffect(async () => {
+    const restult = await serverFnWithNodeBuiltin();
+    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: restult }));
   });
 
   return (

--- a/tests/server-function/src/routes/index.tsx
+++ b/tests/server-function/src/routes/index.tsx
@@ -1,0 +1,16 @@
+import _ from "lodash";
+import { join } from 'path';
+import { createEffect, createSignal } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ clientWithIsServer?: boolean; }>({});
+
+  setOutput(prev => ({ ...prev, clientWithIsServer: isServer }));
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}

--- a/tests/server-function/src/routes/is-server.tsx
+++ b/tests/server-function/src/routes/is-server.tsx
@@ -1,0 +1,27 @@
+import _ from "lodash";
+import { join } from 'path';
+import { createEffect, createSignal } from "solid-js";
+import { isServer } from "solid-js/web";
+
+function serverFnWithIsServer() {
+  "use server";
+
+  return isServer;
+}
+
+export default function App() {
+  const [output, setOutput] = createSignal<{  serverFnWithIsServer?: boolean }>({});
+
+
+  createEffect(async () => {
+    const restult = await serverFnWithIsServer();
+    setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+  });
+
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}

--- a/tests/server-function/src/routes/node-builtin.tsx
+++ b/tests/server-function/src/routes/node-builtin.tsx
@@ -1,0 +1,27 @@
+import _ from "lodash";
+import { join } from 'path';
+import { createEffect, createSignal } from "solid-js";
+import { isServer } from "solid-js/web";
+
+function serverFnWithNodeBuiltin() {
+  "use server";
+
+  return join('can','externalize');
+}
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ serverFnWithNodeBuiltin?: string }>({});
+
+ 
+
+  createEffect(async () => {
+    const restult = await serverFnWithNodeBuiltin();
+    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: restult }));
+  });
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}

--- a/tests/server-function/src/routes/npm-module.tsx
+++ b/tests/server-function/src/routes/npm-module.tsx
@@ -1,0 +1,25 @@
+import _ from "lodash";
+import { join } from 'path';
+import { createEffect, createSignal } from "solid-js";
+import { isServer } from "solid-js/web";
+
+function serverFnWithNpmModule() {
+  "use server";
+
+  return _.map([1, 2, 3], x => x * 2);
+}
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ serverFnWithNpmModule?: number[] }>({});
+
+  createEffect(async () => {
+    const restult = await serverFnWithNpmModule();
+    setOutput(prev => ({ ...prev, serverFnWithNpmModule: restult }));
+  });
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}


### PR DESCRIPTION
This makes sure the server function e2e tests also cover the ability to externalize modules.

As mentioned here: 
- https://github.com/solidjs/solid-start/pull/1715#issuecomment-2612592366

I've also split the suite into 4 tests:

- it("should have isServer false in the client")
- it("should have isServer true in the server function")
- it("should externalize node builtin in server function")
- it("should externalize npm module in server function")
  


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [X] Tests
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Other information
<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
