### PR TITLE
chore: Contributing Compliance Workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,28 @@
+name: Contributing Compliance
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mtfoley/pr-compliance-action@main
+        with:
+          body-auto-close: false
+          ignore-authors: |-
+            allcontributors
+            allcontributors[bot]
+            renovate
+            renovate[bot]
+          ignore-team-members: false


### PR DESCRIPTION
This sets up an automatic workflow to check if a PR is according to the contributing guidelines

- PR title is formatted according to conventional commits: in preparation for a release workflow that will generate releases in GH
- PR body refers to an issue: to make sure proper discussion and considerations were had before writing the code
- PR does not originate from protected branches (in our case, only `main`)

This workflow comes from Create-TypeScript-App by @joshuakgoldberg. Following this standard we can then also use the `post-release` workflow and the `release` workflow which will automate changes and feedback to PR authors about which release carries their code.

closes #1730

---

you can see in the comments below how the comment would work :)
