### PR TITLE
fix leaking server functions to client

### DIFF
--- a/examples/bare/package.json
+++ b/examples/bare/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -11,7 +11,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/experiments/package.json
+++ b/examples/experiments/package.json
@@ -10,7 +10,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/notes/package.json
+++ b/examples/notes/package.json
@@ -10,7 +10,7 @@
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
     "date-fns": "^3.6.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "marked": "^12.0.1",
     "unstorage": "1.10.2",
     "vinxi": "^0.5.3"

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "unstorage": "1.10.2",
     "vinxi": "^0.5.3"
   },

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "unstorage": "1.10.2",
     "vinxi": "^0.5.3"
   },

--- a/examples/with-authjs/package.json
+++ b/examples/with-authjs/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@solidjs/router": "^0.15.1",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3",
     "@solidjs/meta": "^0.29.4",
     "zod": "^3.22.4",

--- a/examples/with-drizzle/package.json
+++ b/examples/with-drizzle/package.json
@@ -16,7 +16,7 @@
     "@solidjs/start": "^1.1.0",
     "better-sqlite3": "^11.0.0",
     "drizzle-orm": "^0.31.2",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -11,7 +11,7 @@
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
     "@vinxi/plugin-mdx": "^3.7.1",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3",
     "solid-mdx": "^0.0.7"
   },

--- a/examples/with-prisma/package.json
+++ b/examples/with-prisma/package.json
@@ -14,7 +14,7 @@
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
     "prisma": "^5.12.1",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/with-solid-styled/package.json
+++ b/examples/with-solid-styled/package.json
@@ -10,7 +10,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "solid-styled": "^0.12.0",
     "vinxi": "^0.5.3",
     "unplugin-solid-styled": "^0.12.0"

--- a/examples/with-solidbase/package.json
+++ b/examples/with-solidbase/package.json
@@ -13,7 +13,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.3",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.6"
   },
   "engines": {

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "devDependencies": {

--- a/examples/with-tanstack-router/package.json
+++ b/examples/with-tanstack-router/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-router-devtools": "^1.114.1",
     "@tanstack/router-plugin": "^1.112.0",
     "@solidjs/start": "^1.1.2",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/examples/with-trpc/package.json
+++ b/examples/with-trpc/package.json
@@ -13,7 +13,7 @@
     "@trpc/client": "^10.45.2",
     "@trpc/server": "^10.45.2",
     "@typeschema/valibot": "^0.13.4",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "valibot": "^0.29.0",
     "vinxi": "^0.5.3"
   },

--- a/examples/with-unocss/package.json
+++ b/examples/with-unocss/package.json
@@ -10,7 +10,7 @@
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.0",
     "@unocss/reset": "^0.65.1",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "unocss": "^0.65.1",
     "vinxi": "^0.5.3"
   },

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -18,7 +18,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@vitest/ui": "3.0.5",
     "jsdom": "^25.0.1",
-    "solid-js": "^1.9.3",
+    "solid-js": "^1.9.7",
     "typescript": "^5.6.3",
     "vinxi": "^0.5.3",
     "vite": "^6.0.0",

--- a/packages/landing-page/package.json
+++ b/packages/landing-page/package.json
@@ -26,7 +26,7 @@
     "@solidjs/start": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "solid-js": "^1.9.4",
+    "solid-js": "^1.9.7",
     "solid-transition-group": "^0.2.3"
   }
 }

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -59,7 +59,7 @@
     }
   },
   "devDependencies": {
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3"
   },
   "dependencies": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -23,7 +23,7 @@
     "@vitest/ui": "3.0.5",
     "jsdom": "^25.0.1",
     "lodash": "^4.17.21",
-    "solid-js": "^1.9.5",
+    "solid-js": "^1.9.7",
     "vinxi": "^0.5.3",
     "vite-plugin-solid": "^2.11.6",
     "vitest": "3.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.4)
+        version: 0.29.4(solid-js@1.9.7)
       '@solidjs/router':
         specifier: ^0.15.3
