### PR TITLE
fix, h3 cant handle solid stream

### DIFF
--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -118,8 +118,11 @@ export function createBaseHandler(
 
       // using TransformStream in dev can cause solid-start-dev-server to crash
       // when stream is cancelled
-      if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;
-
+      if (globalThis.USING_SOLID_START_DEV_SERVER) {
+        const { writable, readable } = new TransformStream();
+        stream.pipeTo(writable);
+        return new Response(readable, { headers: { "content-type": "text/html" } });
+      }
       // returning stream directly breaks cloudflare workers
       const { writable, readable } = new TransformStream();
       stream.pipeTo(writable);


### PR DESCRIPTION
- [x] Addresses an existing open issue: fixes #2133
- [ ] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

  In createBaseHandler (packages/start/src/server/handler.js), when USING_SOLID_START_DEV_SERVER is true, the raw Solid stream from renderToStream is returned directly to avoid a
  TransformStream cancellation crash. However, createBaseHandler now wraps the handler in an H3 app (new H3() + app.use(handler)). The dev server in dev-server.js calls
   serverEntry.default.fetch(webReq) — which is H3.fetch(). h3's response pipeline (toResponse → prepareResponse → prepareResponseBody) doesn't recognize the Solid
  stream object (it's not a Response, ReadableStream, string, or any known type), so it falls through to { body: val }. When srvx's sendNodeResponse writes this to the
  Node response via nodeRes.write(), the object is coerced to the string "[object Object]", which is all the browser receives.

## What is the new behavior?

The dev server path pipes the Solid stream through a TransformStream and wraps the readable side in a standard Response, which h3 handles natively. This matches what
  the non-dev code path already does (pipe through TransformStream), with the addition of the Response wrapper so h3 passes it through without transformation.

## Other information


