### PR TITLE
fix: Handle multiple exports from the same file in fs-router

### DIFF
--- a/.changeset/sharp-rooms-think.md
+++ b/.changeset/sharp-rooms-think.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Handle multiple exports from the same file in fs-router

--- a/.changeset/ten-areas-burn.md
+++ b/.changeset/ten-areas-burn.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Add a test route for multiple exports handling and correct variable typos

--- a/packages/start/config/fs-router.js
+++ b/packages/start/config/fs-router.js
@@ -1,4 +1,4 @@
-import { analyzeModule, BaseFileSystemRouter, cleanPath } from "vinxi/fs-router";
+import {analyzeModule, BaseFileSystemRouter, cleanPath} from "vinxi/fs-router";
 
 export class SolidStartClientFileRouter extends BaseFileSystemRouter {
   toPath(src) {
@@ -43,13 +43,13 @@ export class SolidStartClientFileRouter extends BaseFileSystemRouter {
         page: true,
         $component: {
           src: src,
-          pick: ["default", "$css"]
+          pick: [...exports.filter(e => e.n === e.ln && e.n !== "route").map(e => e.n), "default", "$css"]
         },
         $$route: hasRouteConfig
           ? {
-              src: src,
-              pick: ["route"]
-            }
+            src: src,
+            pick: ["route"]
+          }
           : undefined,
         path,
         filePath: src
@@ -123,15 +123,15 @@ export class SolidStartServerFileRouter extends BaseFileSystemRouter {
         $component:
           !this.config.dataOnly && hasDefault
             ? {
-                src: src,
-                pick: ["default", "$css"]
-              }
+              src: src,
+              pick: [...exports.filter(e => e.n === e.ln && e.n !== "route" && !HTTP_METHODS.includes(e.n)).map(e => e.n), "default", "$css"]
+            }
             : undefined,
         $$route: hasRouteConfig
           ? {
-              src: src,
-              pick: ["route"]
-            }
+            src: src,
+            pick: ["route"]
+          }
           : undefined,
         ...createHTTPHandlers(src, exports),
         path,

--- a/packages/tests/src/app.tsx
+++ b/packages/tests/src/app.tsx
@@ -50,6 +50,9 @@ export default function App() {
             <li>
               <a href="/generator-server-function">generator server function</a>
             </li>
+            <li>
+              <a href="/referencing-multiple-export-named-functions-in-the-same-file">referencing multiple export named functions in the same file</a>
+            </li>
           </ul>
           <Suspense>{props.children}</Suspense>
         </MetaProvider>

--- a/packages/tests/src/functions/text-render-test-component.tsx
+++ b/packages/tests/src/functions/text-render-test-component.tsx
@@ -1,0 +1,4 @@
+export function TextRenderTestComponent() {
+  const text = "(´｡> ᵕ <｡`) ♡";
+  return <>{text}</>;
+}

--- a/packages/tests/src/routes/is-server-const.tsx
+++ b/packages/tests/src/routes/is-server-const.tsx
@@ -6,8 +6,8 @@ export default function App() {
 
 
     createEffect(async () => {
-        const restult = await serverFnWithIsServer();
-        setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+        const result = await serverFnWithIsServer();
+        setOutput(prev => ({ ...prev, serverFnWithIsServer: result }));
     });
 
 

--- a/packages/tests/src/routes/is-server-nested.tsx
+++ b/packages/tests/src/routes/is-server-nested.tsx
@@ -12,8 +12,8 @@ export default function App() {
 
 
   createEffect(async () => {
-    const restult = await serverFnWithIsServer();
-    setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+    const result = await serverFnWithIsServer();
+    setOutput(prev => ({ ...prev, serverFnWithIsServer: result }));
   });
 
 

--- a/packages/tests/src/routes/is-server-toplevel.tsx
+++ b/packages/tests/src/routes/is-server-toplevel.tsx
@@ -6,8 +6,8 @@ export default function App() {
 
 
   createEffect(async () => {
-    const restult = await serverFnWithIsServer();
-    setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+    const result = await serverFnWithIsServer();
+    setOutput(prev => ({ ...prev, serverFnWithIsServer: result }));
   });
 
 

--- a/packages/tests/src/routes/is-server-with-anon-default-export.tsx
+++ b/packages/tests/src/routes/is-server-with-anon-default-export.tsx
@@ -6,8 +6,8 @@ export default function App() {
 
 
     createEffect(async () => {
-        const restult = await serverFnWithIsServer();
-        setOutput(prev => ({ ...prev, serverFnWithIsServer: restult }));
+        const result = await serverFnWithIsServer();
+        setOutput(prev => ({ ...prev, serverFnWithIsServer: result }));
     });
 
 

--- a/packages/tests/src/routes/node-builtin-nested.tsx
+++ b/packages/tests/src/routes/node-builtin-nested.tsx
@@ -13,8 +13,8 @@ export default function App() {
  
 
   createEffect(async () => {
-    const restult = await serverFnWithNodeBuiltin();
-    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: restult }));
+    const result = await serverFnWithNodeBuiltin();
+    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: result }));
   });
 
   return (

--- a/packages/tests/src/routes/node-builtin-toplevel.tsx
+++ b/packages/tests/src/routes/node-builtin-toplevel.tsx
@@ -6,8 +6,8 @@ export default function App() {
   const [output, setOutput] = createSignal<{ serverFnWithNodeBuiltin?: string }>({});
 
   createEffect(async () => {
-    const restult = await serverFnWithNodeBuiltin();
-    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: restult }));
+    const result = await serverFnWithNodeBuiltin();
+    setOutput(prev => ({ ...prev, serverFnWithNodeBuiltin: result }));
   });
 
   return (

--- a/packages/tests/src/routes/npm-module-nested.tsx
+++ b/packages/tests/src/routes/npm-module-nested.tsx
@@ -11,8 +11,8 @@ export default function App() {
   const [output, setOutput] = createSignal<{ serverFnWithNpmModule?: number[] }>({});
 
   createEffect(async () => {
-    const restult = await serverFnWithNpmModule();
-    setOutput(prev => ({ ...prev, serverFnWithNpmModule: restult }));
+    const result = await serverFnWithNpmModule();
+    setOutput(prev => ({ ...prev, serverFnWithNpmModule: result }));
   });
 
   return (

--- a/packages/tests/src/routes/npm-module-toplevel.tsx
+++ b/packages/tests/src/routes/npm-module-toplevel.tsx
@@ -5,8 +5,8 @@ export default function App() {
   const [output, setOutput] = createSignal<{ serverFnWithNpmModule?: number[] }>({});
 
   createEffect(async () => {
-    const restult = await serverFnWithNpmModule();
-    setOutput(prev => ({ ...prev, serverFnWithNpmModule: restult }));
+    const result = await serverFnWithNpmModule();
+    setOutput(prev => ({ ...prev, serverFnWithNpmModule: result }));
   });
 
   return (

--- a/packages/tests/src/routes/referencing-multiple-export-named-functions-in-the-same-file.tsx
+++ b/packages/tests/src/routes/referencing-multiple-export-named-functions-in-the-same-file.tsx
@@ -1,0 +1,23 @@
+import { TextRenderTestComponent as ExternalCuteFaceDisplay} from "../functions/text-render-test-component";
+
+export function TextRenderTestComponent() {
+  return <>(´｡• ᵕ •｡`) ♡</>;
+}
+
+export function VariableImportTestComponent() {
+  return <>{testObjectExport.stringValue}</>;
+}
+
+export const testStringExport = "♡(˃͈ દ ˂͈ ༶ )";
+
+export const testObjectExport = {
+  stringValue: testStringExport,
+};
+
+export default function () {
+  return <>
+    <TextRenderTestComponent/>
+    <VariableImportTestComponent/>
+    <ExternalCuteFaceDisplay/>
+  </>;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #1933 ,https://github.com/solidjs/solid-meta/issues/33
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

If a default function in the file routes folder references an export function in the same file, a not defined error occurs and cannot be rendered.

## What is the new behavior?

The hydration process works even when the default function and its multiple referenced export functions are in the same file.

## Other information

<!-- Add screenshots, GIFS, or any other relevant information that might help give more context. -->
