### PR TITLE
fix: handle deleted cookies in single flight request

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -66,6 +66,7 @@
     "@tanstack/server-functions-plugin": "^1.105.2",
     "@vinxi/plugin-directives": "^0.5.0",
     "@vinxi/server-components": "^0.5.0",
+    "cookie-es": "^2.0.0",
     "defu": "^6.1.2",
     "error-stack-parser": "^2.1.4",
     "html-to-image": "^1.11.11",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #1863 
- [ ] Tests for the changes have been added (for bug fixes / features)

I'm having trouble setting up the solid-start package locally so I haven't tested it yet. I wrote this code without editor support so I might have made a mistake.

## What is the current behavior?

#1863 Right now cookies are not deleted in single flight requests

## What is the new behavior?

Cookies are deleted in single flight requests

## Other information

`cookie-es` is added as a explicit dependency, but it's what `h3` uses internally.
https://github.com/unjs/h3/blob/main/src/utils/cookie.ts#L69

Here's `parseSetCookie` for reference. https://github.com/unjs/cookie-es/blob/main/src/set-cookie/parse.ts
