### PR TITLE
patch: add function name to _server paths

### DIFF
--- a/packages/start/src/runtime/server-fns-runtime.ts
+++ b/packages/start/src/runtime/server-fns-runtime.ts
@@ -5,10 +5,17 @@ import { cloneEvent } from "../server/fetchEvent";
 export function createServerReference(fn: Function, id: string, name: string) {
   if (typeof fn !== "function") throw new Error("Export from a 'use server' module must be a function");
   const baseURL = import.meta.env.SERVER_BASE_URL;
+  // @tanstack/server-functions-plugin contructs the id from the filename + function name eg src_lib_api_ts--getStory_query
+  // So we extract the name by splitting on --
+  // This feels flaky and we should rather try and get the function name directly from the plugin
+  // but this requires a change in the plugin
+  const functionName = id.split("--").pop() || id;
+  const functionPath = `${baseURL}/_server/${encodeURIComponent(functionName)}/`;
+
   return new Proxy(fn, {
     get(target, prop, receiver) {
       if (prop === "url") {
-        return `${baseURL}/_server?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
+        return `${functionPath}/?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}`;
       }
       if (prop === "GET") return receiver;
       return (target as any)[prop];


### PR DESCRIPTION
fixes #1795

## What is the current behavior?

Currently we dont add any path in the _server route

## What is the new behavior?

The extracted function name is now added eg _server/function-name

## Other information

This approach however seems flaky because it depends on the way that the Tanstack server function plugin is extracting and then constructing the ids which is "filepath--function-name_query"
This looks like it is prone to change and does not provide guarantees.

I did see that Tankstack plugin does have the filename but seems like its not in the returned options so it might be stripped off somewhere or I missed it.
