### PR TITLE
fix: reject server function calls on 5xx responses without X-Error

### DIFF
--- a/.changeset/tidy-donkeys-reject.md
+++ b/.changeset/tidy-donkeys-reject.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Reject server function calls when the response is a 5xx without an X-Error header, instead of resolving with the parsed error body

--- a/packages/start/src/fns/client.spec.ts
+++ b/packages/start/src/fns/client.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../shared/dev-toolbar/functions/tracker.ts", () => ({
+  pushRequest: vi.fn(),
+  pushResponse: vi.fn(),
+}));
+
+vi.mock("./serialization.ts", () => ({
+  serializeToJSONString: vi.fn(async () => "[]"),
+}));
+
+vi.mock("./shared.ts", async importOriginal => {
+  const actual = await importOriginal<typeof import("./shared.ts")>();
+  return { ...actual, extractBody: vi.fn(async () => undefined) };
+});
+
+const { cloneServerReference } = await import("./client.ts");
+
+const respondWith = (status: number, headers: Record<string, string> = {}) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(null, { status, headers })),
+  );
+};
+
+const callServerFunction = () =>
+  (cloneServerReference("test-fn") as unknown as () => Promise<unknown>)();
+
+const rejectionOf = async (call: Promise<unknown>) => {
+  try {
+    await call;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the server function call to reject");
+};
+
+describe("fetchServerFunction", () => {
+  beforeEach(() => {
+    vi.stubEnv("BASE_URL", "http://localhost/");
+  });
+
+  it("rejects when the response is a 5xx without an X-Error header", async () => {
+    respondWith(500);
+    const rejection = await rejectionOf(callServerFunction());
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).toHaveProperty("message", "Server function call failed with status 500");
+  });
+
+  it("rejects with an error when an X-Error response carries no body", async () => {
+    respondWith(403, { "X-Error": "true" });
+    const rejection = await rejectionOf(callServerFunction());
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).toHaveProperty("message", "Server function call failed with status 403");
+  });
+
+  it("resolves normally for a successful response", async () => {
+    respondWith(200);
+    await expect(callServerFunction()).resolves.toBeUndefined();
+  });
+});

--- a/packages/start/src/fns/client.ts
+++ b/packages/start/src/fns/client.ts
@@ -94,8 +94,8 @@ async function fetchServerFunction(
   }
 
   const result = await extractBody(instance, true, response.clone());
-  if (response.headers.has("X-Error")) {
-    throw result;
+  if (response.headers.has("X-Error") || response.status >= 500) {
+    throw result ?? new Error(`Server function call failed with status ${response.status}`);
   }
   return result;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: relates to #1434 (covers its 5xx case)
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

Server function calls only reject when the response carries an `X-Error` header. Two cases slip past that check in `packages/start/src/fns/client.ts`:

- A 5xx produced below the handler (a server function module crashing at import time, a proxy or CDN error, a dead worker) has no `X-Error`, so the promise **resolves** and callers mistake server failure for success.
- An error response whose body yields nothing throws `undefined`, so callers have no error to inspect or match on.

Minimal reproduction: https://github.com/adipascu/solid-start-server-fn-500-repro

## What is the new behavior?

Responses with status >= 500 throw the deserialized result the same way `X-Error` does, falling back to an `Error` carrying the status when the body yields nothing. 4xx responses are untouched, since server functions can legitimately return them without `X-Error`.

## Other information

This is the follow-up to #2159, which was merged onto `1.x` where I asked whether to retarget it at `main`. v2's rewritten client has the same logic, so the same fix applies.

Added `packages/start/src/fns/client.spec.ts` beside the existing `handler.spec.ts`. Both regression tests were confirmed to fail without the source change.