### PR TITLE
fix start dev server stream response

### DIFF
--- a/.changeset/pretty-cobras-make.md
+++ b/.changeset/pretty-cobras-make.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix dev server stream responses when using the nitro v2 plugin.

--- a/packages/start/src/server/handler.spec.ts
+++ b/packages/start/src/server/handler.spec.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PageEvent } from "./types.ts";
+
+const streamMock = vi.hoisted(() => ({
+  stream: undefined as
+    | ({
+        then: PromiseLike<string>["then"];
+        pipeTo: ReturnType<typeof vi.fn>;
+      } & Record<string, unknown>)
+    | undefined,
+}));
+
+vi.mock("solid-start:middleware", () => ({
+  default: [],
+}));
+
+vi.mock("solid-js/web", () => ({
+  getRequestEvent: vi.fn(() => ({
+    request: new Request("http://localhost/"),
+    response: new Response(null, {
+      headers: {
+        "content-type": "text/html",
+      },
+    }),
+  })),
+  renderToStream: vi.fn(() => streamMock.stream),
+  renderToString: vi.fn(() => "<html></html>"),
+}));
+
+vi.mock("../fns/handler.ts", () => ({
+  handleServerFunction: vi.fn(),
+}));
+
+vi.mock("../router.tsx", () => ({
+  createRoutes: vi.fn(() => []),
+}));
+
+vi.mock("./fetchEvent.ts", () => ({
+  decorateHandler: vi.fn(handler => handler),
+  decorateMiddleware: vi.fn(middleware => middleware),
+}));
+
+vi.mock("./manifest/ssr-manifest.ts", () => ({
+  getSsrManifest: vi.fn(),
+}));
+
+vi.mock("./routes.ts", () => ({
+  matchAPIRoute: vi.fn(),
+}));
+
+describe("createBaseHandler", () => {
+  beforeEach(() => {
+    vi.stubEnv("START_SSR", "true");
+    globalThis.USING_SOLID_START_DEV_SERVER = true;
+    const html = Promise.resolve("<html>dev stream</html>");
+    streamMock.stream = {
+      then: html.then.bind(html),
+      pipeTo: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete globalThis.USING_SOLID_START_DEV_SERVER;
+    streamMock.stream = undefined;
+  });
+
+  it("returns the thenable Solid stream in the dev server branch", async () => {
+    const { createBaseHandler } = await import("./handler.ts");
+    const app = createBaseHandler(
+      async event =>
+        ({
+          ...event,
+          assets: [],
+          router: {},
+          routes: [],
+          complete: false,
+          $islands: new Set(),
+        }) as PageEvent,
+      () => null,
+    );
+
+    const response = await app.request(new Request("http://localhost/"));
+
+    expect(await response.text()).toBe("<html>dev stream</html>");
+    expect(streamMock.stream?.then).toEqual(expect.any(Function));
+    expect(streamMock.stream?.pipeTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -114,11 +114,11 @@ export function createBaseHandler(
 
       if (mode === "async") return await stream;
 
-      delete (stream as any).then;
-
       // using TransformStream in dev can cause solid-start-dev-server to crash
       // when stream is cancelled
       if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;
+
+      delete (stream as any).then;
 
       // returning stream directly breaks cloudflare workers
       const { writable, readable } = new TransformStream();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #2145
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

With the `@solidjs/vite-plugin-nitro-2` setup, the dev server can return the literal string `[object Object]` for page requests instead of the rendered HTML.

This happens because `stream.then` is deleted before the `USING_SOLID_START_DEV_SERVER` branch returns the Solid stream. h3 v2 then no longer treats the returned value as awaitable and handles it as a plain object body.

Fixes #2145.

## What is the new behavior?

The dev-server branch now returns the Solid stream with its thenable interface still intact, so h3 can await it and return the rendered HTML.

The `then` property is still removed before the TransformStream path, so the existing Cloudflare Workers behavior is unchanged.

A regression test was added for the dev-server path.

## Other information

Checked locally:

- `pnpm --filter @solidjs/start exec vitest run src/server/handler.spec.ts`
- `pnpm --filter @solidjs/start build`

Both pass.

One unrelated note: the full `pnpm --filter @solidjs/start test:ci` run currently fails on `src/fns/handler.spec.ts`, which imports `./server-functions-handler.ts` from the current checkout.