### PR TITLE
fix: remove flaky route treeshake cache

### DIFF
--- a/.changeset/silent-laws-study.md
+++ b/.changeset/silent-laws-study.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed tailwind class changes not getting applied via HMR in filesystem routes.

--- a/packages/start/src/config/fs-routes/tree-shake.ts
+++ b/packages/start/src/config/fs-routes/tree-shake.ts
@@ -6,7 +6,7 @@ import type * as Babel from "@babel/core";
 import type { NodePath, PluginObj, PluginPass } from "@babel/core";
 import type { Binding } from "@babel/traverse";
 import { basename } from "pathe";
-import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
+import type { Plugin } from "vite";
 
 type State = Omit<PluginPass, "opts"> & {
   opts: { pick: string[] };
@@ -280,10 +280,6 @@ function treeShakeTransform({ types: t }: typeof Babel): PluginObj<State> {
 }
 
 export function treeShake(): Plugin {
-  let config: ResolvedConfig;
-  const cache: Record<string, any> = {};
-  let server: ViteDevServer;
-
   async function transform(id: string, code: string) {
     const [path, queryString] = id.split("?");
     const query = new URLSearchParams(queryString);
@@ -308,46 +304,6 @@ export function treeShake(): Plugin {
   return {
     name: "tree-shake",
     enforce: "pre",
-    configResolved(resolvedConfig) {
-      config = resolvedConfig;
-    },
-    configureServer(s) {
-      server = s;
-    },
-    async handleHotUpdate(ctx) {
-      if (cache[ctx.file]) {
-        const mods = [];
-        const newCode = await ctx.read();
-        for (const [id, code] of Object.entries(cache[ctx.file])) {
-          const transformed = await transform(id, newCode);
-          if (!transformed) continue;
-
-          const { code: transformedCode } = transformed;
-
-          if (transformedCode !== code) {
-            const mod = server.moduleGraph.getModuleById(id);
-            if (mod) mods.push(mod);
-          }
-
-          cache[ctx.file] ??= {};
-          cache[ctx.file][id] = transformedCode;
-          // server.moduleGraph.setModuleSource(id, code);
-        }
-
-        return mods;
-      }
-      // 	const mods = [];
-      // 	[...server.moduleGraph.urlToModuleMap.entries()].forEach(([url, m]) => {
-      // 		if (m.file === ctx.file && m.id.includes("pick=")) {
-      // 			if (!m.id.includes("pick=loader")) {
-      // 				mods.push(m);
-      // 			}
-      // 		}
-      // 	});
-      // 	return mods;
-      // 	// this.router.updateRoute(ctx.path);
-      // }
-    },
     async transform(code, id) {
       const [path, queryString] = id.split("?");
       if (!path) return;
@@ -357,9 +313,6 @@ export function treeShake(): Plugin {
       if (query.has("pick") && ["js", "jsx", "ts", "tsx"].includes(ext)) {
         const transformed = await transform(id, code);
         if (!transformed?.code) return;
-
-        cache[path] ??= {};
-        cache[path][id] = transformed.code;
 
         return {
           code: transformed.code,


### PR DESCRIPTION
## What is the current behavior?

Tailwind class changes in route files do not properly (hmr) update the tailwind styles.

https://github.com/user-attachments/assets/8513956a-3eb1-4479-af7a-cd943a3e815a

## What is the new behavior?

Tailwind class changes are applied correctly via hmr.

https://github.com/user-attachments/assets/f0b4a52d-5bc8-42a3-850a-51e285d13c34

## What did the removed code do?

Since this PR only removes code, it's fair to ask, what that removed code actually did:

The removed code included a cache optimization for route tree-shake babel transforms. Based on the logic, the cache however didn't reduce the actual amount of babel transforms, it only was used to silence/mute HMR events for unchanged mods via https://github.com/solidjs/solid-start/pull/2171/changes#diff-a43f34f42abb75b93b0894fd3cb7fe15a353a8f62b25d2f03b3dd52c506330ceL329. This logic however resulted in the silencing of HMR events necessary for tailwind to function properly.

Verdict: This three years old logic was introduced in Vinxi via https://github.com/nksaraf/vinxi/commit/975a185b4af08f6a137a339f9fa49b9923caa605#diff-9c9fee025366fdf03d3645a11a19d4444d9afb53a27a4d29fd72bf4f1c2c9309R8 and doesn't seem to provide any advantage these days, that's why I removed it completely. Maybe it was needed for older Vite versions.. I'd love to hear other opinions, especially from @nksaraf / @Brendonovich 😅.

## Other information

Related issue: tailwindlabs/tailwindcss#19818
