### PR TITLE
chore: update Solid Router to v1

### DIFF
--- a/apps/fixtures/basic/package.json
+++ b/apps/fixtures/basic/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
     "solid-js": "^1.9.14",

--- a/apps/fixtures/css/package.json
+++ b/apps/fixtures/css/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
     "solid-js": "^1.9.14",

--- a/apps/fixtures/experiments/package.json
+++ b/apps/fixtures/experiments/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
     "solid-js": "^1.9.14",

--- a/apps/fixtures/hackernews/package.json
+++ b/apps/fixtures/hackernews/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "solid-js": "^1.9.14",
     "vite": "^8.1.5"

--- a/apps/fixtures/notes/package.json
+++ b/apps/fixtures/notes/package.json
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "date-fns": "^4.4.0",
     "marked": "^18.0.7",

--- a/apps/fixtures/todomvc/package.json
+++ b/apps/fixtures/todomvc/package.json
@@ -8,7 +8,7 @@
     "start": "vite start"
   },
   "dependencies": {
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
     "solid-js": "^1.9.14",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/tests/package.json
+++ b/apps/tests/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.16.2",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.10.0",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -82,7 +82,6 @@
     "vite-plugin-solid": "^2.11.13"
   },
   "devDependencies": {
-    "@solidjs/router": "^1.0.0",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^26.1.1",
     "vite": "^8.1.5",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -82,6 +82,7 @@
     "vite-plugin-solid": "^2.11.13"
   },
   "devDependencies": {
+    "@solidjs/router": "^1.0.0",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^26.1.1",
     "vite": "^8.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -84,8 +84,8 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -112,8 +112,8 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -130,8 +130,8 @@ importers:
   apps/fixtures/hackernews:
     dependencies:
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -145,8 +145,8 @@ importers:
   apps/fixtures/notes:
     dependencies:
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -172,8 +172,8 @@ importers:
   apps/fixtures/todomvc:
     dependencies:
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -196,8 +196,8 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../packages/start
@@ -254,14 +254,14 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
       '@solidjs/router':
-        specifier: ^0.16.2
-        version: 0.16.2(solid-js@1.9.14)
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../packages/start
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.16.2(solid-js@1.9.14))(solid-js@1.9.14)
+        version: 0.8.10(@solidjs/router@1.0.0(solid-js@1.9.14))(solid-js@1.9.14)
       '@testing-library/jest-dom':
         specifier: ^6.10.0
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -323,9 +323,6 @@ importers:
       '@solidjs/meta':
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
-      '@solidjs/router':
-        specifier: '>=0.16.0 <2.0.0-0'
-        version: 0.16.2(solid-js@1.9.14)
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
@@ -390,6 +387,9 @@ importers:
         specifier: ^2.11.13
         version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
     devDependencies:
+      '@solidjs/router':
+        specifier: ^1.0.0
+        version: 1.0.0(solid-js@1.9.14)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -1444,8 +1444,8 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/router@0.16.2':
-    resolution: {integrity: sha512-pncbV4SGUwGGlELlDWc3B4KDVB0Kt+7+7ct+GTN7D8CgetGSJMzl8RzyAFz+/TtSuFFzp9IzrjrACHUpGzxsKQ==}
+  '@solidjs/router@1.0.0':
+    resolution: {integrity: sha512-cCSk1hvgCowiMa9bzzYWHiLu1U4E22+DfJe6/rOwAyECKrxc3jrd5QnoW3sDDJtW+e077cz/M67bPl3DqOBw1Q==}
     peerDependencies:
       solid-js: ^1.8.6
 
@@ -4300,16 +4300,16 @@ snapshots:
     dependencies:
       solid-js: 1.9.14
 
-  '@solidjs/router@0.16.2(solid-js@1.9.14)':
+  '@solidjs/router@1.0.0(solid-js@1.9.14)':
     dependencies:
       solid-js: 1.9.14
 
-  '@solidjs/testing-library@0.8.10(@solidjs/router@0.16.2(solid-js@1.9.14))(solid-js@1.9.14)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@1.0.0(solid-js@1.9.14))(solid-js@1.9.14)':
     dependencies:
       '@testing-library/dom': 10.4.1
       solid-js: 1.9.14
     optionalDependencies:
-      '@solidjs/router': 0.16.2(solid-js@1.9.14)
+      '@solidjs/router': 1.0.0(solid-js@1.9.14)
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@solidjs/meta':
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.14)
+      '@solidjs/router':
+        specifier: '>=0.16.0 <2.0.0-0'
+        version: 1.0.0(solid-js@1.9.14)
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
@@ -387,9 +390,6 @@ importers:
         specifier: ^2.11.13
         version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
     devDependencies:
-      '@solidjs/router':
-        specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ ignoredBuiltDependencies:
 minimumReleaseAgeExclude:
   - srvx@0.12.4
   - h3@2.0.1-rc.26
+  - "@solidjs/router@1.0.0"
 
 onlyBuiltDependencies:
   - "@parcel/watcher"


### PR DESCRIPTION
## Summary

- update the landing page, test app, and router-backed fixtures to `@solidjs/router@^1.0.0`
- resolve `@solidjs/start`'s existing optional Router peer to v1 without adding a direct or development dependency
- refresh the pnpm lockfile and allow the newly released `1.0.0` through the workspace's minimum-release-age policy

Solid Router v1 is API-compatible with the router APIs used in this repository, so no source migration is needed. This makes all workspace consumers resolve Router `1.0.0` instead of `0.16.2`.

No changeset is included because the published `@solidjs/start` dependency contract is unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm build`
- `pnpm --filter './apps/**' --recursive run build`
- `pnpm --filter tests run unit:ci` (5 tests)
- `pnpm --filter @solidjs/start run test:ci` (88 tests)
