### PR TITLE
fix: move esbuild to devDependencies

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -47,7 +47,6 @@
     "defu": "^6.1.4",
     "error-stack-parser": "^2.1.4",
     "es-module-lexer": "^2.0.0",
-    "esbuild": "^0.27.4",
     "fast-glob": "^3.3.3",
     "h3": "2.0.1-rc.16",
     "html-to-image": "^1.11.13",
@@ -68,6 +67,7 @@
     "node": ">=22"
   },
   "devDependencies": {
+    "esbuild": "^0.27.4",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^25.5.0",
     "vite": "^7.3.1",


### PR DESCRIPTION
## Summary

- Move `esbuild` from `dependencies` to `devDependencies` in `packages/start/package.json`

## Motivation

`esbuild` is only imported in build-time Vite plugin code (`src/config/fs-routes/router.ts`) and is never used by the production server output (`.output/server/`). Having it in `dependencies` causes:

1. **Docker image bloat**: esbuild ships a platform-specific Go binary (~9 MB) that gets installed even with `npm ci --omit=dev`
2. **False-positive security findings**: Security scanners (e.g., Trivy) flag Go stdlib CVEs in the esbuild binary that are not exploitable at runtime

Since `vite` (which itself depends on `esbuild`) is already a `peerDependency`, esbuild will always be available during the build step.

Closes #2135

🤖 Generated with [Claude Code](https://claude.ai/claude-code)