### PR TITLE
test: add server-secret leak regression test

### DIFF
--- a/apps/tests/src/functions/server-secret.ts
+++ b/apps/tests/src/functions/server-secret.ts
@@ -1,0 +1,1 @@
+export const serverSecret = "MyServerSuperSecretUniqueString1";

--- a/apps/tests/src/functions/use-is-server.ts
+++ b/apps/tests/src/functions/use-is-server.ts
@@ -1,7 +1,12 @@
 "use server";
 
 import { isServer } from "solid-js/web";
+import { keepAlive } from "~/utils/keep-alive-util";
+
+const serverSecret = "MyServerSuperSecretUniqueString2";
+
 
 export function serverFnWithIsServer() {
+  keepAlive(serverSecret);
   return isServer;
 }

--- a/apps/tests/src/routes/is-server-nested.tsx
+++ b/apps/tests/src/routes/is-server-nested.tsx
@@ -1,9 +1,12 @@
 import { createEffect, createSignal } from "solid-js";
 import { isServer } from "solid-js/web";
+import { serverSecret } from "~/functions/server-secret";
+import { keepAlive } from "~/utils/keep-alive-util";
 
 function serverFnWithIsServer() {
   "use server";
-
+  keepAlive("MyServerSuperSecretUniqueString3");
+  keepAlive(serverSecret);
   return isServer;
 }
 

--- a/apps/tests/src/routes/treeshaking/server-secret-leak.server.test.ts
+++ b/apps/tests/src/routes/treeshaking/server-secret-leak.server.test.ts
@@ -1,0 +1,98 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+// Avoid full pattern to exclude this file from scan
+const SECRET_MARKER = new RegExp(`${"MyServer"}${"SuperSecretUniqueString"}\\d+`, "g");
+const ALL_FILE_EXTENSIONS = /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts|css|map|gz|br)$/;
+
+describe("server code does not leak to client bundle", () => {
+  it("verifies secret markers are server-only and not in client output", async () => {
+    const appRoot = process.cwd();
+    const sourceRoot = path.join(appRoot, "src");
+    const serverOutputRoot = path.join(appRoot, ".output/server");
+    const clientOutputRoot = path.join(appRoot, ".output/public");
+
+    // Verify required directories exist
+    expect(existsSync(sourceRoot), `Source dir not found: ${sourceRoot}`).toBe(true);
+    expect(
+      existsSync(serverOutputRoot),
+      `Server output dir not found: ${serverOutputRoot}. Did you run the build? (pnpm --filter tests run build)`,
+    ).toBe(true);
+    expect(
+      existsSync(clientOutputRoot),
+      `Client output dir not found: ${clientOutputRoot}. Did you run the build? (pnpm --filter tests run build)`,
+    ).toBe(true);
+
+    // Collect and validate markers from source code
+    const sourceMarkerCounts = await countSourceMarkers(sourceRoot);
+    expect(
+      sourceMarkerCounts.size,
+      `No markers found in source code: ${sourceRoot}`,
+    ).toBeGreaterThan(0);
+    for (const [marker, files] of sourceMarkerCounts) {
+      expect(
+        files.length,
+        `Marker "${marker}" appears in multiple files: ${files.join(", ")}. Each marker must appear exactly once.`,
+      ).toBe(1);
+    }
+    const markers = Array.from(sourceMarkerCounts.keys());
+
+    // Verify markers are in server output (not DCE'd)
+    const serverMarkerCounts = await countSourceMarkers(serverOutputRoot);
+    for (const marker of markers) {
+      // Check presence; exact count varies due to bundler duplication
+      expect(
+        serverMarkerCounts.has(marker),
+        `Marker "${marker}" missing from server output (likely DCE'd)`,
+      ).toBe(true);
+    }
+    expect(
+      serverMarkerCounts.size,
+      `Expected ${markers.length} markers, found ${serverMarkerCounts.size} in server output`,
+    ).toBe(markers.length);
+
+    // Verify no markers leak to client
+    const clientMarkerCounts = await countSourceMarkers(clientOutputRoot);
+    for (const [marker, files] of clientMarkerCounts) {
+      expect(files.length, `Marker "${marker}" leaked to client output: ${files.join(", ")}`).toBe(
+        0,
+      );
+    }
+  });
+});
+
+async function countSourceMarkers(rootDir: string) {
+  const sourceFiles = await getFiles(rootDir, ALL_FILE_EXTENSIONS);
+  const markerCounts = new Map<string, string[]>();
+  for (const filePath of sourceFiles) {
+    const content = await readFileContent(filePath);
+    for (const [marker] of content.matchAll(SECRET_MARKER)) {
+      const files = markerCounts.get(marker) ?? [];
+      files.push(filePath);
+      markerCounts.set(marker, files);
+    }
+  }
+  return markerCounts;
+}
+
+async function getFiles(dir: string, fileRegex: RegExp): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  return entries
+    .filter(e => e.isFile() && fileRegex.test(e.name))
+    .map(e => path.join(e.parentPath, e.name));
+}
+
+async function readFileContent(filePath: string) {
+  if (filePath.endsWith(".br")) {
+    return brotliDecompressSync(await readFile(filePath)).toString("utf-8");
+  }
+
+  if (filePath.endsWith(".gz")) {
+    return gunzipSync(await readFile(filePath)).toString("utf-8");
+  }
+
+  return readFile(filePath, "utf-8");
+}

--- a/apps/tests/src/utils/keep-alive-util.ts
+++ b/apps/tests/src/utils/keep-alive-util.ts
@@ -1,0 +1,12 @@
+/**
+ * Prevents the provided value from being removed by dead-code elimination or aggressive
+ * bundler/minifier optimizations by creating an inert side-effect reference. The side-effect
+ * is intentionally never executed at runtime but ensures the value is
+ * referenced so bundlers and minifiers won't drop it.
+ */
+export function keepAlive(value: unknown): void {
+  if (Date.now() < 0) {
+    // kept intentionally unreachable to avoid runtime side-effects
+    console.log(value);
+  }
+}


### PR DESCRIPTION
Adds an integration test that scans source, server build output, and client build output for unique server-only secret markers. The test asserts that:

- markers exist in source files,
- each marker is defined once,
- markers are preserved in server output (not dead-code-eliminated),
- markers do not appear in client bundles (including .gz/.br assets).