### PR TITLE
fix: convert path to file:// URL before ESM import in preview server

### DIFF
--- a/.changeset/fix-windows-preview-path-to-file-url.md
+++ b/.changeset/fix-windows-preview-path-to-file-url.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Convert absolute path to file:// URL before dynamic import in preview server to fix Windows compatibility

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -1,4 +1,5 @@
 import { NodeRequest, sendNodeResponse } from "srvx/node";
+import { pathToFileURL } from "node:url";
 import {
   type Connect,
   isRunnableDevEnvironment,
@@ -18,7 +19,7 @@ export function devServer(): Array<PluginOption> {
             const webReq = new NodeRequest({ req, res });
             const def: {
               default: { fetch: (req: Request) => Promise<Response> };
-            } = await import(process.cwd() + "/dist/server/entry-server.js");
+            } = await import(pathToFileURL(process.cwd() + "/dist/server/entry-server.js").href);
             sendNodeResponse(res, await def.default.fetch(webReq));
           });
         };

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -114,11 +114,14 @@ export function createBaseHandler(
 
       if (mode === "async") return await stream;
 
-      delete (stream as any).then;
-
       // using TransformStream in dev can cause solid-start-dev-server to crash
       // when stream is cancelled
       if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;
+
+      // remove thenable so h3/Cloudflare Workers do not await the stream object;
+      // must happen after the dev-server branch so the stream remains awaitable
+      // when returned to solid-start-dev-server above
+      delete (stream as any).then;
 
       // returning stream directly breaks cloudflare workers
       const { writable, readable } = new TransformStream();


### PR DESCRIPTION
On Windows, Node's ESM loader requires import specifiers to be valid `file://` URLs — a bare absolute path like `C:\Users\...\dist\server\entry-server.js` triggers `ERR_UNSUPPORTED_ESM_URL_SCHEME` because the `c:` prefix is not a recognised URL scheme.

The `configurePreviewServer` middleware constructs the import path by concatenating `process.cwd()` with the server entry filename. This works on POSIX but crashes on Windows. Wrapping the concatenated path with `pathToFileURL(...).href` from `node:url` produces a valid `file://` URL on all platforms while remaining a no-op on POSIX (where `pathToFileURL` still returns a well-formed `file:///...` string that the ESM loader accepts).

Fixes #2140