### PR TITLE
fix: add vite 8 in peer dependency range

### DIFF
--- a/.changeset/tricky-eels-march.md
+++ b/.changeset/tricky-eels-march.md
@@ -1,0 +1,6 @@
+---
+"@solidjs/vite-plugin-nitro-2": patch
+"@solidjs/start": patch
+---
+
+Included Vite 8 in the peer dependency range.

--- a/packages/start-nitro-v2-vite-plugin/package.json
+++ b/packages/start-nitro-v2-vite-plugin/package.json
@@ -34,6 +34,6 @@
     "vite": "^7.3.1"
   },
   "peerDependencies": {
-    "vite": "^7"
+    "vite": "^7 || ^8"
   }
 }

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.0"
   },
   "peerDependencies": {
-    "vite": "^7"
+    "vite": "^7 || ^8"
   }
 }


### PR DESCRIPTION
## What is the current behavior?

The npm installation with vite 8 fails.

## What is the new behavior?

The npm installation with vite 8 succeeds.

Fixes: #2169