-        version: 0.15.3(solid-js@1.9.4)
+        version: 0.15.3(solid-js@1.9.7)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../start
@@ -45,18 +45,18 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       solid-js:
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^1.9.7
+        version: 1.9.7
       solid-transition-group:
         specifier: ^0.2.3
-        version: 0.2.3(solid-js@1.9.4)
+        version: 0.2.3(solid-js@1.9.7)
     devDependencies:
       '@kobalte/core':
         specifier: ^0.13.1
-        version: 0.13.7(solid-js@1.9.4)
+        version: 0.13.7(solid-js@1.9.7)
       '@kobalte/utils':
         specifier: ^0.9.0
-        version: 0.9.1(solid-js@1.9.4)
+        version: 0.9.1(solid-js@1.9.7)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -122,17 +122,17 @@ importers:
         version: 1.2.1
       terracotta:
         specifier: ^1.0.4
-        version: 1.0.6(solid-js@1.9.5)
+        version: 1.0.6(solid-js@1.9.7)
       tinyglobby:
         specifier: ^0.2.2
         version: 0.2.10
       vite-plugin-solid:
         specifier: ^2.11.1
-        version: 2.11.1(@testing-library/jest-dom@6.6.2)(solid-js@1.9.5)(vite@6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
+        version: 2.11.1(@testing-library/jest-dom@6.6.2)(solid-js@1.9.7)(vite@6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
     devDependencies:
       solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
+        specifier: ^1.9.7
+        version: 1.9.7
       vinxi:
         specifier: ^0.5.3
         version: 0.5.3(@types/node@22.13.5)(better-sqlite3@11.8.1)(db0@0.2.3(better-sqlite3@11.8.1)(drizzle-orm@0.31.4(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(better-sqlite3@11.8.1)(prisma@5.22.0)))(drizzle-orm@0.31.4(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(better-sqlite3@11.8.1)(prisma@5.22.0))(ioredis@5.4.1)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.6.0)
@@ -141,16 +141,16 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.5)
+        version: 0.29.4(solid-js@1.9.7)
       '@solidjs/router':
         specifier: ^0.15.3
-        version: 0.15.3(solid-js@1.9.5)
+        version: 0.15.3(solid-js@1.9.7)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../start
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.3(solid-js@1.9.5))(solid-js@1.9.5)
+        version: 0.8.10(@solidjs/router@0.15.3(solid-js@1.9.7))(solid-js@1.9.7)
       '@testing-library/jest-dom':
         specifier: ^6.6.2
         version: 6.6.2
@@ -167,14 +167,14 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
+        specifier: ^1.9.7
+        version: 1.9.7
       vinxi:
         specifier: ^0.5.3
         version: 0.5.3(@types/node@22.13.5)(better-sqlite3@11.8.1)(db0@0.2.3(better-sqlite3@11.8.1)(drizzle-orm@0.31.4(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(better-sqlite3@11.8.1)(prisma@5.22.0)))(drizzle-orm@0.31.4(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(better-sqlite3@11.8.1)(prisma@5.22.0))(ioredis@5.4.1)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.6.0)
       vite-plugin-solid:
         specifier: ^2.11.6
-        version: 2.11.6(@testing-library/jest-dom@6.6.2)(solid-js@1.9.5)(vite@6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
+        version: 2.11.6(@testing-library/jest-dom@6.6.2)(solid-js@1.9.7)(vite@6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
       vitest:
         specifier: 3.0.5
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.5)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.7.0(@types/node@22.13.5)(typescript@5.7.3))(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)
@@ -4775,8 +4775,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.3.2:
+    resolution: {integrity: sha512-0QvCV2lM3aj/U3YozDiVwx9zpH0q8A60CTWIv4Jszj/givcudPb48B+rkU5D51NJ0pTpweGMttHjboPa9/zoIQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.1.1:
     resolution: {integrity: sha512-rqEO6FZk8mv7Hyv4UCj3FD3b6Waqft605TLfsCe/BiaylRpyyMC0b+uA5TJKawX3KzMrdi3wsLbCaLplrQmBvQ==}
+    engines: {node: '>=10'}
+
+  seroval@1.3.2:
+    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
     engines: {node: '>=10'}
 
   serve-placeholder@2.0.2:
@@ -4858,11 +4868,8 @@ packages:
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
-  solid-js@1.9.4:
-    resolution: {integrity: sha512-ipQl8FJ31bFUoBNScDQTG3BjN6+9Rg+Q+f10bUbnO6EOTTf5NGerJeHc7wyu5I4RMHEl/WwZwUmy/PTRgxxZ8g==}
-
-  solid-js@1.9.5:
-    resolution: {integrity: sha512-ogI3DaFcyn6UhYhrgcyRAMbu/buBJitYQASZz5WzfQVPP10RD2AbCoRZ517psnezrasyCbWzIxZ6kVqet768xw==}
+  solid-js@1.9.7:
+    resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
 
   solid-presence@0.1.8:
     resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
@@ -6631,15 +6638,15 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@corvu/utils@0.2.0(solid-js@1.9.4)':
+  '@corvu/utils@0.2.0(solid-js@1.9.7)':
     dependencies:
       '@floating-ui/dom': 1.6.5
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
-  '@corvu/utils@0.4.2(solid-js@1.9.4)':
+  '@corvu/utils@0.4.2(solid-js@1.9.7)':
     dependencies:
       '@floating-ui/dom': 1.6.11
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
   '@cypress/code-coverage@3.14.0(@babel/core@7.26.9)(@babel/preset-env@7.26.0(@babel/core@7.26.9))(babel-loader@9.2.1(@babel/core@7.26.9)(webpack@5.97.1))(cypress@14.3.0)(webpack@5.97.1)':
     dependencies:
@@ -7026,28 +7033,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@kobalte/core@0.13.7(solid-js@1.9.4)':
+  '@kobalte/core@0.13.7(solid-js@1.9.7)':
     dependencies:
       '@floating-ui/dom': 1.6.5
       '@internationalized/date': 3.5.4
       '@internationalized/number': 3.5.3
-      '@kobalte/utils': 0.9.1(solid-js@1.9.4)
-      '@solid-primitives/props': 3.1.11(solid-js@1.9.4)
-      '@solid-primitives/resize-observer': 2.0.26(solid-js@1.9.4)
-      solid-js: 1.9.4
-      solid-presence: 0.1.8(solid-js@1.9.4)
-      solid-prevent-scroll: 0.1.7(solid-js@1.9.4)
+      '@kobalte/utils': 0.9.1(solid-js@1.9.7)
+      '@solid-primitives/props': 3.1.11(solid-js@1.9.7)
+      '@solid-primitives/resize-observer': 2.0.26(solid-js@1.9.7)
+      solid-js: 1.9.7
+      solid-presence: 0.1.8(solid-js@1.9.7)
+      solid-prevent-scroll: 0.1.7(solid-js@1.9.7)
 
-  '@kobalte/utils@0.9.1(solid-js@1.9.4)':
+  '@kobalte/utils@0.9.1(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.4)
-      '@solid-primitives/keyed': 1.2.2(solid-js@1.9.4)
-      '@solid-primitives/map': 0.4.11(solid-js@1.9.4)
-      '@solid-primitives/media': 2.2.9(solid-js@1.9.4)
-      '@solid-primitives/props': 3.1.11(solid-js@1.9.4)
-      '@solid-primitives/refs': 1.0.8(solid-js@1.9.4)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.7)
+      '@solid-primitives/keyed': 1.2.2(solid-js@1.9.7)
+      '@solid-primitives/map': 0.4.11(solid-js@1.9.7)
+      '@solid-primitives/media': 2.2.9(solid-js@1.9.7)
+      '@solid-primitives/props': 3.1.11(solid-js@1.9.7)
+      '@solid-primitives/refs': 1.0.8(solid-js@1.9.7)
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7406,91 +7413,83 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solid-primitives/event-listener@2.3.3(solid-js@1.9.4)':
+  '@solid-primitives/event-listener@2.3.3(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/keyed@1.2.2(solid-js@1.9.4)':
+  '@solid-primitives/keyed@1.2.2(solid-js@1.9.7)':
     dependencies:
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
-  '@solid-primitives/map@0.4.11(solid-js@1.9.4)':
+  '@solid-primitives/map@0.4.11(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/trigger': 1.0.11(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/trigger': 1.0.11(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/media@2.2.9(solid-js@1.9.4)':
+  '@solid-primitives/media@2.2.9(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.4)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.4)
-      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.4)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.7)
+      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.7)
+      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.7)
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/props@3.1.11(solid-js@1.9.4)':
+  '@solid-primitives/props@3.1.11(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/refs@1.0.8(solid-js@1.9.4)':
+  '@solid-primitives/refs@1.0.8(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/resize-observer@2.0.26(solid-js@1.9.4)':
+  '@solid-primitives/resize-observer@2.0.26(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.4)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.4)
-      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.4)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.7)
+      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.7)
+      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.7)
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/rootless@1.4.5(solid-js@1.9.4)':
+  '@solid-primitives/rootless@1.4.5(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/static-store@0.0.8(solid-js@1.9.4)':
+  '@solid-primitives/static-store@0.0.8(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/transition-group@1.0.5(solid-js@1.9.4)':
+  '@solid-primitives/transition-group@1.0.5(solid-js@1.9.7)':
     dependencies:
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
-  '@solid-primitives/trigger@1.0.11(solid-js@1.9.4)':
+  '@solid-primitives/trigger@1.0.11(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  '@solid-primitives/utils@6.2.3(solid-js@1.9.4)':
+  '@solid-primitives/utils@6.2.3(solid-js@1.9.7)':
     dependencies:
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
-  '@solidjs/meta@0.29.4(solid-js@1.9.4)':
+  '@solidjs/meta@0.29.4(solid-js@1.9.7)':
     dependencies:
