### PR TITLE
feat: expose h3 request event decorators

### DIFF
--- a/.changeset/expose-h3-request-event-decorators.md
+++ b/.changeset/expose-h3-request-event-decorators.md
@@ -1,0 +1,7 @@
+---
+"@solidjs/start": minor
+---
+
+Expose experimental `decorateHandler` and `decorateMiddleware` helpers from
+`@solidjs/start/server` for providing Solid's request context to custom h3 handlers and
+middleware.

--- a/packages/start/src/server/fetchEvent.spec.ts
+++ b/packages/start/src/server/fetchEvent.spec.ts
@@ -1,7 +1,14 @@
 import * as h3 from "h3";
+import { getRequestEvent } from "solid-js/web";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createFetchEvent, getFetchEvent, mergeResponseHeaders } from "./fetchEvent.ts";
+import {
+  createFetchEvent,
+  decorateHandler,
+  decorateMiddleware,
+  getFetchEvent,
+  mergeResponseHeaders,
+} from "./fetchEvent.ts";
 
 vi.mock(import("h3"), async mod => {
   return {
@@ -80,6 +87,37 @@ describe("fetchEvent", () => {
 
       expect(headers.get("content-type")).toBe("application/json");
       expect(headers.get("x-custom")).toBe("value");
+    });
+  });
+
+  describe("decorateHandler", () => {
+    it("provides the FetchEvent while the handler runs", async () => {
+      const handler = decorateHandler(async event => {
+        await Promise.resolve();
+        expect(getRequestEvent()).toBe(getFetchEvent(event));
+        return "handled";
+      });
+
+      expect(await handler(mockH3Event)).toBe("handled");
+    });
+  });
+
+  describe("decorateMiddleware", () => {
+    it("provides the FetchEvent while the middleware runs", async () => {
+      const next = vi.fn(async () => {
+        await Promise.resolve();
+        expect(getRequestEvent()).toBe(getFetchEvent(mockH3Event));
+        return "next";
+      });
+      const middleware = decorateMiddleware(async (event, middlewareNext) => {
+        expect(getRequestEvent()).toBe(getFetchEvent(event));
+        const result = await middlewareNext();
+        expect(getRequestEvent()).toBe(getFetchEvent(event));
+        return result;
+      });
+
+      expect(await middleware(mockH3Event, next)).toBe("next");
+      expect(next).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/start/src/server/fetchEvent.ts
+++ b/packages/start/src/server/fetchEvent.ts
@@ -29,8 +29,18 @@ export function mergeResponseHeaders(h3Event: H3Event, headers: Headers) {
   }
 }
 
+/**
+ * Wrap an h3 event handler so Solid's request context is available while it runs.
+ *
+ * @experimental
+ */
 export const decorateHandler = <T extends EventHandler>(fn: T) =>
   (event => provideRequestEvent(getFetchEvent(event), () => fn(event))) as T;
 
+/**
+ * Wrap h3 middleware so Solid's request context is available while it runs.
+ *
+ * @experimental
+ */
 export const decorateMiddleware = <T extends Middleware>(fn: T) =>
   ((event, next) => provideRequestEvent(getFetchEvent(event), () => fn(event, next))) as T;

--- a/packages/start/src/server/index.tsx
+++ b/packages/start/src/server/index.tsx
@@ -1,6 +1,7 @@
 export { default as lazy } from "../shared/lazy.ts";
 export { getServerFunctionMeta } from "../shared/serverFunction.ts";
 export { StartServer } from "./StartServer.tsx";
+export { decorateHandler, decorateMiddleware } from "./fetchEvent.ts";
 export { createHandler } from "./handler.ts";
 
 export type {


### PR DESCRIPTION
Expose experimental `decorateHandler` and `decorateMiddleware` APIs so custom h3 handlers can access Solid’s request context.

Implements Solution A from #2211.