### PR TITLE
Update Deno quick start command

### DIFF
--- a/packages/landing-page/src/components/code-snippet.tsx
+++ b/packages/landing-page/src/components/code-snippet.tsx
@@ -52,7 +52,7 @@ export function CodeSnippet() {
         <TabContent manager="bun" command="create solid" />
         <TabContent manager="npm" command="create solid" />
         <TabContent manager="yarn" command="create solid" />
-        <TabContent manager="deno" command="run -A npm:create-solid" />
+        <TabContent manager="deno" command="init --npm solid" />
       </Tabs>
       <Suspense>
         <small class="font-mono text-right pt-2 inline-block w-full dark:text-sky-400/60 text-sky-950">


### PR DESCRIPTION
This PR updates the "create" command for Deno. [`init --npm`](https://docs.deno.com/runtime/reference/cli/init/) is the official command for this purpose. The documentation site was also recently updated to use `init --npm`.