### PR TITLE
fix: don't send server stack trace to client

### DIFF
--- a/packages/start/src/runtime/server-handler.ts
+++ b/packages/start/src/runtime/server-handler.ts
@@ -1,5 +1,5 @@
 /// <reference types="vinxi/types/server" />
-import { crossSerializeStream, fromJSON, getCrossReferenceHeader } from "seroval";
+import { crossSerializeStream, Feature, fromJSON, getCrossReferenceHeader } from "seroval";
 // @ts-ignore
 import {
   CustomEventPlugin,
@@ -62,6 +62,7 @@ function serializeToStream(id: string, value: any) {
           URLSearchParamsPlugin,
           URLPlugin
         ],
+        disabledFeatures: import.meta.env.PROD ? Feature.ErrorPrototypeStack : undefined,
         onSerialize(data, initial) {
           controller.enqueue(
             createChunk(initial ? `(${getCrossReferenceHeader(id)},${data})` : data)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #1967
- [ ] Tests for the changes have been added (for bug fixes / features) - missing infrastructure to unit test server functions.

Avoid sending Error.stack to the client. Stack traces can leak production file paths, internal function names, and other sensitive info, increasing attack surface.