### PR TITLE
fix: declare @solidjs/router as an optional peer dep below v2

### DIFF
--- a/.changeset/tall-donuts-smile.md
+++ b/.changeset/tall-donuts-smile.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Declare `@solidjs/router` as an optional peer dependency constrained to `>=0.16.0 <2.0.0-0`. Router v2 is expected to target Solid v2, so installing it alongside `@solidjs/start` v2 now surfaces a peer warning instead of silently producing an incompatible pairing. The peer is marked optional, so apps that do not use the router are unaffected.

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -88,7 +88,13 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
+    "@solidjs/router": ">=0.16.0 <2.0.0-0",
     "vite": "^8 || ^9"
+  },
+  "peerDependenciesMeta": {
+    "@solidjs/router": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@solidjs/meta':
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
+      '@solidjs/router':
+        specifier: '>=0.16.0 <2.0.0-0'
+        version: 0.16.2(solid-js@1.9.14)
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0


### PR DESCRIPTION
## Problem

`@solidjs/start` declares no relationship to `@solidjs/router` at all: it is not a dependency, not a peer dependency, and there is no import of it anywhere in `packages/start/src`. The router integration is entirely user-land, with `FileRoutes` in `src/router.tsx` returning plain route configs.

That means nothing constrains the pairing in either direction, and an incompatible router can be installed alongside Start with no signal to the user.

## Change

Declare the router as an **optional** peer dependency with an explicit range:

```json
"peerDependencies": {
  "@solidjs/router": ">=0.16.0 <2.0.0-0",
  "vite": "^8 || ^9"
},
"peerDependenciesMeta": {
  "@solidjs/router": { "optional": true }
}
```

Router v2 is expected to target Solid v2, so `@solidjs/start` v2 should accept `0.16` and up but stay below v2. `peerDependenciesMeta` keeps this advisory for apps that do not use the router at all.

The upper bound is `<2.0.0-0` rather than `<2.0.0` on purpose. Under default semver both exclude a stable `2.0.0`, but `<2.0.0` still admits `2.0.0-*` prereleases under prerelease-inclusive resolution. `<2.0.0-0` excludes them either way.

## Verified

Range behavior:

| version | in range |
| --- | --- |
| `0.15.4` | no |
| `0.16.0` – `0.16.3` | yes |
| `1.0.0`, `1.9.9` | yes |
| `2.0.0-next.1`, `2.0.0` | no |

Install behavior, checked against a synthetic package carrying the same declaration:

- no router installed: installs clean, confirming the optional flag works
- router `0.16.3`: installs clean
- an out-of-range router: npm fails with `ERESOLVE` listing `peerOptional @solidjs/router`, and `pnpm peers check` reports it as an unmet peer

Note that inside this monorepo the constraint will not visibly warn, because `@solidjs/start` is linked via `workspace:*` and pnpm's auto-install-peers simply installs a satisfying version into the `packages/start` importer. That is the new lockfile line. The user-facing behavior was verified separately via a packed tarball.

## Worth a maintainer check

The currently published `@solidjs/router@1.0.0-next.11` (the `next` tag) declares peers of `solid-js: >=2.0.0-beta.22 <2.0.0-experimental.0` and `@solidjs/web: ^2.0.0-beta.26`, so that prerelease line targets Solid **v2**. The same applies to the `0.17.0-next.*` versions that preceded it.

This does not break the range as written: both prerelease lines are excluded under default resolution anyway, since a prerelease only matches when a comparator shares its major.minor.patch tuple. So a stable `1.x` is accepted while today's `1.0.0-next.*` is not.

It does mean the bound depends on the release plan. If the v1 numbering is being repurposed and a Solid-v1-targeting `1.0.0` supersedes those prereleases, this range is correct. If those prereleases are the future v1, the bound should be `<1.0.0-0` instead.