### PR TITLE
fix: Enhance route matching to return `isPage` flag and add tests for…

### DIFF
--- a/packages/start/src/router/routes.ts
+++ b/packages/start/src/router/routes.ts
@@ -60,14 +60,27 @@ function defineRoutes(fileRoutes: Route[]) {
 export function matchAPIRoute(path: string, method: string) {
   const match = router.lookup(path);
   if (match && match.route) {
-    const handler =
-      method === "HEAD" ? match.route["$HEAD"] || match.route["$GET"] : match.route[`$${method}`];
+    const route = match.route;
+
+    // Find the appropriate handler for the HTTP method
+    const handler = method === "HEAD"
+      ? route.$HEAD || route.$GET
+      : route[`$${method}`];
+
     if (handler === undefined) return;
+
+    // Check if this is a page route
+    const isPage = route.page === true && route.$component !== undefined;
+
+    // Return comprehensive route information
     return {
       handler,
-      params: match.params
+      params: match.params,
+      isPage
     };
   }
+
+  return undefined;
 }
 
 function containsHTTP(route: Route) {

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -59,6 +59,7 @@ export function createBaseHandler(
               `API handler for ${event.request.method} "${event.request.url}" did not return a response.`
             );
           }
+          if (!match.isPage) return;
         }
 
         // render

--- a/packages/tests/src/app.tsx
+++ b/packages/tests/src/app.tsx
@@ -50,6 +50,12 @@ export default function App() {
             <li>
               <a href="/generator-server-function">generator server function</a>
             </li>
+            <li>
+              <a href="/not-found">Not Found</a>
+            </li>
+            <li>
+              <a href="/text-plain-response">Text Plain Response</a>
+            </li>
           </ul>
           <Suspense>{props.children}</Suspense>
         </MetaProvider>

--- a/packages/tests/src/routes/[...404].tsx
+++ b/packages/tests/src/routes/[...404].tsx
@@ -1,0 +1,21 @@
+import { Title } from "@solidjs/meta";
+import { HttpStatusCode } from "@solidjs/start";
+import type { APIEvent } from "@solidjs/start/server";
+
+export const GET = (event: APIEvent) => {
+  if (event.request.headers.get("accept") !== "application/json") return;
+  return { notFound: "API" };
+};
+
+export default function NotFound() {
+  return (
+    <main>
+      <Title>Not Found</Title>
+      <HttpStatusCode code={404} />
+      <h1>Page Not Found</h1>
+      <p>
+        {"Your page cannot be found... >_<"}
+      </p>
+    </main>
+  );
+}

--- a/packages/tests/src/routes/api/text-plain.tsx
+++ b/packages/tests/src/routes/api/text-plain.tsx
@@ -1,0 +1,5 @@
+import type { APIEvent } from "@solidjs/start/server";
+
+export const GET = (event: APIEvent) => {
+  return new Response("Text Plain Response");
+};

--- a/packages/tests/src/routes/text-plain-response.tsx
+++ b/packages/tests/src/routes/text-plain-response.tsx
@@ -1,0 +1,15 @@
+export default function App() {
+  const handleClick = (e: Event) => {
+    // e.preventDefault();
+
+    window.location.href = "/api/text-plain";
+  };
+
+  return (
+    <main>
+      <a href="/api/text-plain" onClick={handleClick}>
+        Text Plain Response
+      </a>
+    </main>
+  );
+};


### PR DESCRIPTION
… plain text API response and Missing page handling that has both api/file routes.

## PR Checklist
Please check if your PR fulfills the following requirements:

* [x]  Addresses an existing open issue: fixes [[Bug?]: new Response() returns text/html #1907](https://github.com/solidjs/solid-start/issues/1907), [[Bug?]: Page does not open after 1.1.5>1.1.6 upgrade #1920](https://github.com/solidjs/solid-start/issues/1920)
* [x]  Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?
The `content-type` is `text/html` for the plain-text API response.

## What is the new behavior?
It keeps both API/file routes in one path, and the `content-type` will be `text/plain` for plain-text API responses.

## Other information
Adds a test for plain text API response and a test for handling missing pages with both API/file routes.