-      solid-js: 1.9.4
+      solid-js: 1.9.7
 
-  '@solidjs/meta@0.29.4(solid-js@1.9.5)':
+  '@solidjs/router@0.15.3(solid-js@1.9.7)':
     dependencies:
-      solid-js: 1.9.5
+      solid-js: 1.9.7
 
-  '@solidjs/router@0.15.3(solid-js@1.9.4)':
-    dependencies:
-      solid-js: 1.9.4
-
-  '@solidjs/router@0.15.3(solid-js@1.9.5)':
-    dependencies:
-      solid-js: 1.9.5
-
-  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.3(solid-js@1.9.5))(solid-js@1.9.5)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.3(solid-js@1.9.7))(solid-js@1.9.7)':
     dependencies:
       '@testing-library/dom': 10.4.0
-      solid-js: 1.9.5
+      solid-js: 1.9.7
     optionalDependencies:
-      '@solidjs/router': 0.15.3(solid-js@1.9.5)
+      '@solidjs/router': 0.15.3(solid-js@1.9.7)
 
   '@swc/counter@0.1.3': {}
 
@@ -10695,7 +10694,13 @@ snapshots:
     dependencies:
       seroval: 1.1.1
 
+  seroval-plugins@1.3.2(seroval@1.3.2):
+    dependencies:
+      seroval: 1.3.2
+
   seroval@1.1.1: {}
