### PR TITLE
feat(config): add server-only and client-only virtual module plugin

### DIFF
--- a/.changeset/fix-windows-preview-path-to-file-url.md
+++ b/.changeset/fix-windows-preview-path-to-file-url.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Convert absolute path to file:// URL before dynamic import in preview server to fix Windows compatibility

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -1,4 +1,5 @@
 import { NodeRequest, sendNodeResponse } from "srvx/node";
+import { pathToFileURL } from "node:url";
 import {
   type Connect,
   isRunnableDevEnvironment,
@@ -18,7 +19,7 @@ export function devServer(): Array<PluginOption> {
             const webReq = new NodeRequest({ req, res });
             const def: {
               default: { fetch: (req: Request) => Promise<Response> };
-            } = await import(process.cwd() + "/dist/server/entry-server.js");
+            } = await import(pathToFileURL(process.cwd() + "/dist/server/entry-server.js").href);
             sendNodeResponse(res, await def.default.fetch(webReq));
           });
         };

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -201,6 +201,30 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
       filter: options?.serverFunctions?.filter,
     }),
     {
+      name: "solid-start:boundary-modules",
+      resolveId(id, importer, { ssr }) {
+        if (id === "server-only") {
+          if (!ssr) {
+            this.error(
+              `[server-only] "${importer}" cannot import a server-only module on the client`,
+            );
+          }
+          return "\0server-only";
+        }
+        if (id === "client-only") {
+          if (ssr) {
+            this.error(
+              `[client-only] "${importer}" cannot import a client-only module on the server`,
+            );
+          }
+          return "\0client-only";
+        }
+      },
+      load(id) {
+        if (id === "\0server-only" || id === "\0client-only") return "export {}";
+      },
+    },
+    {
       name: "solid-start:virtual-modules",
       async resolveId(id) {
         const { filename, query } = parseIdQuery(id);

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -114,11 +114,14 @@ export function createBaseHandler(
 
       if (mode === "async") return await stream;
 
-      delete (stream as any).then;
-
       // using TransformStream in dev can cause solid-start-dev-server to crash
       // when stream is cancelled
       if (globalThis.USING_SOLID_START_DEV_SERVER) return stream;
+
+      // remove thenable so h3/Cloudflare Workers do not await the stream object;
+      // must happen after the dev-server branch so the stream remains awaitable
+      // when returned to solid-start-dev-server above
+      delete (stream as any).then;
 
       // returning stream directly breaks cloudflare workers
       const { writable, readable } = new TransformStream();


### PR DESCRIPTION
Closes #2162

SolidStart has no build-time mechanism to prevent a module from being bundled on the wrong side. `"use server"` marks functions as RPCs but does not stop a module containing DB credentials or Node-only APIs from leaking into the client bundle. The only workaround today is a runtime `import.meta.env.SSR` check that only fires in the browser, too late to be caught in CI.

This PR adds a `solid-start:boundary-modules` Vite plugin to the array returned by `solidStart()`. It resolves two bare specifiers:

- `server-only` — calling `this.error()` during `resolveId` when `ssr` is false turns the import into a hard build error pointing at the importing file. In the SSR environment the specifier resolves to a virtual empty module.
- `client-only` — the mirror: errors in the SSR environment, resolves to an empty module on the client.

Both produce zero runtime overhead (empty export). The build error surfaces the violating file path, so the mistake is caught at `pnpm build` or in CI rather than at runtime in the browser.

The implementation follows the shape suggested in the issue and mirrors what Next.js ships in its `server-only` and `client-only` packages, with no new dependencies.