### PR TITLE
fix: debounce fs route hmr events, avoid reload for existing routes

### DIFF
--- a/.changeset/heavy-bottles-like.md
+++ b/.changeset/heavy-bottles-like.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed changes in route files resulting in a reload instead of hot module replace. Reloads now only are triggered when adding or removing routes.

--- a/packages/start/src/config/constants.ts
+++ b/packages/start/src/config/constants.ts
@@ -14,6 +14,6 @@ export const VIRTUAL_MODULES = {
 } as const;
 
 export const VITE_ENVIRONMENTS = {
-  client: "client",
-  server: "ssr",
+  client: "client" as const,
+  server: "ssr" as const,
 };

--- a/packages/start/src/config/fs-routes/fs-watcher.ts
+++ b/packages/start/src/config/fs-routes/fs-watcher.ts
@@ -1,22 +1,10 @@
-import type {
-  EnvironmentModuleNode,
-  FSWatcher,
-  PluginOption,
-  ViteDevServer,
-} from "vite";
+import type { EnvironmentModuleNode, FSWatcher, PluginOption, ViteDevServer } from "vite";
+import { debounce } from "../../utils/debounce.ts";
 import { VITE_ENVIRONMENTS } from "../constants.ts";
 import { moduleId } from "./index.ts";
 import type { BaseFileSystemRouter } from "./router.ts";
 
