### PR TITLE
fix: restore routerLoad argument to createHandler

### DIFF
--- a/.changeset/spotty-moons-repeat.md
+++ b/.changeset/spotty-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Restore the optional `routerLoad` third argument to `createHandler`, which primes custom routers (e.g. TanStack Router) on the server before SSR rendering. It was accidentally dropped in the v2 rewrite.

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -21,6 +21,7 @@ export function createBaseHandler(
   createPageEvent: (e: FetchEvent) => Promise<PageEvent>,
   fn: (context: PageEvent) => JSX.Element,
   options: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>) = {},
+  routerLoad?: (event: FetchEvent) => Promise<void>,
 ): H3 {
   const handler = defineHandler({
     middleware: middleware.length ? middleware.map(decorateMiddleware) : undefined,
@@ -63,6 +64,8 @@ export function createBaseHandler(
           if (!match.isPage) return;
         }
       }
+
+      if (routerLoad) await routerLoad(event);
 
       const context = await createPageEvent(event);
 
@@ -134,8 +137,9 @@ export function createBaseHandler(
 export function createHandler(
   fn: (context: PageEvent) => JSX.Element,
   options: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>) = {},
+  routerLoad?: (event: FetchEvent) => Promise<void>,
 ): H3 {
-  return createBaseHandler(createPageEvent, fn, options);
+  return createBaseHandler(createPageEvent, fn, options, routerLoad);
 }
 
 export async function createPageEvent(ctx: FetchEvent) {

--- a/packages/start/src/server/spa/handler.ts
+++ b/packages/start/src/server/spa/handler.ts
@@ -12,8 +12,9 @@ import type { FetchEvent, HandlerOptions, PageEvent } from "../types.ts";
 export function createHandler(
   fn: (context: PageEvent) => JSX.Element,
   options?: HandlerOptions | ((context: PageEvent) => HandlerOptions),
+  routerLoad?: (event: FetchEvent) => Promise<void>,
 ): H3 {
-  return createBaseHandler(createPageEvent, fn, options);
+  return createBaseHandler(createPageEvent, fn, options, routerLoad);
 }
 
 async function createPageEvent(ctx: FetchEvent) {


### PR DESCRIPTION
## Summary

Restores the optional `routerLoad` third argument to `createHandler`, which was accidentally dropped in the v2 rewrite (#1942).

`routerLoad` was introduced in #1840 to enable TanStack Router SSR — it primes the router store on the server before rendering. The client half of that integration (`StartClientTanstack`) survived the rewrite, but the server half didn't, so any v2 app following the `with-tanstack-router` template pattern (`createHandler(fn, undefined, routerLoad)`) returns HTTP 500 with `TypeError: Cannot read properties of undefined` from the uninitialized router store. The docs (`create-handler.mdx`) still document the parameter.

Fixes #2221

## Changes

- `createHandler` (server + SPA variants) accepts `routerLoad?: (event: FetchEvent) => Promise<void>` again and threads it through `createBaseHandler`.
- It's invoked just before `createPageEvent`, so it only runs for page renders. This is a slight narrowing from v1, where it ran at the top of `provideRequestEvent` for every request including API routes — the hook exists to prime the router store for SSR, so running it for non-page requests was wasted work.

## Verification

Tested with a fixture app based on the original `with-tanstack-router` example (code-based routes, no router-plugin codegen), on a fresh server each time since the module-level router singleton retains state across hot reloads:

- Without this fix: fresh server → HTTP 500, TypeErrors from the uninitialized router store (dev).
- With this fix: HTTP 200 in dev **and** production build, route loader data rendered server-side, no console errors, client-side navigation works after hydration.
- `tsc --noEmit` passes; unit test suite unchanged (the one pre-existing `fetchEvent.spec` failure reproduces identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)