### PR TITLE
refactor: avoid nested h3 defineHandler call in createBaseHandler

### DIFF
--- a/packages/start/src/server/fetchEvent.ts
+++ b/packages/start/src/server/fetchEvent.ts
@@ -1,4 +1,5 @@
-import { getRequestIP, type H3Event } from "h3";
+import { type EventHandler, getRequestIP, type H3Event, type Middleware } from "h3";
+import { provideRequestEvent } from "solid-js/web/storage";
 import type { FetchEvent } from "./types.ts";
 
 const FETCH_EVENT_CONTEXT = "solidFetchEvent";
@@ -27,3 +28,9 @@ export function mergeResponseHeaders(h3Event: H3Event, headers: Headers) {
 		h3Event.res.headers.append(key, value);
 	}
 }
+
+export const decorateHandler = <T extends EventHandler>(fn: T) =>
+	(event => provideRequestEvent(getFetchEvent(event), () => fn(event))) as T;
+
+export const decorateMiddleware = <T extends Middleware>(fn: T) =>
+	((event, next) => provideRequestEvent(getFetchEvent(event), () => fn(event, next))) as T;


### PR DESCRIPTION
## What is the current behavior?

To decorate the handler and all middleware with FetchEvent, h3's `defineHandler` is wrapped in another `defineHandler`. This is not conforming with h3's intended API usage.

## What is the new behavior?

Instead the handler and each middleware are decorated separately. This shouldn't change any behavior, but follows h3's usage patterns closer and hopefully reduces the chance of future related bugs.

## More info

The old code was introduced during the devinxi work.