### PR TITLE
fix: apply nonce to streaming redirect and SPA entry scripts

### DIFF
--- a/.changeset/lucky-moths-nonce.md
+++ b/.changeset/lucky-moths-nonce.md
@@ -1,0 +1,8 @@
+---
+"@solidjs/start": patch
+---
+
+Apply the configured `nonce` to the two script tags that were still missing it, so a strict `script-src` CSP no longer needs `unsafe-inline`:
+
+- The client-side redirect that streaming mode emits after the shell has already flushed (`<script>window.location=...</script>`) now carries the nonce.
+- The SPA entry script tag now carries the nonce, matching the SSR entry script.

--- a/packages/start/src/server/handler.ts
+++ b/packages/start/src/server/handler.ts
@@ -210,8 +210,18 @@ function handleStreamCompleteRedirect(context: PageEvent) {
   return ({ write }: { write: (html: string) => void }) => {
     context.complete = true;
     const to = context.response && context.response.headers.get("Location");
-    to && write(`<script>window.location=${JSON.stringify(to).replace(/</g, "\\u003c")}</script>`);
+    if (!to) return;
+    // The shell has already flushed, so the redirect has to happen client side.
+    // Carry the nonce so a strict `script-src` CSP doesn't block it.
+    const nonce = context.nonce ? ` nonce="${escapeAttribute(context.nonce)}"` : "";
+    write(
+      `<script${nonce}>window.location=${JSON.stringify(to).replace(/</g, "\\u003c")}</script>`,
+    );
   };
+}
+
+function escapeAttribute(value: string) {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
 }
 
 function stripBaseUrl(path: string) {

--- a/packages/start/src/server/spa/StartServer.tsx
+++ b/packages/start/src/server/spa/StartServer.tsx
@@ -31,6 +31,7 @@ export function StartServer(props: { document: Component<DocumentComponentProps>
               <PatchVirtualDevStyles nonce={nonce} />
               <script
                 type="module"
+                nonce={nonce}
                 src={getSsrManifest("client").path(import.meta.env.START_CLIENT_ENTRY_URL)}
               />
             </>


### PR DESCRIPTION
- Closes #1263

Closes the remaining CSP gaps from #1263, so a strict `script-src` policy no longer needs `unsafe-inline`.

Two script tags weren't picking up the configured `nonce`:

- **Streaming redirect** (`server/handler.ts`). When a redirect resolves after the shell has flushed, the fallback is a client-side `<script>window.location=...</script>`. It was emitted without a nonce. Since this string is built as raw HTML rather than JSX, the nonce is escaped on the way in.
- **SPA entry script** (`server/spa/StartServer.tsx`). Now passes `nonce`, matching what the SSR `StartServer` already did.

Note that the manifest part of #1263 was already fixed: v2 no longer inlines `window.manifest`, and `HydrationScript` already receives the nonce via `sharedConfig.context`.

### Verification

Built the `bare` fixture with `{ nonce: "..." }` plus a route that sets `Location` after the shell flushes:

