### PR TITLE
Add a hook to observe server function errors before serialization

### DIFF
--- a/packages/start/src/fns/handler.ts
+++ b/packages/start/src/fns/handler.ts
@@ -114,6 +114,11 @@ export async function handleServerFunction(h3Event: H3Event) {
     h3Event.res.headers.set("content-type", "text/plain");
     return serializeToJSONStream(result);
   } catch (x) {
+    // Give monitoring a chance to observe server-function failures before
+    // they are serialized into the response, since no error hook fires for
+    // them today. Thrown Responses are control flow (redirects, forbidden),
+    // not errors.
+    if (!(x instanceof Response)) (globalThis as any).__reportServerFnError?.(x);
     if (x instanceof Response) {
       if (singleFlight && instance) {
         x = await handleSingleFlight(event, x);


### PR DESCRIPTION
## Problem

When a server function throws, the handler in `packages/start/src/fns/handler.ts` catches the error, sets `X-Error`, and serializes it into the response for the calling client. No server-side error hook ever fires, so genuine crashes inside server functions are invisible to monitoring (Sentry and friends): the platform error hooks (for example Nitro's `error` hook) only see errors that escape the handler, and these never do.

The result is that a production server function can crash on every call while dashboards stay green, and the only signal is users reporting a generic failure state.

## Prior art in other frameworks

- **SvelteKit** has [`handleError`](https://svelte.dev/docs/kit/hooks#Shared-hooks-handleError), called only for *unexpected* errors (expected `error()` throws skip it), letting apps report to monitoring and return a sanitized user-safe representation. This expected-vs-unexpected split is exactly what server-function consumers need here too.
- **Next.js** has [`onRequestError`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation#onrequesterror-optional) in `instrumentation.ts`, invoked for server errors including Server Actions (`routeType: 'action'`), designed for custom observability providers.
- **TanStack Start** supports [global server-function middleware](https://tanstack.com/start/latest/docs/framework/react/guide/middleware) via `registerGlobalMiddleware`, which wraps every server function and can observe failures.

## Proposal

Call an app-registered global hook from the handler's `catch`, before serialization, skipping thrown `Response`s since those are control flow (redirects, forbidden):

```ts
if (!(x instanceof Response)) (globalThis as any).__reportServerFnError?.(x);
```

An app can then register `globalThis.__reportServerFnError` from its server entry (or a Nitro plugin) and forward to its monitoring SDK.

## Status

Draft on purpose: the global hook is the minimal shape that solves the problem, and I am happy to rework it into whatever API surface you prefer (an option on the handler, an exported `setServerFnErrorHandler`, an event on the app instance, or a SvelteKit-style `handleError` in the server entry). We currently maintain this as a `pnpm patch` in production alongside #2159 and would love to drop both.