### PR TITLE
fix(types): add StartHandler type that extends H3

### DIFF
--- a/.changeset/olive-apes-clap.md
+++ b/.changeset/olive-apes-clap.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fix TS2883/TS2742 when emitting declarations for `entry-server.tsx`. `createHandler` now returns `StartHandler`, a type owned by `@solidjs/start`, instead of h3's `H3`, so the inferred type of `export default createHandler(...)` no longer has to be named through a nested `node_modules/@solidjs/start/node_modules/h3` path.

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -10,7 +10,7 @@ import { decorateHandler, decorateMiddleware } from "./fetchEvent.ts";
 import { getSsrManifest } from "./manifest/ssr-manifest.ts";
 import { matchAPIRoute } from "./routes.ts";
 import { handleServerFunction } from "../fns/handler.ts";
-import type { APIEvent, FetchEvent, HandlerOptions, PageEvent } from "./types.ts";
+import type { APIEvent, FetchEvent, HandlerOptions, PageEvent, StartHandler } from "./types.ts";
 import { getExpectedRedirectStatus } from "./util.ts";
 import { toWebReadableStream } from "./web-stream.ts";
 import { stripPathBase } from "./strip-path-base.ts";
@@ -22,7 +22,7 @@ export function createBaseHandler(
   fn: (context: PageEvent) => JSX.Element,
   options: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>) = {},
   routerLoad?: (event: FetchEvent) => Promise<void>,
-): H3 {
+): StartHandler {
   const handler = defineHandler({
     middleware: middleware.length ? middleware.map(decorateMiddleware) : undefined,
     handler: decorateHandler(async (e: H3Event) => {
@@ -138,7 +138,7 @@ export function createHandler(
   fn: (context: PageEvent) => JSX.Element,
   options: HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>) = {},
   routerLoad?: (event: FetchEvent) => Promise<void>,
-): H3 {
+): StartHandler {
   return createBaseHandler(createPageEvent, fn, options, routerLoad);
 }
 

--- a/packages/start/src/server/index.tsx
+++ b/packages/start/src/server/index.tsx
@@ -15,6 +15,7 @@ export type {
   PageEvent,
   ResponseStub,
   ServerFunctionMeta,
+  StartHandler,
 } from "./types.ts";
 
 /**

--- a/packages/start/src/server/spa/handler.ts
+++ b/packages/start/src/server/spa/handler.ts
@@ -1,9 +1,8 @@
-import type { H3 } from "h3/generic";
 import type { JSX } from "solid-js";
 
 import { createBaseHandler } from "../handler.ts";
 import { getSsrManifest } from "../manifest/ssr-manifest.ts";
-import type { FetchEvent, HandlerOptions, PageEvent } from "../types.ts";
+import type { FetchEvent, HandlerOptions, PageEvent, StartHandler } from "../types.ts";
 
 /**
  *
@@ -13,7 +12,7 @@ export function createHandler(
   fn: (context: PageEvent) => JSX.Element,
   options?: HandlerOptions | ((context: PageEvent) => HandlerOptions),
   routerLoad?: (event: FetchEvent) => Promise<void>,
-): H3 {
+): StartHandler {
   return createBaseHandler(createPageEvent, fn, options, routerLoad);
 }
 

--- a/packages/start/src/server/types.ts
+++ b/packages/start/src/server/types.ts
@@ -1,8 +1,19 @@
-import type { H3Event } from "h3";
+import type { H3, H3Event } from "h3";
 import type { JSX } from "solid-js";
 import type { RequestEvent } from "solid-js/web";
 
 // export const FETCH_EVENT = "$FETCH";
+
+/**
+ * The h3 app instance returned by `createHandler`.
+ *
+ * Structurally identical to h3's `H3`, but declared here so that `export default
+ * createHandler(...)` in `entry-server.tsx` can be named through `@solidjs/start`.
+ * Referring to `H3` directly makes TypeScript emit a reference to h3's internal
+ * `H3$1` class, which is not portable when h3 is nested inside
+ * `node_modules/@solidjs/start/node_modules` (TS2742 / TS2883).
+ */
+export interface StartHandler extends H3 {}
 
 export type DocumentComponentProps = {
   assets?: JSX.Element;


### PR DESCRIPTION
- Closes #2233

This is a types-only change. We have problems when using H3 types, which we do a few places as return types, and that happens in both hoisted and nested cases. If not familiar with hoisted/nested installs, see bottom of this PR.

`createHandler` returns h3's `H3`, which is `declare const H3: { new(): H3$1 }` plus `type H3 = H3$1`. The class `H3$1` is exported only from h3's internal `dist/h3.d.mts`, never from `h3` or `h3/generic`, so TypeScript cannot route the reference through the package and points at the internal file instead. When h3 also sits nested under `node_modules/@solidjs/start/node_modules`, that path is not portable and emit fails.

## This PR

Implements so `createHandler` (both `server` and `server/spa`) returns `StartHandler`, an interface declared by `@solidjs/start` that extends h3's `H3`, so it tracks h3 automatically and stays structurally interchangeable with it. Emit becomes:

```ts
declare const _default: import("@solidjs/start/server").StartHandler;
```

Tried to fix this in H3 itself (two middle rows), but only manage to resolve the hoisted cases, so it seems most feasible to solve this on the Start side of things to have it work in both cases.

| h3 `.d.ts` shape | h3 hoisted | h3 nested |
|---|---|---|
| current | fails | fails |
| real `class H3` exported from entry | ok | fails |
| entry re-exports `H3$1` | ok | fails |
| type declared by `@solidjs/start` | ok | ok |


## Hoisted/Nested

#### **Hoisted** means one copy of h3 at the top of the tree, reachable from the app:

```
node_modules/
  @solidjs/start/
  h3/            <- app can resolve "h3"
```

#### **Nested** means solid-start has its own private copy:
```
node_modules/
  @solidjs/start/
    node_modules/
      h3/        <- solid-start's copy
  h3/            <- a different version, or nothing here at all
```