### PR TITLE
docs: update landing page for v2

### DIFF
--- a/apps/landing-page/src/components/sections/deploy-anywhere.tsx
+++ b/apps/landing-page/src/components/sections/deploy-anywhere.tsx
@@ -55,8 +55,8 @@ export function DeployAnywhere() {
       <header>
         <SectionTitle>Deploy Anywhere</SectionTitle>
         <p class="w-full sm:w-3/5 pt-5 px-2 leading-relaxed max-w-[70ch] mx-auto text-center dark:font-thin text-lg transition-all ease-in-out">
-          On the shoulders of open-source. SolidStart can be deployed to every platform Nitro has a
-          preset for.
+          On the shoulders of open-source. SolidStart can be deployed to every platform with a Vite
+          plugin.
         </p>
       </header>
       <div class="mx-auto w-fit pt-12">
@@ -75,20 +75,30 @@ export function DeployAnywhere() {
             <span class="dark:text-[#89DDFF] text-pink-600">{`({`}</span>
             <br />
             <span>
-              {"    "}server{`: `}
+              {"    "}plugins{`: `}
             </span>
-            <span class="dark:text-[#89DDFF]">{`{`}</span>
+            <span class="dark:text-[#89DDFF]">{`[`}</span>
             <br />
             <span>
-              {"        "}preset{`: `}
+              {"        "}
+              <span class="dark:text-[#82AAFF] text-sky-950">solidStart</span>
+              <span class="dark:text-[#89DDFF] text-pink-600">{`()`}</span>
+              {`,`}
             </span>
-            <span class="dark:text-[#89DDFF] text-pink-600">{`"`}</span>
-            <span class="dark:text-[#C3E88D] text-rose-500">netlify</span>
-            <span class="dark:text-[#89DDFF] text-pink-600">{`"`}</span>
+            <br />
+            <span>
+              {"        "}
+              <span class="dark:text-[#82AAFF] text-sky-950">netlify</span>
+              <span class="dark:text-[#89DDFF] text-pink-600">{`({ `}</span>
+              build{`: { `}
+              enabled{`: `}
+              <span class="dark:text-[#C792EA] text-purple-800">true</span>
+              <span class="dark:text-[#89DDFF] text-pink-600">{` } })`}</span>
+            </span>
             <br />
             <span class="dark:text-[#89DDFF] text-pink-600">
               {"    "}
-              {`}`}
+              {`]`}
             </span>
             <br />
             <span class="dark:text-[#89DDFF] text-pink-600">{`})`}</span>

--- a/apps/landing-page/src/components/sections/hero.tsx
+++ b/apps/landing-page/src/components/sections/hero.tsx
@@ -12,18 +12,28 @@ const buttonOutlineStyles = buttonVariants({
 export function Hero() {
   return (
     <header class="w-full mx-auto md:px-10 bg-linear-to-b from-transparent dark:to-[#081924] via-white dark:via-white/0 to-white">
-      <div class="flex flex-col items-center justify-center">
+      <div class="flex flex-col items-center justify-center gap-2">
         <a
-          href="https://github.com/solidjs/solid-start/discussions/1960"
+          href="#"
+          class="inline-block px-4 py-1 group rounded-full border border-black/5 text-base text-white transition-all ease-in dark:border-white/15 dark:bg-neutral-900/30 dark:hover:bg-neutral-800/20"
+        >
+          <AnimatedShinyText>
+            <span>🚀 Solid v2 is now in Release Candidate</span>
+          </AnimatedShinyText>
+        </a>
+
+        <a
+          href="https://github.com/solidjs/solid-start/discussions/2281"
           target="_blank"
           rel="noopener"
           class="inline-block px-4 py-1 group rounded-full border border-black/5 text-base text-white transition-all ease-in dark:border-white/15 dark:bg-neutral-900/30 dark:hover:bg-neutral-800/20"
         >
           <AnimatedShinyText>
-            <span>✨ Public Roadmap - DeVinxi and Beyond</span>
+            <span>✨ SolidStart v2 is now Stable</span>
           </AnimatedShinyText>
         </a>
       </div>
+
       <div class="max-w-5xl mx-auto">
         <DownloadLogosMenu />
         <div class="flex flex-col">

--- a/apps/landing-page/src/components/sections/meta-framework.tsx
+++ b/apps/landing-page/src/components/sections/meta-framework.tsx
@@ -18,20 +18,30 @@ export function MetaFramework() {
             <p>A strong, highly-performant serializer.</p>
           </NestItem>
 
-          <NestItem isHighlight accent="neutral" title="Vinxi">
-            <p class="leading-relaxed text-lg">Bundler and server runtime</p>
-            <ul class="grid grid-cols-2 gap-2 pt-5">
-              <NestItem title="Vite" accent="yellow">
-                <p>Dev env and bundler</p>
+          <NestItem isHighlight accent="neutral" title="Vite">
+            <p class="leading-relaxed text-lg">Bundler</p>
+            <ul class="grid grid-cols-3 gap-2 pt-5">
+              <NestItem title="Nitro V3" accent="pink">
+                <p>Deployment</p>
               </NestItem>
-              <NestItem title="Nitro" accent="teal">
-                <p>server APIs and presets</p>
+              <NestItem title="Netlify Vite Plugin" accent="teal">
+                <p>Deployment</p>
+              </NestItem>
+              <NestItem title="Cloudflare Vite Plugin" accent="yellow">
+                <p>Deployment</p>
               </NestItem>
             </ul>
           </NestItem>
 
-          <NestItem title="Solid Router" accent="pink">
-            <p>Official client-side router.</p>
+          <NestItem accent="neutral" title="Router Agnostic">
+            <ul class="grid grid-cols-2 gap-2 pt-5">
+              <NestItem title="Solid Router" accent="cyan">
+                <p>Official router</p>
+              </NestItem>
+              <NestItem title="Tanstack Router" accent="emerald">
+                <p>Third party router</p>
+              </NestItem>
+            </ul>
           </NestItem>
         </NesterBox>
         <div class="w-full grid place-items-center overflow-x-hidden">


### PR DESCRIPTION
## Summary

- announce the Solid and SolidStart v2 release status in the hero
- update the deployment example for Vite deployment plugins
- refresh the composable framework diagram for Vite, deployment plugins, and router choices

## Testing

- `pnpm exec oxfmt --check apps/landing-page/src/components/sections/deploy-anywhere.tsx apps/landing-page/src/components/sections/hero.tsx apps/landing-page/src/components/sections/meta-framework.tsx`
- `pnpm lp:build`