### PR TITLE
infra: automate issue management

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,4 +1,5 @@
-name: Issue Close Require
+# CronJob
+name: ⏱️ Issue Close Require
 
 on:
   schedule:

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,18 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'solidjs/solid-start'
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs reproduction
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "needs reproduction"
+          inactive-day: 3

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -27,4 +27,4 @@ jobs:
             allcontributors[bot]
             renovate
             renovate[bot]
-          ignore-team-members: false
+          ignore-team-members: true

--- a/.github/workflows/issue-labelled.yml
+++ b/.github/workflows/issue-labelled.yml
@@ -1,0 +1,30 @@
+name: 🔖 Issue Labelled
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'vitejs/vite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: contribution welcome
+        if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted' || github.event.label.name == 'good first issue'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "pending triage, needs reproduction"
+
+      - name: needs reproduction
+        if: github.event.label.name == 'needs reproduction'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment, remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://stackblitz.com/). Issues marked with `needs reproduction` will be closed if they have no activity within 3 days.
+          labels: "pending triage"


### PR DESCRIPTION
I'm adding a few automations to the repository that will help us reduce the number of opened issues...copied from Vite.

- new label: **need reproduction**
- new action: triggers a bot comment asking and instructing how to make a reproduction
- cronjob: if the issue that needs reproduction is inactive for 3 days, it's closed.

I also added:
- **needs triage** so we know we need to look at it
- **good first issue** for low-hanging fruits
- **contributions welcome** we triaged but have no time to tackle it