### PR TITLE
Added options to transform API event handlers

### DIFF
--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -146,10 +146,11 @@ function handleStreamCompleteRedirect(context: PageEvent) {
 /**
  *
  * Read more: https://docs.solidjs.com/solid-start/reference/server/create-handler
- */ 
+ */
 export function createHandler(
   fn: (context: PageEvent) => unknown,
-  options?: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>)
+  options?: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>),
+  httpOptions?: HttpHandlerOptions
 ) {
-  return createBaseHandler(fn, createPageEvent, options);
+  return createBaseHandler(fn, createPageEvent, options, httpOptions);
 }

--- a/packages/start/src/server/types.ts
+++ b/packages/start/src/server/types.ts
@@ -30,6 +30,10 @@ export type HandlerOptions = {
   onCompleteShell?: (options: { write: (v: any) => void }) => void;
 };
 
+export type HttpHandlerOptions = {
+  transformHandler?: (event: APIEvent, handler: (event: APIEvent) => unknown) => unknown,
+}
+
 export type ContextMatches = {
   originalPath: string;
   pattern: string;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Addresses an existing open issue: fixes #000
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

N/A

## What is the new behavior?

Add an additional options to the server configuration to allow for HTTP endpoints to be arbitrarily modified without.

### Use Cases

These are just some examples why I personally would find this useful all though there are many other applications.

Say we had some service function that includes some fairly nested function calls say something like the following example of a transaction in drizzle.

Rather than having to drill back up the errors it's nice to be able to just throw them

```ts
async function createUser(values: SignupForm) {
    return await database.transaction(async transaction => {
         const user = await transaction
            .insert(users)
            .values(values)
            .returning()
            .catch(async error => {
              if (error.constraint === "users_email_unique") {
                throw new Response("This email is taken", { status: 409 });
              }

              if (error.constraint === "users_username_unique") {
                throw new Response("This username is taken", { status: 409 });
              }
     
              throw error;
         });

        return user;
    })
}  
```

But we need to make sure that we are properly handling each and every endpoint, say something like so

```ts
export function METHOD() {
   try {
      // call some service
   } catch (error) {
      if (error instanceof Response) {
         return error;
      }

     // handle the non response error, throw it again, etc...
   }
}
```

Again though this still leads to a lot of boilerplate even if we break out this into it's own function instead we could use this new proposed API.

```tsx
createHandler({
  () => <StartServer/>, 
  {}, 
  {
    transformHandler: async (event, handler) => {
       try {
         await handler(event);
       } catch (error) {
          if (error instanceof Response) {
            return error;
         }
  
          // handle the non response error, throw it again, etc...
       }
     }
  }
);
```

This would then be applied to all event handlers. Additionally it opens the door for some additional DX niceties without having to make any breaking changes by being able to modify the `APIEvent` bespoke to the application. Perhaps exposing cookies, query parameters etc more directly but that's really up to the individual application

### Some Additional Notes and Considerations

This API isn't perfect, especially taking two different options objects but that mostly stems from maintaining backwards compatibility and to only effect projects that make direct use of it. Any suggestions would be very welcome.

Notably this is distinct from middleware as we need to be able to access the transform function itself