### PR TITLE
fix: `fetchEvent` -> `HeaderProxy` checks for `null` instead of `undefined`

### DIFF
--- a/.changeset/open-ducks-flash.md
+++ b/.changeset/open-ducks-flash.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix: check for `null` instad of `undefined` in `HeaderProxy`

--- a/packages/start/src/server/fetchEvent.ts
+++ b/packages/start/src/server/fetchEvent.ts
@@ -53,7 +53,7 @@ class HeaderProxy {
 		return Array.isArray(h) ? h.join(", ") : (h as string) || null;
 	}
 	has(key: string) {
-		return this.get(key) !== undefined;
+		return this.get(key) !== null;
 	}
 	set(key: string, value: string) {
 		return setResponseHeader(this.event, key, value);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Addresses an existing open issue: fixes #000
- [ ] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?
`event.response.headers.has("does-not-exist")` returns `true`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
`event.response.headers.has("does-not-exist")` returns `false`
## Other information

<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
