### PR TITLE
feat:encode sfn > functionId & extractedFilename

### DIFF
--- a/packages/start/config/index.js
+++ b/packages/start/config/index.js
@@ -37,6 +37,23 @@ function solidStartServerFsRouter(config) {
     );
 }
 
+/**
+ * @param {string} filepath
+ * @returns {string}
+ */
+function convertToRelativePath(filepath) {
+  const arr = filepath.split("/src/");
+  return arr[1] ? `~/${arr[1]}` : filepath;
+}
+
+/** encode string, here to base64
+ * @param {string} str
+ * @returns {string}
+ */
+function encodeString(str) {
+  return btoa(encodeURIComponent(str));
+}
+
 const SolidStartServerFnsPlugin = createTanStackServerFnPlugin({
   // This is the ID that will be available to look up and import
   // our server function manifest and resolve its module
@@ -47,7 +64,7 @@ const SolidStartServerFnsPlugin = createTanStackServerFnPlugin({
         fileURLToPath(new URL("../dist/runtime/server-runtime.js", import.meta.url))
       )}"`,
     replacer: opts =>
-      `createServerReference(${() => {}}, '${opts.functionId}', '${opts.extractedFilename}')`
+      `createServerReference(${() => {}}, '${encodeString(opts.functionId)}', '${encodeString(convertToRelativePath(opts.extractedFilename))}')`
   },
   ssr: {
     getRuntimeCode: () =>
@@ -55,7 +72,7 @@ const SolidStartServerFnsPlugin = createTanStackServerFnPlugin({
         fileURLToPath(new URL("../dist/runtime/server-fns-runtime.js", import.meta.url))
       )}'`,
     replacer: opts =>
-      `createServerReference(${opts.fn}, '${opts.functionId}', '${opts.extractedFilename}')`
+      `createServerReference(${opts.fn}, '${encodeString(opts.functionId)}', '${encodeString(convertToRelativePath(opts.extractedFilename))}')`
   },
   server: {
     getRuntimeCode: () =>
@@ -63,7 +80,7 @@ const SolidStartServerFnsPlugin = createTanStackServerFnPlugin({
         fileURLToPath(new URL("../dist/runtime/server-fns-runtime.js", import.meta.url))
       )}'`,
     replacer: opts =>
-      `createServerReference(${opts.fn}, '${opts.functionId}', '${opts.extractedFilename}')`
+      `createServerReference(${opts.fn}, '${encodeString(opts.functionId)}', '${encodeString(convertToRelativePath(opts.extractedFilename))}')`
   }
 });
 

--- a/packages/start/src/runtime/server-handler.ts
+++ b/packages/start/src/runtime/server-handler.ts
@@ -78,6 +78,11 @@ function serializeToStream(id: string, value: any) {
   });
 }
 
+/** decode string, here to base64 */
+function decodeString(str?: string) {
+  return str ? decodeURIComponent(atob(str)) : str;
+}
+
 async function handleServerFunction(h3Event: HTTPEvent) {
   const event = getFetchEvent(h3Event);
   const request = event.request;
@@ -100,7 +105,7 @@ async function handleServerFunction(h3Event: HTTPEvent) {
         : new Response(null, { status: 404 });
     }
   }
-
+  functionId = decodeString(functionId);
   const serverFnInfo = serverFnManifest[functionId];
   let fnModule: undefined | { [key: string]: any };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #1859
- [ ] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/5c26a37d-b567-4998-81f7-50079a50929c" />

## What is the new behavior?

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/516b7a2b-a3a6-449a-b6ca-8c6b1fcaec40" />


## Other information

The encoded characters are guaranteed to be ASCII characters, and the path before `src` is removed to improve security and reduce string size

Currently encoded as base64, the size increases by 25%, but I don't know if there is a better way
