### PR TITLE
Fix spelling of “whistles” on landing page

### DIFF
--- a/packages/landing-page/src/components/sections/rock-solid-dx.tsx
+++ b/packages/landing-page/src/components/sections/rock-solid-dx.tsx
@@ -30,7 +30,7 @@ export function RockSolidDX() {
         </BentoItem>
         <BentoItem accent="emerald" title="Server Actions">
           <p>
-            Form actions running on the server with code co-location and all the bells, whisltles,
+            Form actions running on the server with code co-location and all the bells, whistles,
             and whimsy you need.
           </p>
         </BentoItem>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Addresses an existing open issue: fixes #000
  - fix is trivial; no issue is needed
- [ ] Tests for the changes have been added (for bug fixes / features)
  - Website copy should not be tested

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Other information

Fixes this mistake on https://start.solidjs.com/:

<img width="502" height="162" alt="image" src="https://github.com/user-attachments/assets/dc08b3f9-a81d-40cf-98cd-3580dee85e0d" />
