### PR TITLE
fix: import DevEnvironment and Rollup as type from vite

### DIFF
--- a/.changeset/clean-actors-jam.md
+++ b/.changeset/clean-actors-jam.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+import DevEnvironment and Rollup as type from vite

--- a/packages/start/src/config/vite-utils.ts
+++ b/packages/start/src/config/vite-utils.ts
@@ -1,4 +1,4 @@
-import { DevEnvironment, Rollup } from "vite";
+import type { DevEnvironment, Rollup } from "vite";
 import fs from "node:fs";
 import path from "node:path";
 


### PR DESCRIPTION
these imports are types, and should be imported as such