### PR TITLE
fix: detect shared chunks via moduleIds and imported css instead of isDynamicEntry

### DIFF
--- a/.changeset/deep-sails-peel.md
+++ b/.changeset/deep-sails-peel.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Fixed shared chunk css not being server rendered in production (Vite 8 regression).

--- a/apps/fixtures/css/vite.config.ts
+++ b/apps/fixtures/css/vite.config.ts
@@ -13,13 +13,14 @@ export default defineConfig({
          * Creates a shared chunk with two components. Needed for the "SharedChunk" test!
          * The vite manifest behaves differently for such shared chunks.
          * More info: packages/start/src/config/lazy.ts
-         *
-         * TODO: When switching to Rolldown, migrate this to advancedChunks
-         * https://vite.dev/guide/rolldown.html#manualchunks-to-advancedchunks
          */
-        manualChunks(id) {
-          if (!id.includes("src/components/sharedChunk")) return;
-          return "shared";
+        codeSplitting: {
+          groups: [
+            {
+              name: "shared-css",
+              test: "src/components/sharedChunk",
+            },
+          ],
         },
       },
     },

--- a/packages/start/src/config/lazy.ts
+++ b/packages/start/src/config/lazy.ts
@@ -73,12 +73,16 @@ const lazy = (): PluginOption => {
       if (this.environment.name !== VITE_ENVIRONMENTS.client) return;
 
       for (const chunk of Object.values(bundle)) {
-        if (chunk.type !== "chunk" || !chunk.isDynamicEntry || chunk.facadeModuleId) continue;
+        if (chunk.type !== "chunk" || chunk.facadeModuleId) continue;
+        if (!chunk.viteMetadata?.importedCss.size) continue;
+
+        const moduleIds = chunk.moduleIds.filter(id => !id.endsWith("css"));
+        if (moduleIds.length <= 1) continue;
 
         // Has to follow Vites implementation:
         // https://github.com/vitejs/vite/blob/4be37a8389c67873880f826b01fe40137e1c29a7/packages/vite/src/node/plugins/manifest.ts#L179
         const chunkName = `_${basename(chunk.fileName)}`;
-        for (const id of chunk.moduleIds) {
+        for (const id of moduleIds) {
           sharedChunkNames[id] = chunkName;
         }
       }


### PR DESCRIPTION
## What is the current behavior?

Shared chunk css hasn't been server rendered in production as of late, resulting in flashes of unstyled content. Probably caused by the upgrade to vite 8, shared chunks no longer are being flagged as dynamic entry, causing them to not be picked up by the shared chunk id remapping logic.

<img width="1032" height="921" alt="Screenshot_20260801_215023" src="https://github.com/user-attachments/assets/5cb6f368-70b6-4774-8ddc-3c66825dfabb" />

## What is the new behavior?

Shared chunk css is being server rendered again in production. The remapping logic has being updated, to detect shared chunks based on quantity of included modules + imported css, instead of `isDynamicEntry`.

<img width="1042" height="936" alt="Screenshot_20260801_215156" src="https://github.com/user-attachments/assets/dbd9ac60-cbc5-434e-a9c1-0c8b2a1a5974" />