-interface CompiledRouter {
-  removeRoute(path: string): void;
-  addRoute(path: string): void;
-  updateRoute(path: string): void;
-  addEventListener(event: "reload", handler: () => void): void;
-  removeEventListener(event: "reload", handler: () => void): void;
-}
-
-function setupWatcher(watcher: FSWatcher, routes: CompiledRouter): void {
+function setupWatcher(watcher: FSWatcher, routes: BaseFileSystemRouter): void {
   watcher.on("unlink", path => routes.removeRoute(path));
   watcher.on("add", path => routes.addRoute(path));
   watcher.on("change", path => routes.updateRoute(path));
@@ -24,33 +12,41 @@ function setupWatcher(watcher: FSWatcher, routes: CompiledRouter): void {
 
 function createRoutesReloader(
   server: ViteDevServer,
-  routes: CompiledRouter,
+  routes: BaseFileSystemRouter,
   environment: "client" | "ssr",
-): () => void {
-  routes.addEventListener("reload", handleRoutesReload);
-  return () => routes.removeEventListener("reload", handleRoutesReload);
+) {
+  const devEnv = server.environments[environment]!;
+  if (!devEnv?.moduleGraph) return;
 
-  function handleRoutesReload(): void {
-    const envName =
-      environment === "ssr" ? VITE_ENVIRONMENTS.server : VITE_ENVIRONMENTS.client;
-    const devEnv = server.environments[envName];
-    if (!devEnv?.moduleGraph) return;
+  /**
+   * Debounce catches multiple route changes in a row
+   * Short timeout for inexpensive invalidations
+   */
+  const invalidateModule = debounce((mod: EnvironmentModuleNode) => {
+    devEnv.moduleGraph.invalidateModule(mod);
+  }, 0);
 
-    const mod: EnvironmentModuleNode | undefined =
-      devEnv.moduleGraph.getModuleById(moduleId);
-    if (mod) {
-      const seen = new Set<EnvironmentModuleNode>();
-      devEnv.moduleGraph.invalidateModule(mod, seen);
+  /**
+   * Long debounce timeout for expensive reloads
+   */
+  const reloadModule = debounce((mod: EnvironmentModuleNode) => {
+    devEnv.reloadModule(mod);
+  }, 200);
+
+  return routes.on("reload", function handleRoutesReload(evt): void {
+    const mod = devEnv.moduleGraph.getModuleById(moduleId)!;
+    if (!mod) {
+      devEnv.hot.send({ type: "full-reload" });
+      return;
     }
 
-    if (environment !== "ssr") {
-      if (mod) {
-        devEnv.reloadModule(mod);
-      } else if (devEnv.hot) {
-        devEnv.hot.send({ type: "full-reload" });
-      }
+    if (environment === VITE_ENVIRONMENTS.client && evt.detail.type !== "update") {
+      // Client has to be reloaded when routes are added or removed
+      reloadModule(mod);
+    } else {
+      invalidateModule(mod);
     }
-  }
+  });
 }
 
 export const fileSystemWatcher = (
@@ -59,11 +55,11 @@ export const fileSystemWatcher = (
   const plugin: PluginOption = {
     name: "fs-watcher",
     async configureServer(server: ViteDevServer) {
-      Object.keys(routers).forEach(environment => {
-        const router = (globalThis as any).ROUTERS[environment];
+      for (const environment of [VITE_ENVIRONMENTS.server, VITE_ENVIRONMENTS.client]) {
+        const router = routers[environment];
         setupWatcher(server.watcher, router);
-        createRoutesReloader(server, router, environment as keyof typeof routers);
-      });
+        createRoutesReloader(server, router, environment);
+      }
     },
   };
   return plugin;

--- a/packages/start/src/config/fs-routes/router.ts
+++ b/packages/start/src/config/fs-routes/router.ts
@@ -100,8 +100,11 @@ export class BaseFileSystemRouter extends EventTarget {
   update = undefined;
 
   _addRoute(route: Route) {
-    this.routes = this.routes.filter(r => r.path !== route.path);
+    const idx = this.routes.findIndex(r => r.path === route.path);
+    if (idx >= 0) this.routes.splice(idx, 1);
     this.routes.push(route);
+
+    return idx >= 0;
   }
 
   async addRoute(src: string) {
@@ -130,14 +133,16 @@ export class BaseFileSystemRouter extends EventTarget {
     );
   }
 
-  async updateRoute(src: string) {
-    src = normalizePath(src);
+  async updateRoute(src_: string) {
+    const src = normalizePath(src_);
     if (this.isRoute(src)) {
       try {
         const route = this.toRoute(src);
         if (route) {
-          this._addRoute(route);
-          this.reload(route.path, "update");
+          const updated = this._addRoute(route);
+          this.reload(route.path, updated ? "update" : "add");
+        } else {
+          this.removeRoute(src_);
         }
       } catch (e) {
         console.error(e);
@@ -153,7 +158,11 @@ export class BaseFileSystemRouter extends EventTarget {
       if (path === undefined) {
         return;
       }
-      this.routes = this.routes.filter(r => r.path !== path);
+
+      const idx = this.routes.findIndex(r => r.path === path);
+      if (idx === -1) return;
+
+      this.routes.splice(idx, 1);
       this.reload(path, "remove");
     }
   }

--- a/packages/start/src/config/fs-routes/router.ts
+++ b/packages/start/src/config/fs-routes/router.ts
@@ -32,6 +32,8 @@ export function analyzeModule(src: string) {
   );
 }
 
+type RouterEvent = CustomEvent<{ route: string; type: "update" | "remove" | "add" }>;
+
 export class BaseFileSystemRouter extends EventTarget {
   routes: Route[];
 
@@ -109,7 +111,7 @@ export class BaseFileSystemRouter extends EventTarget {
         const route = this.toRoute(src);
         if (route) {
           this._addRoute(route);
-          this.reload(route.path);
+          this.reload(route.path, "add");
         }
       } catch (e) {
         console.error(e);
@@ -117,12 +119,12 @@ export class BaseFileSystemRouter extends EventTarget {
     }
   }
 
-  reload(route: string) {
+  reload(route: string, type: "update" | "remove" | "add") {
     this.dispatchEvent(
-      new Event("reload", {
-        // @ts-ignore
+      new CustomEvent("reload", {
         detail: {
           route,
+          type,
         },
       }),
     );
@@ -135,7 +137,7 @@ export class BaseFileSystemRouter extends EventTarget {
         const route = this.toRoute(src);
         if (route) {
           this._addRoute(route);
-          this.reload(route.path);
+          this.reload(route.path, "update");
         }
       } catch (e) {
         console.error(e);
@@ -152,8 +154,13 @@ export class BaseFileSystemRouter extends EventTarget {
         return;
       }
       this.routes = this.routes.filter(r => r.path !== path);
-      this.dispatchEvent(new Event("reload", {}));
+      this.reload(path, "remove");
     }
+  }
+
+  on(type: string, cb: (evt: RouterEvent) => void) {
+    this.addEventListener(type, cb as any);
+    return () => this.removeEventListener(type, cb as any);
   }
 
   buildRoutesPromise?: Promise<any[]>;

--- a/packages/start/src/utils/debounce.ts
+++ b/packages/start/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+/**
+ * Creates a debounced function that delays the invocation of a function
+ */
+export const debounce = <T extends (...args: any[]) => void>(cb: T, debounceMs: number) => {
+  let timeout: NodeJS.Timeout | undefined;
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => cb(...args), debounceMs)
+  }
+}


### PR DESCRIPTION
## What is the current behavior?

- When starting the server, multiple reloads and invalidations are triggered per added route
- When renaming routes, multiple reloads and invalidations are triggered (file rename = "remove file + add file")
- When just changing an existing route, it still triggers a full client reload

https://github.com/user-attachments/assets/41e2475f-0c24-49e3-b581-b25c7e772360

## What is the new behavior?

- Reloads and invalidations are debounced
- Changing an existing valid route triggers a soft HMR, no client reload
- Adding a default export to an existing invalid route file, adds the route and reloads the client
- Removing a default export from an existing valid route file, removes the route and reloads the client 

https://github.com/user-attachments/assets/f2f970f6-f874-42a0-8d2b-3b2ba2b1a6d8

## Other information

From what I can tell the route HMR has been broken atleast since https://github.com/solidjs/solid-start/pull/2125. I tried to make sure that I didn't introduce a regression. The routes graph is still updated when adding new files.
