### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,136 @@
-<p>
-  <img width="100%" src="https://assets.solidjs.com/banner?project=Start&type=core" alt="Solid Docs">
-</p>
+[![Banner](https://assets.solidjs.com/banner?project=Start&type=core)](https://github.com/solidjs)
 
-# SolidStart
+[![Version](https://img.shields.io/npm/v/@solidjs/start.svg?style=for-the-badge&color=blue)](https://www.npmjs.com/package/@solidjs/start)
+[![Downloads](https://img.shields.io/npm/dm/@solidjs/start.svg?style=for-the-badge&color=blue)](https://www.npmjs.com/package/@solidjs/start)
+[![Stars](https://img.shields.io/github/stars/solidjs/solid-start?style=for-the-badge&color=blue)](https://github.com/solidjs/solid-start)
+[![Discord](https://img.shields.io/discord/722131463138705510?style=for-the-badge&color=blue)](https://discord.com/invite/solidjs)
+[![Reddit](https://img.shields.io/reddit/subreddit-subscribers/solidjs?style=for-the-badge&color=blue)](https://www.reddit.com/r/solidjs/)
 
-This is the home of the SolidStart, the Solid app framework.
+SolidStart brings fine-grained reactivity fullstack with full flexibility. Built with features like unified rendering and isomorphic code execution, SolidStart enables you to create highly performant and scalable web applications. Explore the official [documentation](https://docs.solidjs.com/solid-start) for detailed guides and examples.
 
-## Features
+## Core Features
 
-- File-system based routing
-- Supports all rendering modes:
-  - Server-side rendering (SSR)
-  - Streaming SSR
-  - Client-side rendering (CSR)
-  - Static site generation (SSG)
-- Streaming
-- Build optimizations with code splitting, tree shaking and dead code elimination
-- API Routes
-- Built on Web standards like Fetch, Streams, and WebCrypto
-- Adapters for deployment to all popular platforms
-- CSS Modules, SASS/SCSS Support
-- TypeScript-first
+- **All Rendering Modes**:
+  - Server-Side Rendering (SSR) with synchronous, asynchronous, and streaming options
+  - Client-Side Rendering (CSR)
+  - Static Site Generation (SSG)
+- **TypeScript**: Full integration for robust, type-safe development
+- **File-Based Routing**: Intuitive routing based on your project’s file structure
+- **API Routes**: Dedicated server-side endpoints for seamless API development
+- **Streaming**: Efficient data rendering for faster page loads
+- **Build Optimizations**: Code splitting, tree shaking, and dead code elimination
+- **Deployment Adapters**: Easily deploy to platforms like Vercel, Netlify, Cloudflare, and more
 
-### Getting started
+## Getting Started
 
-Create a SolidStart application and run a development server using your preferred package manager:
+### Installation
+
+Create a template project with your preferred package manager:
 
 ```bash
-mkdir my-app
-cd my-app
-
-# with npm
-npm init solid@latest
-npm install
-npm run dev
-
-# or with pnpm
-pnpm create solid@latest
-pnpm install
-pnpm dev
-
-# or with Bun
-bun create solid@latest
-bun install
-bun dev
+# With npm
+npm create solid
+# With pnpm
+pnpm create solid --solidstart
+# With bun
+bun create solid
 ```
 
-### Development
+1. Follow the CLI prompts to set up your project.
+2. Navigate to your project directory and install dependencies:
 
-You should use a Node.js version manager [compatible with `.node-version`](https://stackoverflow.com/a/62978089/565877) ([asdf-vm](https://asdf-vm.com/) is a great option macOS/Linux users)
+```bash
+cd <project-name>
+npm install # or pnpm install or bun install
+```
 
-The monorepo uses `pnpm` as the package manager. To install `pnpm`, run the following command in your terminal.
+3. Start the development server:
+
+```bash
+npm run dev # or pnpm dev or bun dev
+```
+
+### Project Structure
+
+- `public/`: Static assets like icons, images, and fonts
+- `src/`: Core application (aliased to `~/`)
+  - `routes/`: File-based routing for pages and APIs
+  - `app.tsx`: Root component of your application
+  - `entry-client.tsx`: Handles client-side hydration
+  - `entry-server.tsx`: Manages server-side request handling
+- **Configuration Files**: `app.config.ts`, `package.json`, and more
+
+Learn more about routing in the [documentation](https://docs.solidjs.com/solid-start/building-your-application/routing).
+
+## Configuration
+
+Configure adapters in `app.config.ts` to deploy to platforms like Vercel, Netlify, Cloudflare, and others:
+
+```ts
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  ssr: true, // Set to false for client-side rendering
+  server: { preset: "vercel" },
+});
+```
+
+Presets also support runtimes like Node.js, Bun or Deno. For example, the `node-server` preset enables hosting on your server. Learn more about [`defineConfig`](https://docs.solidjs.com/solid-start/reference/config/define-config).
+
+## Building for Production
+
+Generate production-ready bundles:
+
+```bash
+npm run build # or pnpm build or bun build
+```
+
+The output is saved to the `dist/` directory. Then, start the server:
+
+```bash
+npm start # or pnpm start or bun start
+```
+
+## Contributing
+
+Join the SolidJS community and contribute!
+
+- [Discord](https://discord.com/invite/solidjs): Ask for help and discuss ideas
+- [Issues](https://github.com/solidjs/solid-start/issues): Report bugs or suggest features
+- [Docs Issues](https://github.com/solidjs/solid-docs/issues): Report documentation issues
+
+<details>
+  <summary><h3>Development Setup</h3></summary>
+
+Use a Node.js version manager compatible with `.node-version`. We recommend [asdf-vm](https://asdf-vm.com/) for macOS and Linux users.
+
+### Monorepo & Package Manager
+
+SolidStart uses `pnpm` as the package manager. Install it globally:
 
 ```bash
 npm install -g pnpm
 ```
 
-Run `pnpm install` to install all the dependencies for the packages and examples in your monorepo.
+Install dependencies for the monorepo:
 
-Run `pnpm build` to build SolidStart project
+```bash
+pnpm install
+```
 
-<details>
-<summary><h4>Monorepo & <code>project.json</code> <code>"workspace"</code> support</h4></summary>
+Build the project:
 
-If you are using SolidStart within a monorepo that takes advantage of the `package.json` `"workspaces"` property (e.g. [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)) with hoisted dependencies (the default for Yarn), you must include `#solidjs/start` within the optional `"nohoist"` (for Yarn v2 or higher, see further down for instructions) workspaces property.
+```bash
+pnpm build
+```
 
-- _In the following, "workspace root" refers to the root of your repository while "project root" refers to the root of a child package within your repository._
+### Monorepo & `package.json` Workspaces
 
-For example, if specifying `"nohoist"` options from the workspace root (i.e. for all packages):
+If using a monorepo with `package.json` `"workspaces"` (e.g., [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)), ensure `@solidjs/start` is not hoisted. Add it to the `"nohoist"` field in the workspace root or project root:
+
+**Workspace Root Example**:
 
 ```jsonc
-// in workspace root
 {
   "workspaces": {
     "packages": [
@@ -81,10 +141,9 @@ For example, if specifying `"nohoist"` options from the workspace root (i.e. for
 }
 ```
 
-If specifying `"nohoist"` options for a specific package using `@solidjs/start`:
+**Project Root Example**:
 
 ```jsonc
-// in project root of a workspace child
 {
   "workspaces": {
     "nohoist": ["@solidjs/start"]
@@ -92,21 +151,16 @@ If specifying `"nohoist"` options for a specific package using `@solidjs/start`:
 }
 ```
 
-Regardless of where you specify the `nohoist` option, you also need to include `@solidjs/start` as a `devDependency` in the child `package.json`.
-
-The reason why this is necessary is because `@solidjs/start` creates an `index.html` file within your project which expects to load a script located in `/node_modules/@solidjs/start/runtime/entry.jsx` (where `/` is the path of your project root). By default, if you hoist the `@solidjs/start` dependency into the workspace root then that script will not be available within the package's `node_modules` folder.
-
-**Yarn v2 or higher**
-
-The `nohoist` option is no longer available in Yarn v2+. In this case, we can use the `installConfig` property in the `package.json` (either workspace package or a specific project package) to make sure our deps are not hoisted.
+For **Yarn v2+**, use `installConfig` to prevent hoisting:
 
 ```jsonc
-// in project root of a workspace child
 {
   "installConfig": {
     "hoistingLimits": "dependencies"
   }
 }
 ```
+
+**Note**: Add `@solidjs/start` as a `devDependency` in the child `package.json` to ensure the `/node_modules/@solidjs/start/runtime/entry.jsx` script is available.
 
 </details>


### PR DESCRIPTION
This pull request improves the README by enhancing its visual appeal and usability. The current README on npm is nearly empty, and the GitHub version, while functional, lacks polish. This update addresses these issues by:

- **Adding Visual Badges**: Included badges for npm version, downloads, GitHub stars, Discord, and Reddit to make the project more engaging and provide quick insights into its popularity and community.
- **Improved Structure and Clarity**: Rewritten content to be concise, user-friendly, and focused on key features, setup instructions, and deployment options.
- **Relocated Development Guide**: Moved the detailed development setup and monorepo instructions under a "Contributing" section with a collapsible `<details>` tag to prioritize user-facing content.
- **Updated Installation Commands**: Added the `--solidstart` flag for `pnpm create solid` to streamline project setup. Note: The equivalent flag for `npm create solid` seems unsupported, so it remains unchanged. Please confirm if this is intentional or if further tweaks are needed.

### Notes on Yarn and Monorepo Section
The monorepo and `package.json` workspace instructions prominently feature Yarn, but Yarn isn't included in the installation or server startup commands. This inconsistency suggests we could remove the Yarn-specific guidance entirely to align with the focus on npm, pnpm, and Bun?
