### PR TITLE
chore: migrate from rollupOptions to rolldownOptions

### DIFF
--- a/.changeset/fresh-tools-build.md
+++ b/.changeset/fresh-tools-build.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Migrate the built-in Vite configuration from the deprecated `rollupOptions` alias to `rolldownOptions`.

--- a/apps/fixtures/css/vite.config.ts
+++ b/apps/fixtures/css/vite.config.ts
@@ -7,7 +7,7 @@ import virtualCSS from "./src/virtualCssPlugin";
 export default defineConfig({
   plugins: [virtualCSS(), solidStart(), nitro(), tailwindcss()],
   build: {
-    rollupOptions: {
+    rolldownOptions: {
       output: {
         /**
          * Creates a shared chunk with two components. Needed for the "SharedChunk" test!

--- a/packages/start/src/config/app-root-alias.spec.ts
+++ b/packages/start/src/config/app-root-alias.spec.ts
@@ -69,7 +69,7 @@ it("resolves ~ in stylesheets, which are resolved without user plugins", async (
     logLevel: "silent",
     root,
     plugins: [appRootAlias(root, "./src")],
-    build: { write: false, rollupOptions: { input: join(root, "src/main.js") } },
+    build: { write: false, rolldownOptions: { input: join(root, "src/main.js") } },
   })) as { output: { fileName: string; source?: unknown }[] };
 
   const css = result.output.find(chunk => chunk.fileName.endsWith(".css"));

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -270,7 +270,7 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
           appType: "custom",
           build: {
             assetsDir: "_build/assets",
-            rollupOptions: {
+            rolldownOptions: {
               output: {
                 // Keeps route chunks named after their file rather than after
                 // the `?pick=...` id that addresses them. See toPickId.
@@ -295,7 +295,7 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
                 write: true,
                 manifest: true,
                 outDir: "dist/client",
-                rollupOptions: {
+                rolldownOptions: {
                   input: clientInput,
                   treeshake: true,
                   preserveEntrySignatures: "exports-only",
@@ -309,7 +309,7 @@ export function solidStart(options?: SolidStartOptions): Array<PluginOption> {
                 write: true,
                 manifest: true,
                 copyPublicDir: false,
-                rollupOptions: {
+                rolldownOptions: {
                   input: handlers.server,
                 },
                 outDir: "dist/server",


### PR DESCRIPTION
Since Start 2 promise support for Vite 8+, we just forwarded from the deprecated rollupOptions to rolldownOptions - it's gonna age better to use it directly.