### PR TITLE
fix: add files field so published package includes dist

### DIFF
--- a/.changeset/tidy-pans-flash.md
+++ b/.changeset/tidy-pans-flash.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix published package missing `dist/`: pnpm 11 respects `.gitignore` when packing a package without a `files` field, so `2.0.0-beta.1` was published without its build output. Add an explicit `files` field.

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -2,6 +2,11 @@
   "name": "@solidjs/start",
   "version": "2.0.0-beta.1",
   "type": "module",
+  "files": [
+    "dist",
+    "env.d.ts",
+    "CHANGELOG.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs/solid-start.git",


### PR DESCRIPTION
## Problem

`@solidjs/start@2.0.0-beta.1` was published **without its `dist/` folder**, while the published `exports` (rewritten from `publishConfig`) all point at `./dist/*` — so none of the package's entry points resolve.

## Cause

The pnpm 10.8.1 → 11.13.0 bump (#2184) changed packing behavior: pnpm 11 respects `.gitignore` when a package has no `files` field, and the root `.gitignore` lists `dist`. CI built `dist/` fine — it was silently excluded at pack time. beta.0 (packed with pnpm 10) still included it.

Verified locally with pnpm 11.13.0: `pnpm pack` in `packages/start` produces **0** `dist/` entries without this fix, **195** with it.

## Fix

Add an explicit `files` field to `packages/start/package.json` (`dist`, `env.d.ts`, `CHANGELOG.md` — README/LICENSE/package.json are always included). `@solidjs/vite-plugin-nitro-2` already has a `files` field and is unaffected.

Includes a patch changeset so a fixed **beta.2** goes out — note beta.1 can't be re-published, and the release run on `58dee028` already skipped publishing because beta.1 exists on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)