### PR TITLE
fix: return 404 when server function not found

### DIFF
--- a/packages/start/src/runtime/server-handler.ts
+++ b/packages/start/src/runtime/server-handler.ts
@@ -87,12 +87,13 @@ async function handleServerFunction(h3Event: HTTPEvent) {
   } else {
     functionId = url.searchParams.get("id");
     name = url.searchParams.get("name");
-    if (!functionId || !name) throw new Error("Invalid request");
+    if (!functionId || !name) return new Response("Server function not found", { status: 404 });
   }
 
   const serverFnInfo = serverFnManifest[functionId];
   let fnModule: undefined | { [key: string]: any };
 
+  if (!serverFnInfo) return new Response("Server function not found", { status: 404 });
   
   if (process.env.NODE_ENV === "development") {
     // In dev, we use Vinxi to get the "server" server-side router


### PR DESCRIPTION
fixes #1779

## What is the current behavior?

Currently server functions calls are expected to always provide the correct id and name. However in our use case we have had bots that try to access older id and name combinations which results in a 500 error.

## What is the new behavior?

This change treats not found server functions with a 404 response so that it provides better logging results in case an older or wrong id is being accessed directly.
