### PR TITLE
align dev port

### DIFF
--- a/.changeset/fast-hats-find.md
+++ b/.changeset/fast-hats-find.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": minor
+---
+
+make port 3000 all the time

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -11,6 +11,9 @@ export function devServer(): Array<PluginOption> {
   return [
     {
       name: "solid-start-dev-server",
+      config() {
+        return { server: { port: 3000 } };
+      },
       configureServer(viteDevServer) {
         (globalThis as any).VITE_DEV_SERVER = viteDevServer;
         return async () => {


### PR DESCRIPTION
when you don't use nitro, as in:
```ts
import { solidStart } from "@solidjs/start/config";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [
    solidStart(),
  ],
});
```
instead of:
```ts
import { solidStart } from "@solidjs/start/config";
import { nitro } from "nitro/vite";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [
    solidStart(),
    nitro({
      preset: "node-server",
    }),
  ],
});
```
then solid start will use the 5173 port. now the port is aligned to be 3000 in both cases