+
+  seroval@1.3.2: {}
 
   serve-placeholder@2.0.2:
     dependencies:
@@ -10799,46 +10804,40 @@ snapshots:
 
   smob@1.5.0: {}
 
-  solid-js@1.9.4:
+  solid-js@1.9.7:
     dependencies:
       csstype: 3.1.3
-      seroval: 1.1.1
-      seroval-plugins: 1.1.1(seroval@1.1.1)
+      seroval: 1.3.2
+      seroval-plugins: 1.3.2(seroval@1.3.2)
 
-  solid-js@1.9.5:
+  solid-presence@0.1.8(solid-js@1.9.7):
     dependencies:
-      csstype: 3.1.3
-      seroval: 1.1.1
-      seroval-plugins: 1.1.1(seroval@1.1.1)
+      '@corvu/utils': 0.4.2(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  solid-presence@0.1.8(solid-js@1.9.4):
+  solid-prevent-scroll@0.1.7(solid-js@1.9.7):
     dependencies:
-      '@corvu/utils': 0.4.2(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@corvu/utils': 0.2.0(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  solid-prevent-scroll@0.1.7(solid-js@1.9.4):
-    dependencies:
-      '@corvu/utils': 0.2.0(solid-js@1.9.4)
-      solid-js: 1.9.4
-
-  solid-refresh@0.6.3(solid-js@1.9.5):
+  solid-refresh@0.6.3(solid-js@1.9.7):
     dependencies:
       '@babel/generator': 7.26.9
       '@babel/helper-module-imports': 7.25.9
       '@babel/types': 7.26.9
-      solid-js: 1.9.5
+      solid-js: 1.9.7
     transitivePeerDependencies:
       - supports-color
 
-  solid-transition-group@0.2.3(solid-js@1.9.4):
+  solid-transition-group@0.2.3(solid-js@1.9.7):
     dependencies:
-      '@solid-primitives/refs': 1.0.8(solid-js@1.9.4)
-      '@solid-primitives/transition-group': 1.0.5(solid-js@1.9.4)
-      solid-js: 1.9.4
+      '@solid-primitives/refs': 1.0.8(solid-js@1.9.7)
+      '@solid-primitives/transition-group': 1.0.5(solid-js@1.9.7)
+      solid-js: 1.9.7
 
-  solid-use@0.9.0(solid-js@1.9.5):
+  solid-use@0.9.0(solid-js@1.9.7):
     dependencies:
-      solid-js: 1.9.5
+      solid-js: 1.9.7
 
   source-map-js@1.2.1: {}
 
@@ -11056,10 +11055,10 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terracotta@1.0.6(solid-js@1.9.5):
+  terracotta@1.0.6(solid-js@1.9.7):
     dependencies:
-      solid-js: 1.9.5
-      solid-use: 0.9.0(solid-js@1.9.5)
+      solid-js: 1.9.7
+      solid-use: 0.9.0(solid-js@1.9.7)
 
   terser-webpack-plugin@5.3.12(webpack@5.97.1):
     dependencies:
@@ -11482,14 +11481,14 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.1(@testing-library/jest-dom@6.6.2)(solid-js@1.9.5)(vite@6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)):
+  vite-plugin-solid@2.11.1(@testing-library/jest-dom@6.6.2)(solid-js@1.9.7)(vite@6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)):
     dependencies:
       '@babel/core': 7.26.7
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.8.17(@babel/core@7.26.7)
       merge-anything: 5.1.7
