### PR TITLE
fix: move delete stream.then after dev-server branch to restore thenable

### DIFF
--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -114,11 +114,14 @@ export function createBaseHandler(
 
       if (mode === "async") return await stream;
 
-      delete (stream as any).then;
-
       // using TransformStream in dev can cause solid-start-dev-server to crash
       // when stream is cancelled
       if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;
+
+      // remove thenable so h3/Cloudflare Workers do not await the stream object;
+      // must happen after the dev-server branch so the stream remains awaitable
+      // when returned to solid-start-dev-server above
+      delete (stream as any).then;
 
       // returning stream directly breaks cloudflare workers
       const { writable, readable } = new TransformStream();


### PR DESCRIPTION
Fixes #2145

## What

In `packages/start/src/server/handler.ts`, the line

```ts
delete (stream as any).then;
```

was executing before the `USING_SOLID_START_DEV_SERVER` early return. This stripped the `.then` property from the stream before returning it to the dev server, making it non-thenable.

h3 v2's `toResponse` / `prepareResponseBody` no longer recognizes the value as awaitable and falls through to `new FastResponse(streamObject, …)`, which stringifies the body to `[object Object]`.

## Why `delete stream.then` exists

The deletion is there so that the `TransformStream` path (used for Cloudflare Workers) does not try to await the stream object. It only needs to apply immediately before the `new TransformStream()` block, not for the dev-server path.

## Fix

Move `delete (stream as any).then` to after the `USING_SOLID_START_DEV_SERVER` guard. The stream stays thenable when returned to the dev server; the deletion still takes effect for the Cloudflare Workers path that follows.

```ts
if (mode === "async") return await stream;

if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;

// remove thenable so h3/Cloudflare Workers do not await the stream object;
// must happen after the dev-server branch so the stream remains awaitable
// when returned to solid-start-dev-server above
delete (stream as any).then;

const { writable, readable } = new TransformStream();
stream.pipeTo(writable);
return readable;
```

## Reproduction

Scaffold a SolidStart 2.0.0-alpha.2 project with `@solidjs/vite-plugin-nitro-2` per its README (no `mode` option on `createHandler`), run `vite dev`, and `curl http://localhost:5173/` returns `[object Object]`. After this patch the rendered HTML is returned instead.