### PR TITLE
fix: stop the dev toolbar from reporting benign `ResizeObserver loop`

### DIFF
--- a/.changeset/tricky-goats-cheer.md
+++ b/.changeset/tricky-goats-cheer.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Stop the dev toolbar from reporting benign `ResizeObserver loop` notifications as application errors. Browsers dispatch these as window `error` events carrying no error object, so the toolbar was capturing the raw `ErrorEvent` and force-opening the error panel over the app on every resize.

--- a/packages/start/src/shared/dev-toolbar/index.tsx
+++ b/packages/start/src/shared/dev-toolbar/index.tsx
@@ -157,6 +157,11 @@ export function DevToolbar(props: DevToolbarProps) {
 
   createEffect(() => {
     const onErrorEvent = (error: ErrorEvent) => {
+      // Browsers dispatch benign ResizeObserver loop notifications as window
+      // "error" events carrying no error object. They aren't app errors.
+      if (!error.error && error.message?.startsWith("ResizeObserver loop")) {
+        return;
+      }
       pushError(error.error ?? error);
     };
 


### PR DESCRIPTION
- Fixes #1608

Browsers dispatch `ResizeObserver loop completed with undelivered notifications` as a window `error` event with no `error` object. The dev toolbar's handler did `pushError(error.error ?? error)`, so it fell through to the raw `ErrorEvent`, logged it to the console as a stackless `ErrorEvent`, and called `setContent("err")`, forcing the error panel open over the app on every resize.

Guards the handler against stackless `ResizeObserver loop` events. Kept narrow on purpose: other stackless non-`Error` events (cross-origin `Script error.`) are still captured, which can be revisited separately.

### Verification

Ran the repro from the issue in dev mode and drove viewport resizes with Playwright.

Before: 5 captured errors, panel auto-opened, `[error] ErrorEvent` in console.
After: zero captured errors, error button stays disabled, app renders normally.