-      solid-js: 1.9.5
-      solid-refresh: 0.6.3(solid-js@1.9.5)
+      solid-js: 1.9.7
+      solid-refresh: 0.6.3(solid-js@1.9.7)
       vite: 6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)
       vitefu: 1.0.4(vite@6.1.4(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
     optionalDependencies:
@@ -11497,14 +11496,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.6(@testing-library/jest-dom@6.6.2)(solid-js@1.9.5)(vite@6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)):
+  vite-plugin-solid@2.11.6(@testing-library/jest-dom@6.6.2)(solid-js@1.9.7)(vite@6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)):
     dependencies:
       '@babel/core': 7.26.9
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.5(@babel/core@7.26.9)
       merge-anything: 5.1.7
-      solid-js: 1.9.5
-      solid-refresh: 0.6.3(solid-js@1.9.5)
+      solid-js: 1.9.7
+      solid-refresh: 0.6.3(solid-js@1.9.7)
       vite: 6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0)
       vitefu: 1.0.6(vite@6.1.0(@types/node@22.13.5)(jiti@2.4.2)(lightningcss@1.27.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.6.0))
     optionalDependencies:


### PR DESCRIPTION
tested and bumped version

fixes leaking server code to client bundle because of missing matches for compresed js assets in [vinxi](https://github.com/nksaraf/vinxi/blob/6d31572a0516d2298e51c7e3db7846efe3e5441f/packages/vinxi/lib/build.js#L334)

this is a workaround until this is fixed in vinxi. left a comment in the code.

related issues:
[1869](https://github.com/solidjs/solid-start/issues/1869 ) from 2025-03-23
