### PR TITLE
fix(types): add missing properties to `SolidStartOptions` and expose them via Vite plugin configuration

### DIFF
--- a/.changeset/eleven-actors-nail.md
+++ b/.changeset/eleven-actors-nail.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+fix(types): add missing properties to `SolidStartOptions` and expose them via Vite plugin configuration

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -15,29 +15,109 @@ import lazy from "./lazy.ts";
 import { manifest } from "./manifest.ts";
 import { parseIdQuery } from "./utils.ts";
 
+/**
+ * Configuration options for SolidStart. (previously in `app.config.ts`)
+ *
+ * @see https://docs.solidjs.com/solid-start/v2/migrating-from-v1#move-framework-configuration-into-viteconfigts
+ */
 export interface SolidStartOptions {
+  /**
+   * Path to the root of the application (where `app.tsx` / `app.jsx` lives).
+   *
+   * @default "./src"
+   */
   appRoot: string;
+
+  /**
+   * Options forwarded to `vite-plugin-solid`.
+   *
+   * @see https://github.com/solidjs/vite-plugin-solid#api
+   */
   solid?: Partial<SolidOptions>;
+
+  /**
+   * Enable or disable server-side rendering.
+   *
+   * - `true` — SSR (default)
+   * - `false` — client-side rendering only (SPA mode)
+   *
+   * @default true
+   */
   ssr?: boolean;
+
+  /**
+   * Show the SolidStart development overlay (error overlay, etc.) in development.
+   *
+   * @default true
+   */
   devOverlay: boolean;
+
+  /**
+   * Experimental features.
+   */
   experimental: {
+    /**
+     * Enable islands architecture mode.
+     *
+     * Currently fixed to `false` (not yet fully supported).
+     *
+     * @default false
+     */
     islands: false;
   };
+
+  /**
+   * Directory containing file-system routes, relative to {@link appRoot}.
+   *
+   * @default "./routes"
+   */
   routeDir?: string;
+
+  /**
+   * File extensions that should be treated as routes.
+   *
+   * @default ["js", "jsx", "ts", "tsx"]
+   */
   extensions?: string[];
+
+  /**
+   * Path to an optional middleware module.
+   *
+   * The module should export a middleware created with `createMiddleware`
+   * from `@solidjs/start/middleware`.
+   *
+   * @example "src/middleware/index.ts"
+   */
   middleware?: string;
+
+  /**
+   * Serialization settings for server-function / action payloads
+   * that cross the server-client boundary.
+   */
   serialization?: {
     /**
      * The serialization mode to use for server functions/actions.
-     * The "js" mode uses a custom binary format that is more efficient than JSON, but requires a custom deserializer (with `eval()`) on the client.
-     * A strong CSP should block `eval()` executions, which would prevent the "js" mode from working.
-     * The "json" mode uses JSON for serialization, which is less efficient but can be deserialized with `JSON.parse` on the client.
+     *
+     * - `"js"` — Uses a custom binary format (Seroval) that is more efficient
+     *   than JSON, but requires a custom deserializer (with `eval()`) on the client.
+     *   A strong CSP that blocks `eval()` will prevent this mode from working.
+     * - `"json"` — Uses JSON for serialization. Less efficient / larger payloads,
+     *   but can be deserialized with `JSON.parse` on the client and is CSP-friendly.
      *
      * @default "json"
      */
     mode?: "js" | "json";
   };
+
+  /**
+   * Configures plugin behavior per build environment
+   */
   env?: EnvPluginOptions;
+
+  /**
+   * Options controlling which files are processed as server functions
+   * (inclusion / exclusion filters for the `"use server"` transform).
+   */
   serverFunctions?: Pick<ServerFunctionsOptions, "filter">;
 }
 

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -26,7 +26,7 @@ export interface SolidStartOptions {
    *
    * @default "./src"
    */
-  appRoot: string;
+  appRoot?: string;
 
   /**
    * Options forwarded to `vite-plugin-solid`.
@@ -50,12 +50,12 @@ export interface SolidStartOptions {
    *
    * @default true
    */
-  devOverlay: boolean;
+  devOverlay?: boolean;
 
   /**
    * Experimental features.
    */
-  experimental: {
+  experimental?: {
     /**
      * Enable islands architecture mode.
      *
@@ -63,7 +63,7 @@ export interface SolidStartOptions {
      *
      * @default false
      */
-    islands: false;
+    islands?: false;
   };
 
   /**

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -16,8 +16,13 @@ import { manifest } from "./manifest.ts";
 import { parseIdQuery } from "./utils.ts";
 
 export interface SolidStartOptions {
+  appRoot: string;
   solid?: Partial<SolidOptions>;
   ssr?: boolean;
+  devOverlay: boolean;
+  experimental: {
+    islands: false;
+  };
   routeDir?: string;
   extensions?: string[];
   middleware?: string;
@@ -50,7 +55,7 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
     },
     solid: {},
     extensions: [],
-  });
+  } satisfies SolidStartOptions);
   const extensions = [...DEFAULT_EXTENSIONS, ...(start.extensions || [])];
   const routeDir = join(start.appRoot, start.routeDir);
   const root = process.cwd();
@@ -224,15 +229,9 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
       enforce: "pre",
       resolveId(id, importer, { ssr }) {
         if (id === "server-only") {
-          if (!ssr)
-            this.error(
-              `Attempt to import 'server-only' in a client module: ${importer}`,
-            );
+          if (!ssr) this.error(`Attempt to import 'server-only' in a client module: ${importer}`);
         } else if (id === "client-only") {
-          if (ssr)
-            this.error(
-              `Attempt to import 'client-only' in a server module: ${importer}`,
-            );
+          if (ssr) this.error(`Attempt to import 'client-only' in a server module: ${importer}`);
         } else {
           return null;
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Addresses an existing open issue: fixes #2235 
- [ ] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

SolidStartOptions (exported from @solidjs/start/config) does not correctly expose all of the configuration properties actually accepted by the solidStart() Vite plugin.

Because `appRoot` cannot be set, consumers are also unable to move `app.{jsx,tsx}` out of the default `./src` directory (e.g. to mirror a Next.js-style /app structure), and doing so causes a build-time failure.

## What is the new behavior?

- `SolidStartOptions` now correctly declares all configuration properties accepted by solidStart(), including `appRoot` and `devOverlay`.
- `appRoot` can now be set by consumers to relocate `app.{jsx,tsx}` (and, by extension, `routeDir` and other paths relative to it) away from the default `./src`.
- Added JSDoc comments to the majority of `SolidStartOptions` properties, documenting their purpose, accepted values, and defaults along with a links to documentation when relevant.
- The [`start` configuration dictionary](https://github.com/solidjs/solid-start/compare/main...TymonMarek:solid-start:main?expand=1#diff-f1e30a86aa39e30762bd6d1af01ea41718cdf39cd46e99978950372965949369L43) is now constrained to the `SolidStartOptions` interface using `satisfies`, causing type errors when one does not match the shape of the other, in hopes to prevent future issues like this one.