### PR TITLE
fix: don't fail on PR body

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: mtfoley/pr-compliance-action@main
         with:
+          body-fail: false
           body-auto-close: false
           ignore-authors: |-
             allcontributors

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: mtfoley/pr-compliance-action@main
         with:
           body-fail: false
+          body-regex: '*' # Accept any body
           body-auto-close: false
           ignore-authors: |-
             allcontributors

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: mtfoley/pr-compliance-action@main
         with:
           body-fail: false
-          body-regex: '*' # Accept any body
+          body-regex: '[\s\S]*' # Accept any body including newlines
           body-auto-close: false
           ignore-authors: |-
             allcontributors


### PR DESCRIPTION
This makes Compliance check not break the ci flow on missing issue link

https://github.com/mtfoley/pr-compliance-action/tree/main/?tab=readme-ov-file