### PR TITLE
fix: infinite loop on unexpected response from server function (#1898)

### DIFF
--- a/.changeset/tasty-hounds-poke.md
+++ b/.changeset/tasty-hounds-poke.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix infinite loop on unexpected response from server function (issue #1898)

--- a/packages/start/src/runtime/server-runtime.ts
+++ b/packages/start/src/runtime/server-runtime.ts
@@ -58,6 +58,10 @@ class SerovalChunkReader {
     // deserialize the data
     const head = new TextDecoder().decode(this.buffer.subarray(1, 11));
     const bytes = Number.parseInt(head, 16); // ;0x00000000;
+    if (Number.isNaN(bytes)) {
+      throw new Error(`Malformed server function stream header: ${head}`);
+    }
+
     // Check if the buffer has enough bytes to be parsed
     while (bytes > this.buffer.length - 12) {
       // If it's not enough, and the reader is done


### PR DESCRIPTION
This fixes an infinite loop when a server function receives unexpected response like 403
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
```
see issue #1898

There aren't any unit tests setup I could find to add a test for this.

This just fixes the infinite loop, but probably better error handling for response codes like 403 and response content types like should be made, it would be beneficial to get the response code and body to be able to gracefully handle errors on server functions - this requires some API design decisions?