### PR TITLE
fix: encode X-Error header for server function errors with non-latin1 messages (#1874)

### DIFF
--- a/.changeset/fix-1874-unicode-error-header.md
+++ b/.changeset/fix-1874-unicode-error-header.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix: don't crash when a server function throws an error whose message contains non-latin1 characters. The message was assigned verbatim to the `X-Error` response header, and since header values must be ByteString-safe, a message like `"Ошибка 🚀"` made `Headers.set` throw inside the catch block — producing a bare 500 with no error propagated, so the client never threw and the route section hung empty instead of hitting the `ErrorBoundary`. The header value is now encoded when it contains such characters (the real error still travels in the serialized body). (#1874)

--- a/apps/tests/src/e2e/server-function.test.ts
+++ b/apps/tests/src/e2e/server-function.test.ts
@@ -120,4 +120,23 @@ test.describe("server-function", () => {
     await page.locator("#server-fn-test").click();
     await expect(page.locator("#server-fn-test")).toContainText("false");
   });
+
+  /**
+   * A thrown server-function error whose message contains non-ByteString
+   * characters (> U+00FF) must still reach the client. Previously the raw
+   * message was assigned to the X-Error response header, and Headers.set threw
+   * a TypeError, producing a bare 500 with no error to deserialize.
+   * https://github.com/solidjs/solid-start/issues/1874
+   */
+  test("should propagate a server function error with non-latin1 message", async ({ page }) => {
+    await page.goto("http://localhost:3000/server-function-unicode-error");
+    // Retry the click until it registers post-hydration (clicks aren't auto-retried).
+    await expect(async () => {
+      await page.locator("#server-fn-test").click();
+      await expect(page.locator("#server-fn-test")).toContainText(
+        "Ошибка 🚀 ünïcode — special chars",
+        { timeout: 1000 },
+      );
+    }).toPass({ timeout: 15000 });
+  });
 });

--- a/apps/tests/src/routes/server-function-unicode-error.tsx
+++ b/apps/tests/src/routes/server-function-unicode-error.tsx
@@ -1,0 +1,30 @@
+async function serverFnThrowsUnicode() {
+  "use server";
+
+  // Non-ByteString message (chars > U+00FF) used to crash Headers.set for the
+  // X-Error header, producing a bare 500 with no error propagated to the client.
+  throw new Error("Ошибка 🚀 ünïcode — special chars");
+}
+
+export default function App() {
+  return (
+    <main>
+      <span
+        id="server-fn-test"
+        onClick={evt => {
+          const el = evt.target as HTMLElement;
+          serverFnThrowsUnicode().then(
+            () => {
+              el.textContent = "no error";
+            },
+            err => {
+              el.textContent = err instanceof Error ? err.message : String(err);
+            },
+          );
+        }}
+      >
+        Click me
+      </span>
+    </main>
+  );
+}

--- a/packages/start/src/fns/handler.ts
+++ b/packages/start/src/fns/handler.ts
@@ -143,7 +143,7 @@ export async function handleServerFunction(h3Event: H3Event) {
     } else if (instance) {
       const error = x instanceof Error ? x.message : typeof x === "string" ? x : "true";
 
-      h3Event.res.headers.set("X-Error", error.replace(/[\r\n]+/g, ""));
+      h3Event.res.headers.set("X-Error", toHeaderValue(error));
     } else {
       x = handleNoJS(x, request, parsed, true);
     }
@@ -156,7 +156,7 @@ export async function handleServerFunction(h3Event: H3Event) {
           headers.set("X-Error", errorHeader);
         }
         return new Response(body.body, {
-          headers: body.headers,
+          headers,
         });
       }
       h3Event.res.headers.set(BODY_FORMAT_KEY, BodyFormat.Seroval);
@@ -168,6 +168,17 @@ export async function handleServerFunction(h3Event: H3Event) {
       return serializeToJSONStream(x);
     }
     return x;
+  }
+}
+
+// header values must be ByteString-safe (no chars > 0xFF), otherwise Headers.set throws
+function toHeaderValue(value: string) {
+  const stripped = value.replace(/[\r\n]+/g, "");
+  try {
+    return /[^\x00-\xFF]/.test(stripped) ? encodeURIComponent(stripped) : stripped;
+  } catch {
+    // encodeURIComponent throws on lone surrogates
+    return "true";
   }
 }
 


### PR DESCRIPTION
## Problem

Closes #1874. When a server function throws an `Error` whose message contains characters above U+00FF (e.g. `"Ошибка 🚀"`), the request crashes instead of surfacing the error.

In `packages/start/src/fns/handler.ts`, the catch block assigns the raw error message directly to the `X-Error` response header. HTTP header values must be ByteString-safe (chars ≤ U+00FF), so `Headers.set` throws a `TypeError` **inside the catch block**. The result is a bare, unhandled `500` with no `X-Error` header and no serialized body — so the client (`fns/client.ts`) never sees `X-Error`, never throws the deserialized error, and the route section hangs empty instead of rendering the `ErrorBoundary`.

## Fix

- Add `toHeaderValue()`: strips newlines (as before), then `encodeURIComponent`s the value only when it contains non-latin1 characters (ASCII messages stay human-readable), with a fallback to `"true"` on the lone-surrogate edge case. The client only checks `response.headers.has("X-Error")` — the value itself is unused — so the real error message continues to travel in the seroval-serialized body that the client throws.
- Return the constructed `headers` (which carries `X-Error`) instead of the discarded `body.headers` in the body-error path, so `X-Error` propagates consistently with the seroval path. Previously this variable was built and then thrown away.

## Testing

- Added an e2e test (`apps/tests`): a route with a server function that throws a unicode-message error, and a test asserting the message reaches the client via the `X-Error` path. Verified it **fails without the fix** and **passes with it**; the full `server-function` e2e suite is green (20/20).
- Manually verified against a prod build of a repro app: the `/_server` request now returns `200` with an encoded `x-error` header, the client navigates, and the `ErrorBoundary` renders `caught: Ошибка 🚀 ünïcode — special chars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)