### PR TITLE
fix: add repository field to published packages for provenance validation

### DIFF
--- a/packages/start-nitro-v2-vite-plugin/package.json
+++ b/packages/start-nitro-v2-vite-plugin/package.json
@@ -3,6 +3,11 @@
   "description": "Nitro v2 plugin for development with SolidStart 2.0",
   "version": "0.3.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs/solid-start.git",
+    "directory": "packages/start-nitro-v2-vite-plugin"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -2,6 +2,11 @@
   "name": "@solidjs/start",
   "version": "2.0.0-alpha.3",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs/solid-start.git",
+    "directory": "packages/start"
+  },
   "scripts": {
     "build": "pnpm validate-imports && tsc && node scripts/build.js",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary

Follow-up to #2157. The release got past authentication (OIDC worked, provenance was signed) but npm rejected both packages with E422:

```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/solidjs/solid-start" from provenance
```

Trusted publishing generates provenance attestations, and npm validates that the published `package.json` `repository.url` matches the repo in the attestation. Neither `@solidjs/start` nor `@solidjs/vite-plugin-nitro-2` had a `repository` field. This adds it (with `directory` for the monorepo path).

No changeset on purpose: the pending `2.0.0-alpha.3` / `0.3.0` are versioned but unpublished — merging with no changesets makes the action retry publishing them directly.

## Test plan

- [ ] Merge and confirm the Release workflow publishes both packages

Made with [Cursor](https://cursor.com)