### PR TITLE
fix: add files list to pnpm 11 bundle

### DIFF
--- a/.changeset/curvy-carrots-dream.md
+++ b/.changeset/curvy-carrots-dream.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Include the compiled `dist` directory in the published package.

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -15,6 +15,17 @@
     "typecheck:dist": "pnpm build && pnpx @arethetypeswrong/cli --pack . --profile esm-only",
     "validate-imports": "node scripts/validate-imports.js"
   },
+  "files": [
+    "dist",
+    "src",
+    "scripts",
+    "env.d.ts",
+    "package.json",
+    "README.md",
+    "CHANGELOG.md",
+    "tsconfig.json",
+    "vitest.config.ts"
+  ],
   "exports": {
     ".": "./src/index.tsx",
     "./config": "./dist/config/index.js",


### PR DESCRIPTION
This PR ensures `@solidjs/start` includes its compiled output when published with pnpm 11.

The pnpm 11 upgrade changed the package contents because `packages/start` did not define a `files` field. The root `.gitignore` excludes `dist`, causing the compiled output to be omitted even though the published exports point to `./dist`.

This adds an explicit package allowlist matching the contents previously published with beta.0, including both `dist` and `src`.