### PR TITLE
chore: use nvmrc instead of node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {},
   "engines": {
-    "pnpm": "^9.0.0",
-    "node": "^20.5.0"
+    "pnpm": "^9.0.0"
   }
 }


### PR DESCRIPTION
Similar to
- #1766 