### PR TITLE
fix: move getServerFunctionMeta export to @solidjs/start

### DIFF
--- a/.changeset/metal-ladybugs-check.md
+++ b/.changeset/metal-ladybugs-check.md
@@ -1,0 +1,7 @@
+---
+"@solidjs/start": patch
+---
+
+Move `getServerFunctionMeta` from `@solidjs/start/server` to `@solidjs/start` to fix circular import issues.
+
+The old export at `@solidjs/start/server` still exists, but is **deprecated** and will be removed in a future release.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules
 
 .tmp
 test/playwright-report
+tests/server-function/cypress/screenshots
 
 # Temp
 gitignore

--- a/packages/start/src/index.tsx
+++ b/packages/start/src/index.tsx
@@ -1,6 +1,6 @@
 // @refresh skip
+export { default as clientOnly } from "./shared/clientOnly";
 export { GET } from "./shared/GET";
 export { HttpHeader } from "./shared/HttpHeader";
 export { HttpStatusCode } from "./shared/HttpStatusCode";
-export { default as clientOnly } from "./shared/clientOnly";
-
+export { getServerFunctionMeta } from "./shared/serverFunction";

--- a/packages/start/src/server/index.tsx
+++ b/packages/start/src/server/index.tsx
@@ -1,9 +1,11 @@
 // @refresh skip
-export { StartServer } from "./StartServer";
 export { createHandler } from "./handler";
-export { getServerFunctionMeta } from "./serverFunction";
+export { StartServer } from "./StartServer";
 export type {
   APIEvent,
   APIHandler, Asset, ContextMatches, DocumentComponentProps, FetchEvent, HandlerOptions, PageEvent, ResponseStub, ServerFunctionMeta
 } from "./types";
+import { getServerFunctionMeta as getServerFunctionMeta_ } from "../shared/serverFunction";
 
+/** @deprecated */
+export const getServerFunctionMeta = getServerFunctionMeta_;

--- a/packages/start/src/shared/serverFunction.tsx
+++ b/packages/start/src/shared/serverFunction.tsx
@@ -1,5 +1,5 @@
 import { getRequestEvent } from "solid-js/web";
-import type { ServerFunctionMeta } from "./types";
+import type { ServerFunctionMeta } from "../server/types";
 
 /**
  *

--- a/tests/server-function/cypress/e2e/server-function.cy.ts
+++ b/tests/server-function/cypress/e2e/server-function.cy.ts
@@ -7,6 +7,10 @@ describe("server-function", () => {
     cy.visit("/is-server-nested");
     cy.get("#server-fn-test").contains('{"serverFnWithIsServer":true}');
   })
+  it("should have an id of type string in the server function meta - nested", () => {
+    cy.visit("/server-function-meta-nested");
+    cy.get("#server-fn-test").contains('{"serverFnWithMeta":"string"}');
+  })
   it("should externalize node builtin in server function - nested", () => {
     cy.visit("/node-builtin-nested");
     cy.get("#server-fn-test").contains('{"serverFnWithNodeBuiltin":"can/externalize"}');
@@ -19,6 +23,10 @@ describe("server-function", () => {
   it("should have isServer true in the server function - toplevel", () => {
     cy.visit("/is-server-toplevel");
     cy.get("#server-fn-test").contains('{"serverFnWithIsServer":true}');
+  })
+  it("should have an id of type string in the server function meta - toplevel", () => {
+    cy.visit("/server-function-meta");
+    cy.get("#server-fn-test").contains('{"serverFnWithMeta":"string"}');
   })
   it("should externalize node builtin in server function - toplevel", () => {
     cy.visit("/node-builtin-toplevel");

--- a/tests/server-function/src/functions/use-server-function-meta.ts
+++ b/tests/server-function/src/functions/use-server-function-meta.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { getServerFunctionMeta } from "@solidjs/start";
+
+export function serverFnWithMeta() {
+  return typeof getServerFunctionMeta()?.id;
+}

--- a/tests/server-function/src/routes/server-function-meta-nested.tsx
+++ b/tests/server-function/src/routes/server-function-meta-nested.tsx
@@ -1,0 +1,23 @@
+import { getServerFunctionMeta } from "@solidjs/start";
+import { createEffect, createSignal } from "solid-js";
+
+function serverFnWithMeta() {
+  "use server";
+
+  return typeof getServerFunctionMeta()?.id;
+}
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ serverFnWithMeta?: string }>({});
+
+  createEffect(async () => {
+    const result = await serverFnWithMeta();
+    setOutput(prev => ({ ...prev, serverFnWithMeta: result }));
+  });
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}

--- a/tests/server-function/src/routes/server-function-meta.tsx
+++ b/tests/server-function/src/routes/server-function-meta.tsx
@@ -1,0 +1,17 @@
+import { createEffect, createSignal } from "solid-js";
+import { serverFnWithMeta } from "~/functions/use-server-function-meta";
+
+export default function App() {
+  const [output, setOutput] = createSignal<{ serverFnWithMeta?: string }>({});
+
+  createEffect(async () => {
+    const result = await serverFnWithMeta();
+    setOutput(prev => ({ ...prev, serverFnWithMeta: result }));
+  });
+
+  return (
+    <main>
+      <span id="server-fn-test">{JSON.stringify(output())}</span>
+    </main>
+  );
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #1772
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

`getServerFunctionMeta` is exported in `@solidjs/start/server`. Importing it can lead to circular import issues, because `StartServer` also resides in that entry. During such a circular import issue, `getServerFunctionMeta` will be undefined, resulting in an `getServerFunctionMeta is not a function` error.

## What is the new behavior?

- The old `getServerFunctionMeta` export in `@solidjs/start/server` is deprecated.
- A new `getServerFunctionMeta` export is added to `@solidjs/start`, which fixes the circular import.

## Other information

PR for changing the `getServerFunctionMeta` docs entry: solidjs/solid-docs#1064

A similar change had to be made in the past related to `FileRoutes` (#1365).

This PR includes a new test for `getServerFunctionMeta`. If you run this test with the old `getServerFunctionMeta` from `@solidjs/start/server` the test fails - because of the circular import issue. The resulting cypress screenshots:

![server-function -- should have an id of type string in the server function meta - nested (failed)](https://github.com/user-attachments/assets/0da726a2-8f82-4a21-bcdf-dcbbd8f6673a)
![server-function -- should have an id of type string in the server function meta - toplevel (failed)](https://github.com/user-attachments/assets/717e7753-f83f-4365-a10b-c2b5581ba385)




