### PR TITLE
Multibranch release

### DIFF
--- a/.changeset/config-v1.json
+++ b/.changeset/config-v1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "v1.x",
+  "updateInternalDependencies": "patch",
+  "ignore": ["landing-page", "tests"]
+}

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v1.x
   merge_group:
   pull_request:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v1.x
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -27,13 +28,19 @@ jobs:
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile
 
+      - name: Setup changeset config for v1.x branch
+        if: github.ref_name == 'v1.x'
+        run: |
+          cp .changeset/config-v1.json .changeset/config.json
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run release
-          title: "chore: release"
-          commit: "chore: release"
+          title: "${{ github.ref_name == 'v1.x' && 'chore: release v1.x' || 'chore: release' }}"
+          commit: "${{ github.ref_name == 'v1.x' && 'chore: release v1.x' || 'chore: release' }}"
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,9 @@ name: 🧪 Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, v1.x]
   push:
-    branches: [main]
+    branches: [main, v1.x]
 
 jobs:
   tests:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v1.x
       - dev
       - release-*
     tags-ignore:
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1.x
       - dev
       - release-*
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# SolidStart Agent Guidelines
+
+## Build/Test Commands
+- `pnpm build` - Build all packages
+- `pnpm test` - Run all tests  
+- `pnpm test -- <pattern>` - Run specific test pattern
+- `pnpm --filter tests unit` - Run unit tests with Vitest
+- `pnpm --filter tests unit -- <file>` - Run single test file
+- `pnpm --filter tests e2e:run` - Run Cypress E2E tests
+- `pnpm --filter @solidjs/start typecheck` - Type check main package
+- `pnpm -r typecheck` - Type check all packages
+- `pnpm clean` - Clean all build artifacts
+
+## CI/CD & Release Process
+- Uses changesets for versioning - create `.changeset/<name>.md` files for releases
+- All PRs must pass typecheck, unit tests, and E2E tests (Chromium + Firefox)
+- Release workflow auto-publishes on main branch push with changesets
+- Continuous releases use `pkg-pr-new` for preview packages on PRs
+
+## Code Style & Architecture
+- **TypeScript**: Required, use ESNext target, strict typing, jsxImportSource: "solid-js"
+- **File Structure**: `/src/{client,server,shared,router,middleware}` - separate by runtime environment
+- **Exports**: Use `// @refresh skip` at top of non-reactive files, group related exports
+- **Imports**: Named imports, relative paths for local files, organize by: solid-js, external, internal
+- **Components**: Function declarations for components, arrow functions for utilities
+- **Error Handling**: Use ErrorBoundary patterns, proper TypeScript error types, console.error for logging
+- **Formatting**: Prettier with 2-space tabs, no trailing commas, double quotes, 100 char width
+- **Testing**: Vitest for unit tests, Cypress for E2E, use `describe.skip()` for problematic tests
+- **Server Functions**: Export server functions properly, use getServerFunctionMeta() for metadata


### PR DESCRIPTION
This PR prepares the monorepo for multibranch releases.
Our plan is to continue supporting start `1.x` while `2.x` isn't stable.

- `main` branch: version `2.0.0` from DeVinxi work.
- `v1.x` will still shit the Vinxi architecture and receive bugfixes or general maintenance ( timeline for EOL is not defined yet).

Changesets does not support configurable `baseBranch` so we need dual-config for that at the moment. Going forward we can keep specific configurations per branch if we prefer.