### PR TITLE
fix css hot reload in route/layout files

### DIFF
--- a/packages/start/src/config/fs-routes/fs-watcher.ts
+++ b/packages/start/src/config/fs-routes/fs-watcher.ts
@@ -1,9 +1,4 @@
-import type {
-  EnvironmentModuleNode,
-  FSWatcher,
-  PluginOption,
-  ViteDevServer,
-} from "vite";
+import type { EnvironmentModuleNode, FSWatcher, PluginOption, ViteDevServer } from "vite";
 import { VITE_ENVIRONMENTS } from "../constants.ts";
 import { moduleId } from "./index.ts";
 import type { BaseFileSystemRouter } from "./router.ts";
@@ -31,13 +26,11 @@ function createRoutesReloader(
   return () => routes.removeEventListener("reload", handleRoutesReload);
 
   function handleRoutesReload(): void {
-    const envName =
-      environment === "ssr" ? VITE_ENVIRONMENTS.server : VITE_ENVIRONMENTS.client;
+    const envName = environment === "ssr" ? VITE_ENVIRONMENTS.server : VITE_ENVIRONMENTS.client;
     const devEnv = server.environments[envName];
     if (!devEnv?.moduleGraph) return;
 
-    const mod: EnvironmentModuleNode | undefined =
-      devEnv.moduleGraph.getModuleById(moduleId);
+    const mod: EnvironmentModuleNode | undefined = devEnv.moduleGraph.getModuleById(moduleId);
     if (mod) {
       const seen = new Set<EnvironmentModuleNode>();
       devEnv.moduleGraph.invalidateModule(mod, seen);
@@ -46,6 +39,17 @@ function createRoutesReloader(
     if (environment !== "ssr") {
       if (mod) {
         devEnv.reloadModule(mod);
+
+        const extensions = [".css", ".scss", ".sass.", ".less"];
+        for (const [file, mods] of devEnv.moduleGraph.fileToModulesMap) {
+          if (extensions.some(ext => file.endsWith(ext))) {
+            for (const cssModule of mods) {
+              if (cssModule) {
+                devEnv.moduleGraph.invalidateModule(cssModule);
+              }
+            }
+          }
+        }
       } else if (devEnv.hot) {
         devEnv.hot.send({ type: "full-reload" });
       }

--- a/packages/start/src/config/fs-routes/fs-watcher.ts
+++ b/packages/start/src/config/fs-routes/fs-watcher.ts
@@ -35,21 +35,22 @@ function createRoutesReloader(
       const seen = new Set<EnvironmentModuleNode>();
       devEnv.moduleGraph.invalidateModule(mod, seen);
     }
-
+    
     if (environment !== "ssr") {
       if (mod) {
         devEnv.reloadModule(mod);
-
+        
         const extensions = [".css", ".scss", ".sass.", ".less"];
         for (const [file, mods] of devEnv.moduleGraph.fileToModulesMap) {
           if (extensions.some(ext => file.endsWith(ext))) {
             for (const cssModule of mods) {
               if (cssModule) {
-                devEnv.moduleGraph.invalidateModule(cssModule);
+                devEnv.reloadModule(cssModule);
               }
             }
           }
         }
+
       } else if (devEnv.hot) {
         devEnv.hot.send({ type: "full-reload" });
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes [#19818 (Tailwindlabs)](https://github.com/tailwindlabs/tailwindcss/issues/19818)
also see [discord support](https://discord.com/channels/722131463138705510/1503035564356796476)

## What is the current behavior?
When adding or changing a tailwind class within a route/layout file, it does not get applied. Hot reloading of css is broken.
It works any tsx/jsx file which is not a route though.

This PR hook into the hot reload of the route/layout files and invalidates the cssModules.
