### PR TITLE
fix: update routes graph when new file is created

### DIFF
--- a/.changeset/purple-taxes-join.md
+++ b/.changeset/purple-taxes-join.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+reload ssr server when new route files are created in dev

--- a/packages/start/src/config/fs-routes/fs-watcher.ts
+++ b/packages/start/src/config/fs-routes/fs-watcher.ts
@@ -34,17 +34,21 @@ function createRoutesReloader(
     const envName =
       environment === "ssr" ? VITE_ENVIRONMENTS.server : VITE_ENVIRONMENTS.client;
     const devEnv = server.environments[envName];
-    if (devEnv && devEnv.moduleGraph) {
-      const mod: EnvironmentModuleNode | undefined =
-        devEnv.moduleGraph.getModuleById(moduleId);
-      if (mod) {
-        const seen = new Set<EnvironmentModuleNode>();
-        devEnv.moduleGraph.invalidateModule(mod, seen);
-      }
+    if (!devEnv?.moduleGraph) return;
+
+    const mod: EnvironmentModuleNode | undefined =
+      devEnv.moduleGraph.getModuleById(moduleId);
+    if (mod) {
+      const seen = new Set<EnvironmentModuleNode>();
+      devEnv.moduleGraph.invalidateModule(mod, seen);
     }
 
-    if (devEnv && devEnv.hot) {
-      devEnv.hot.send({ type: "full-reload" });
+    if (environment !== "ssr") {
+      if (mod) {
+        devEnv.reloadModule(mod);
+      } else if (devEnv.hot) {
+        devEnv.hot.send({ type: "full-reload" });
+      }
     }
   }
 }

--- a/packages/start/src/config/fs-routes/fs-watcher.ts
+++ b/packages/start/src/config/fs-routes/fs-watcher.ts
@@ -1,11 +1,10 @@
 import type {
   EnvironmentModuleNode,
   FSWatcher,
-  ModuleGraph,
-  ModuleNode,
   PluginOption,
   ViteDevServer,
 } from "vite";
+import { VITE_ENVIRONMENTS } from "../constants.ts";
 import { moduleId } from "./index.ts";
 import type { BaseFileSystemRouter } from "./router.ts";
 
@@ -32,30 +31,20 @@ function createRoutesReloader(
   return () => routes.removeEventListener("reload", handleRoutesReload);
 
   function handleRoutesReload(): void {
-    if (environment === "ssr") {
-      // Handle server environment HMR reload
-      const serverEnv = server.environments.server;
-      if (serverEnv && serverEnv.moduleGraph) {
-        const mod: EnvironmentModuleNode | undefined =
-          serverEnv.moduleGraph.getModuleById(moduleId);
-        if (mod) {
-          const seen = new Set<EnvironmentModuleNode>();
-          serverEnv.moduleGraph.invalidateModule(mod, seen);
-        }
-      }
-    } else {
-      // Handle client environment HMR reload
-      const { moduleGraph }: { moduleGraph: ModuleGraph } = server;
-      const mod: ModuleNode | undefined = moduleGraph.getModuleById(moduleId);
+    const envName =
+      environment === "ssr" ? VITE_ENVIRONMENTS.server : VITE_ENVIRONMENTS.client;
+    const devEnv = server.environments[envName];
+    if (devEnv && devEnv.moduleGraph) {
+      const mod: EnvironmentModuleNode | undefined =
+        devEnv.moduleGraph.getModuleById(moduleId);
       if (mod) {
-        const seen = new Set<ModuleNode>();
-        moduleGraph.invalidateModule(mod, seen);
-        server.reloadModule(mod);
+        const seen = new Set<EnvironmentModuleNode>();
+        devEnv.moduleGraph.invalidateModule(mod, seen);
       }
     }
 
-    if (!server.hot) {
-      server.ws.send({ type: "full-reload" });
+    if (devEnv && devEnv.hot) {
+      devEnv.hot.send({ type: "full-reload" });
     }
   }
 }

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -43,21 +43,23 @@ export function createBaseHandler(
         const mod = await match.handler.import();
         const fn =
           event.request.method === "HEAD" ? mod["HEAD"] || mod["GET"] : mod[event.request.method];
-        (event as APIEvent).params = match.params || {};
-        // @ts-expect-error
-        sharedConfig.context = { event };
-        const res = await fn!(event);
-        if (res !== undefined) {
-          if (res instanceof Response) return produceResponseWithEventHeaders(res);
+        if (typeof fn === "function") {
+          (event as APIEvent).params = match.params || {};
+          // @ts-expect-error
+          sharedConfig.context = { event };
+          const res = await fn(event);
+          if (res !== undefined) {
+            if (res instanceof Response) return produceResponseWithEventHeaders(res);
 
-          return res;
+            return res;
+          }
+          if (event.request.method !== "GET") {
+            throw new Error(
+              `API handler for ${event.request.method} "${event.request.url}" did not return a response.`,
+            );
+          }
+          if (!match.isPage) return;
         }
-        if (event.request.method !== "GET") {
-          throw new Error(
-            `API handler for ${event.request.method} "${event.request.url}" did not return a response.`,
-          );
-        }
-        if (!match.isPage) return;
       }
 
       const context = await createPageEvent(event);


### PR DESCRIPTION

When in devserver, hot-reload would not catch newly created routes. Existing routes would work fine because Vite would handle the client-side HMR. But on new routes, we need to reload the devserver for ssr


**Problem**: FS Watcher used `server.environments.server` but the SSR environment is named `ssr` 

- [x] Changes from  `server.environments.server` => `server.environments.ssr` **(actual fix)**
- [x]  replaced deprecated `server.moduleGraph` (Vite 5 API) with `server.environments.client.moduleGraph`
