### PR TITLE
fix: resolve correct source positions for server-side stack frames in dev overlay

### DIFF
--- a/packages/start/src/shared/dev-overlay/createStackFrame.ts
+++ b/packages/start/src/shared/dev-overlay/createStackFrame.ts
@@ -9,9 +9,20 @@ export interface StackFrameSource {
   column: number;
 }
 
+// Frames from an SSR error carry filesystem paths (or file:// URLs) rather
+// than the http URL the module is served from. Their positions are already
+// mapped back to the original source by the Vite module runner, unlike
+// client frames whose positions refer to the compiled module.
+function isServerSource(path: string): boolean {
+  return !/^https?:\/\//.test(path);
+}
+
 function getActualFileSource(path: string): string {
   if (path.startsWith("file://")) {
-    return "/_build/@fs" + path.substring("file://".length);
+    return "/@fs/" + path.substring("file://".length).replace(/^\/+/, "");
+  }
+  if (isServerSource(path)) {
+    return "/@fs/" + path.replace(/^\/+/, "");
   }
   return path;
 }
@@ -28,16 +39,18 @@ export function createStackFrame(stackframe: StackFrame, isCompiled: () => boole
       if (!source.fileName) {
         return null;
       }
-      const response = await fetch(getActualFileSource(source.fileName));
+      const url = getActualFileSource(source.fileName);
+      const response = await fetch(url);
       if (!response.ok) {
         return null;
       }
       const content = await response.text();
-      const sourceMap = await getSourceMap(source.fileName, content);
+      const sourceMap = await getSourceMap(url, content);
       return {
         source,
         content,
         sourceMap,
+        isServer: isServerSource(source.fileName),
       };
     },
   );
@@ -47,18 +60,36 @@ export function createStackFrame(stackframe: StackFrame, isCompiled: () => boole
     if (!current) {
       return undefined;
     }
-    const { source, content, sourceMap } = current;
+    const { source, content, sourceMap, isServer } = current;
 
     if (!isCompiled() && source.line && source.column && sourceMap) {
-      const result = sourceMap.originalPositionFor({
-        line: source.line,
-        column: source.column,
-      });
-
-      return {
-        ...result,
-        content: sourceMap.sourceContentFor(result.source),
-      } as StackFrameSource;
+      if (isServer) {
+        // The position is already original; only the original content needs
+        // to be pulled out of the source map.
+        const originalContent = sourceMap.sources.length
+          ? sourceMap.sourceContentFor(sourceMap.sources[0]!, true)
+          : null;
+        if (originalContent) {
+          return {
+            source: source.fileName,
+            line: source.line,
+            column: source.column,
+            name: source.functionName,
+            content: originalContent,
+          } as StackFrameSource;
+        }
+      } else {
+        const result = sourceMap.originalPositionFor({
+          line: source.line,
+          column: source.column,
+        });
+        if (result.source) {
+          return {
+            ...result,
+            content: sourceMap.sourceContentFor(result.source, true),
+          } as StackFrameSource;
+        }
+      }
     }
 
     return {

--- a/packages/start/src/shared/dev-overlay/createStackFrame.ts
+++ b/packages/start/src/shared/dev-overlay/createStackFrame.ts
@@ -1,6 +1,9 @@
 import { type Accessor, createMemo, createResource } from "solid-js";
 import getSourceMap from "./get-source-map.ts";
 
+const HTTP_URL_REGEX = /^https?:\/\//;
+const LEADING_SLASH_REGEX = /^\/+/;
+
 export interface StackFrameSource {
   content: string;
   source: string;
@@ -14,15 +17,15 @@ export interface StackFrameSource {
 // mapped back to the original source by the Vite module runner, unlike
 // client frames whose positions refer to the compiled module.
 function isServerSource(path: string): boolean {
-  return !/^https?:\/\//.test(path);
+  return !HTTP_URL_REGEX.test(path);
 }
 
 function getActualFileSource(path: string): string {
   if (path.startsWith("file://")) {
-    return "/@fs/" + path.substring("file://".length).replace(/^\/+/, "");
+    return "/@fs/" + path.substring("file://".length).replace(LEADING_SLASH_REGEX, "");
   }
   if (isServerSource(path)) {
-    return "/@fs/" + path.replace(/^\/+/, "");
+    return "/@fs/" + path.replace(LEADING_SLASH_REGEX, "");
   }
   return path;
 }


### PR DESCRIPTION
Fixes #1914

### The bug

Throwing in a route component during SSR made the dev overlay highlight the wrong line (line 1 instead of line 2 in the issue's repro), and the console showed `Error: "null" is not in the SourceMap` with the overlay's code view often rendering blank.

### Root cause

Server-side stack traces are **already source-mapped** by the Vite module runner — a frame like `/abs/path/src/routes/index.tsx?pick=default&pick=$css:2:9` points at the original source. The overlay assumed every frame held *compiled* coordinates: it fetched the client-transformed module and ran `originalPositionFor` against the client source map, double-mapping an already-original position → wrong line. When the double-mapping landed on an unmapped line, `sourceContentFor(null)` threw `"null" is not in the SourceMap` and the surrounding `ErrorBoundary` blanked the code view.

Additionally, `getActualFileSource` rewrote `file://` frames to the vinxi-era `/_build/@fs/...` prefix, which 404s on the current Vite + nitro setup.

### The fix

In `createStackFrame.ts`:

- Frames whose source is not an `http(s)://` URL are treated as server frames: fetched through Vite's `/@fs/` endpoint, keeping the frame's line/column as-is, with the original file content pulled from the source map's `sourcesContent`.
- Client frames keep the `originalPositionFor` path, now guarded on `result.source` and using `returnNullOnMissing`, so an unmappable position falls back to the compiled content instead of throwing.
- `/_build/@fs/` → `/@fs/`.

### Verified

With the issue's repro (`export default function Home() { throw new Error("yes") }`):

- SSR throw → overlay shows the original TSX with line 2 highlighted, and every frame in the stack list resolves (previously most frames errored and were hidden).
- Client-only throw during hydration (`http://` frames, compiled coordinates) → still resolves through the source-map path to the correct line, so no regression on the existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)