### PR TITLE
fix: add vite 9 forward compat

### DIFF
--- a/.changeset/tame-dingos-wave.md
+++ b/.changeset/tame-dingos-wave.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Use per-environment Vite plugin hook APIs for forward compatibility with Vite 9.

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -89,6 +89,6 @@
     "vitest": "^4.1.0"
   },
   "peerDependencies": {
-    "vite": "^8"
+    "vite": "^8 || ^9"
   }
 }

--- a/packages/start/src/config/env.ts
+++ b/packages/start/src/config/env.ts
@@ -71,9 +71,10 @@ export function envPlugin(options?: EnvPluginOptions): Plugin {
       }
       return undefined;
     },
-    load(id, opts) {
+    load(id) {
+      const isServer = this.environment.config.consumer === "server";
       if (id === SERVER_ENV) {
-        if (!opts?.ssr) {
+        if (!isServer) {
           return SERVER_ONLY_MODULE;
         }
         const vars = currentOptions.server?.load
@@ -88,13 +89,13 @@ export function envPlugin(options?: EnvPluginOptions): Plugin {
         return convertObjectToModule(vars);
       }
       if (id === SERVER_RUNTIME_LOADER) {
-        if (!opts?.ssr) {
+        if (!isServer) {
           return SERVER_ONLY_MODULE;
         }
         return runtimeCode;
       }
       if (id === SERVER_RUNTIME_ENV) {
-        if (!opts?.ssr) {
+        if (!isServer) {
           return SERVER_ONLY_MODULE;
         }
         return SERVER_RUNTIME_CODE;

--- a/packages/start/src/directives/index.ts
+++ b/packages/start/src/directives/index.ts
@@ -181,8 +181,8 @@ export function serverFunctionsPlugin(options: ServerFunctionsOptions): Plugin[]
         }
         return null;
       },
-      async load(id, opts) {
-        const mode = opts?.ssr ? "server" : "client";
+      async load(id) {
+        const mode = this.environment.config.consumer;
         if (id === options.manifest) {
           const current = new Debouncer(() =>
             [...manifest[mode]].map(entry => `import "${entry}";`).join("\n"),
@@ -197,8 +197,8 @@ export function serverFunctionsPlugin(options: ServerFunctionsOptions): Plugin[]
     {
       name: "solid-start:server-functions/compiler",
       enforce: 'pre',
-      async transform(code, fileId, opts) {
-        const mode = opts?.ssr ? "server" : "client";
+      async transform(code, fileId) {
+        const mode = this.environment.config.consumer;
         const [id] = fileId.split("?");
         if (!filter(id)) {
           return null;


### PR DESCRIPTION
Planned breaking changes for vite 9:
- https://vite.dev/changes/#planned

We are affected by the bullet named `this.environment in Hooks`.

This updates SolidStart’s Vite plugin hooks for forward compatibility with Vite 9.

  - Replace the deprecated hook `ssr` argument with `this.environment.config.consumer`
  - Remove the unused hook options arguments
