### PR TITLE
fix: match API routes under server base URL

### DIFF
--- a/.changeset/tidy-zebras-route.md
+++ b/.changeset/tidy-zebras-route.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix API route matching when `server.baseURL` is configured.

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -181,6 +181,9 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
             "import.meta.env.START_CLIENT_ENTRY": JSON.stringify(handlers.client),
             "import.meta.env.START_CLIENT_ENTRY_URL": JSON.stringify(clientEntryUrl),
             "import.meta.env.START_DEV_OVERLAY": JSON.stringify(start.devOverlay),
+            "import.meta.env.SERVER_BASE_URL": JSON.stringify(
+              (config.server as { baseURL?: string } | undefined)?.baseURL ?? "",
+            ),
             "import.meta.env.SEROVAL_MODE": JSON.stringify(start.serialization?.mode || "json"),
           },
           builder: {

--- a/packages/start/src/env.d.ts
+++ b/packages/start/src/env.d.ts
@@ -14,5 +14,5 @@ interface SolidStartMetaEnv {
   START_CLIENT_ENTRY_URL: string;
   START_ISLANDS: boolean;
   // START_DEV_OVERLAY: boolean;
-  // SERVER_BASE_URL: string;
+  SERVER_BASE_URL: string;
 }

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -13,6 +13,7 @@ import { handleServerFunction } from "../fns/handler.ts";
 import type { APIEvent, FetchEvent, HandlerOptions, PageEvent } from "./types.ts";
 import { getExpectedRedirectStatus } from "./util.ts";
 import { toWebReadableStream } from "./web-stream.ts";
+import { stripPathBase } from "./strip-path-base.ts";
 
 const SERVER_FN_BASE = "/_server";
 
@@ -252,6 +253,6 @@ function produceResponseWithEventHeaders(res: Response) {
 }
 
 function stripBaseUrl(path: string) {
-  if (import.meta.env.BASE_URL === "/" || import.meta.env.BASE_URL === "") return path;
-  return path.slice(import.meta.env.BASE_URL.length);
+  const base = import.meta.env.SERVER_BASE_URL || import.meta.env.BASE_URL || "/";
+  return stripPathBase(path, base);
 }

--- a/packages/start/src/server/strip-path-base.spec.ts
+++ b/packages/start/src/server/strip-path-base.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { stripPathBase } from "./strip-path-base.ts";
+
+describe("stripPathBase", () => {
+  it("leaves paths unchanged for an empty or root base", () => {
+    expect(stripPathBase("/api/hello", "")).toBe("/api/hello");
+    expect(stripPathBase("/api/hello", "/")).toBe("/api/hello");
+  });
+
+  it("strips the base from paths below it", () => {
+    expect(stripPathBase("/app/api/hello", "/app")).toBe("/api/hello");
+    expect(stripPathBase("/app/api/hello", "/app/")).toBe("/api/hello");
+  });
+
+  it("maps an exact base path to root", () => {
+    expect(stripPathBase("/app", "/app")).toBe("/");
+  });
+
+  it("does not strip a partial path segment match", () => {
+    expect(stripPathBase("/application/api/hello", "/app")).toBe("/application/api/hello");
+  });
+});

--- a/packages/start/src/server/strip-path-base.ts
+++ b/packages/start/src/server/strip-path-base.ts
@@ -1,0 +1,9 @@
+export function stripPathBase(path: string, base: string) {
+  if (!base || base === "/") return path;
+
+  const normalizedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  if (path === normalizedBase) return "/";
+  if (path.startsWith(`${normalizedBase}/`)) return path.slice(normalizedBase.length);
+
+  return path;
+}


### PR DESCRIPTION
## Summary

- expose `server.baseURL` to the server handler
- strip the configured base path before matching API and server-function routes
- preserve `BASE_URL` as a fallback and avoid partial path-segment matches
- add regression coverage and a patch changeset

Closes #2106.

## Testing

- `pnpm test:ci` (69 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm oxfmt --check packages/start/src/config/index.ts packages/start/src/env.d.ts packages/start/src/server/handler.ts packages/start/src/server/strip-path-base.ts packages/start/src/server/strip-path-base.spec.ts .changeset/tidy-zebras-route.md`