### PR TITLE
chore: stabilize flaky ci tests

### DIFF
--- a/apps/tests/package.json
+++ b/apps/tests/package.json
@@ -12,7 +12,7 @@
     "e2e": "playwright test",
     "e2e:bundled-dev": "playwright test --config playwright.bundled-dev.config.ts",
     "e2e:ui": "playwright test --ui",
-    "test:all": "npm run unit:ci && npm run e2e && npm run e2e:bundled-dev"
+    "test:all": "pnpm run unit:ci && pnpm run e2e && pnpm run e2e:bundled-dev"
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",

--- a/apps/tests/src/e2e/hydration.test.ts
+++ b/apps/tests/src/e2e/hydration.test.ts
@@ -19,9 +19,11 @@ test.describe("SSR Hydration", () => {
 
     await expect(output).toHaveText("0");
 
-    await button.click();
-
-    await expect(output).toHaveText("1");
+    // Retry until a click is handled post-hydration. Pre-hydration clicks are synchronous no-ops.
+    await expect(async () => {
+      await button.click();
+      await expect(output).toHaveText("1", { timeout: 1000 });
+    }).toPass({ timeout: 15000 });
 
     expect(consoleErrors, "Expected no hydration mismatch errors in console").toEqual([]);
   });

--- a/apps/tests/vitest.config.ts
+++ b/apps/tests/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     },
   },
   plugins: [solid()],
+  optimizeDeps: {
+    include: ["@solidjs/testing-library"],
+  },
   test: {
     mockReset: true,
     globals: true,


### PR DESCRIPTION
During CI Vite warns about:


>  [vitest] Vite unexpectedly reloaded a test. This may cause tests to fail, lead to flaky behaviour or duplicated test runs.
>  For a stable experience, please add mentioned dependencies to your config's `optimizeDeps.include` field manually.

So this adds the testing library to teh optimizeDeps, so vite deosn't warn about flakiness.

This also adds a small timeout on the hydration tests which is flaky.

These issues are why teh ci currently fails in e.g.
- #2049 