### PR TITLE
fix: remove noisy logs from server fns

### DIFF
--- a/.changeset/brave-hoops-listen.md
+++ b/.changeset/brave-hoops-listen.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Remove leftover debug `console.log` calls from the server functions inspector, which logged on every server function request in dev.

--- a/packages/start/src/fns/client.ts
+++ b/packages/start/src/fns/client.ts
@@ -19,7 +19,6 @@ async function createRequest(base: string, id: string, instance: string, options
     },
   });
   if (import.meta.env.DEV) {
-    console.log(pushRequest);
     pushRequest(id, instance, request.clone());
   }
   const response = await fetch(request);

--- a/packages/start/src/shared/dev-toolbar/index.tsx
+++ b/packages/start/src/shared/dev-toolbar/index.tsx
@@ -179,7 +179,6 @@ export function DevToolbar(props: DevToolbarProps) {
   createEffect(() => {
     onCleanup(
       captureServerFunctionCall(call => {
-        console.log(call);
         if (call.type === "request") {
           setStore("instances", call.instance, value => {
             return {


### PR DESCRIPTION
Remove few debug logs from
- https://github.com/solidjs/solid-start/pull/2049