### PR TITLE
chore: exit changeset pre-mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@solidjs/start": "2.0.0-rc.1",


### PR DESCRIPTION
Now that we are feature complete and have resolved all the bugs we planned for initial Start 2 release (the remainig issues are either Feature Requests, or bugs in other libraries), this is how we opt out of the changeset pre.json, so that we get a changeset release PR we can prepare for launch.

We have docs / annoucement etc. ready to go.

There's a bit of changeset tinkering, because of the way we stepped from alpha to beta to rc, but I can handle that in the changeset PR when this pre-tag is gone.