### PR TITLE
fix: remove type-only server import remnants

### DIFF
--- a/.changeset/calm-types-vanish.md
+++ b/.changeset/calm-types-vanish.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Remove type-only import remnants from client server-function transforms so they do not retain server-only dependency chains.

--- a/packages/start/src/directives/compile.spec.ts
+++ b/packages/start/src/directives/compile.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { compile, type CompileOptions } from "./compile.ts";
+
+const clientOptions: CompileOptions = {
+  env: "development",
+  mode: "client",
+  directive: "use server",
+  definitions: {
+    register: {
+      kind: "named",
+      name: "createServerReference",
+      source: "virtual:server-runtime",
+    },
+    clone: {
+      kind: "named",
+      name: "cloneServerReference",
+      source: "virtual:server-runtime",
+    },
+  },
+};
+
+describe("compile", () => {
+  it("removes an import when only type specifiers remain", async () => {
+    const result = await compile(
+      "/src/server-action.ts",
+      `
+        import { type Session, verify } from "./server-module.ts";
+
+        export const serverAction = async (): Promise<Session | null> => {
+          "use server";
+          return verify();
+        };
+      `,
+      clientOptions,
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.code).not.toContain("./server-module.ts");
+  });
+
+  it("preserves live value specifiers from a mixed import", async () => {
+    const result = await compile(
+      "/src/server-action.ts",
+      `
+        import { type Session, clientValue, verify } from "./server-module.ts";
+
+        export const value = clientValue;
+        export const serverAction = async (): Promise<Session | null> => {
+          "use server";
+          return verify();
+        };
+      `,
+      clientOptions,
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.code).toContain(
+      'import { type Session, clientValue } from "./server-module.ts";',
+    );
+    expect(result.code).not.toMatch(/\bverify\b/);
+  });
+});

--- a/packages/start/src/directives/remove-unused-variables.ts
+++ b/packages/start/src/directives/remove-unused-variables.ts
@@ -44,6 +44,14 @@ export function removeUnusedVariables(program: babel.NodePath<t.Program>) {
                     parent.remove();
                   } else {
                     binding.path.remove();
+                    if (
+                      parent.node.specifiers.every(
+                        specifier =>
+                          t.isImportSpecifier(specifier) && specifier.importKind === "type",
+                      )
+                    ) {
+                      parent.remove();
+                    }
                   }
                   dirty = true;
                 } else if (!isInvalidForRemoval(binding.path)) {

--- a/packages/start/src/directives/remove-unused-variables.ts
+++ b/packages/start/src/directives/remove-unused-variables.ts
@@ -16,6 +16,22 @@ function isInvalidForRemoval(path: babel.NodePath) {
   return isPathValid(target, t.isObjectPattern) || isPathValid(target, t.isArrayPattern);
 }
 
+function countValidImport(node: t.ImportDeclaration): number {
+  if (node.importKind === "type") {
+    return 0;
+  }
+
+  let count = 0;
+
+  for (const specifier of node.specifiers) {
+    if (specifier.type !== "ImportSpecifier" || specifier.importKind === "value") {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
 export function removeUnusedVariables(program: babel.NodePath<t.Program>) {
   // TODO(Alexis):
   // This implementation is simple but slow
@@ -40,18 +56,10 @@ export function removeUnusedVariables(program: babel.NodePath<t.Program>) {
               if (binding.references === 0 && !binding.path.removed) {
                 const parent = binding.path.parentPath;
                 if (isPathValid(parent, t.isImportDeclaration)) {
-                  if (parent.node.specifiers.length === 1) {
+                  if (countValidImport(parent.node) <= 1) {
                     parent.remove();
                   } else {
                     binding.path.remove();
-                    if (
-                      parent.node.specifiers.every(
-                        specifier =>
-                          t.isImportSpecifier(specifier) && specifier.importKind === "type",
-                      )
-                    ) {
-                      parent.remove();
-                    }
                   }
                   dirty = true;
                 } else if (!isInvalidForRemoval(binding.path)) {


### PR DESCRIPTION
- Fixes #2272

Removes type-only import remnants after unused server function imports are eliminated. Adds regression tests to ensure live value imports are preserved.