### PR TITLE
re-enable start unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,5 @@ jobs:
       - name: Run all apps/tests (Unit, Node, Browser UI, and E2E)
         run: pnpm --filter tests run test:all
 
-      # The @solidjs/start package currently has no tests, so we are skipping this step.
-      # Uncomment if tests are added to the @solidjs/start package.
-      # - name: Run @solidjs/start unit tests
-      #   run: pnpm --filter @solidjs/start test:ci
+      - name: Run @solidjs/start unit tests
+        run: pnpm --filter @solidjs/start test:ci

--- a/packages/start/src/fns/handler.spec.ts
+++ b/packages/start/src/fns/handler.spec.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { FetchEvent } from "./types.ts";
+import type { FetchEvent } from "../server/types.ts";
 
 vi.mock("h3", () => ({
   parseCookies: vi.fn(() => ({})),
-  parseSetCookie: vi.fn(),
 }));
 
 vi.mock("solid-js/web", () => ({
   renderToString: vi.fn(),
+}));
+
+vi.mock("solid-js/web/storage", () => ({
   provideRequestEvent: vi.fn((_event, fn) => fn()),
 }));
 
-vi.mock("solid-start:server-fn-manifest", () => ({
-  getServerFnById: vi.fn(),
-}));
+vi.mock("solid-start:server-fn-manifest", () => ({}));
 
-vi.mock("./handler.ts", () => ({
+vi.mock("../server/handler.ts", () => ({
   createPageEvent: vi.fn(),
 }));
 
-vi.mock("./fetchEvent.ts", () => ({
+vi.mock("../server/fetchEvent.ts", () => ({
   getFetchEvent: vi.fn(),
   mergeResponseHeaders: vi.fn(),
 }));
@@ -42,7 +42,7 @@ describe("createSingleFlightHeaders", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    const module = await import("./server-functions-handler.ts");
+    const module = await import("./handler.ts");
     createSingleFlightHeaders = module.createSingleFlightHeaders;
   });
 


### PR DESCRIPTION
The package test step was accidentally disabled during the Vitest and Playwright migration (https://github.com/solidjs/solid-start/pull/2007), despite `@solidjs/start` already containing tests. This allowed broken test imports to go unnoticed.
  
- Fix stale imports and mocks in the `createSingleFlightHeaders` tests
- Restore the `@solidjs/start` unit-test step in CI

