### PR TITLE
fix(manifest): use resolved virtual module ID for CSS imports in Vite 8

### DIFF
--- a/packages/start/src/server/collect-styles.ts
+++ b/packages/start/src/server/collect-styles.ts
@@ -72,7 +72,16 @@ export async function findStylesInModuleGraph(
   const styles: Record<string, any> = {};
   for (const dep of dependencies) {
     if (dep.id && isCssFile(dep.url)) {
-      styles[dep.id] = dep.url;
+      // Virtual modules (e.g. UnoCSS /__uno.css) have dep.file === null and
+      // dep.id starting with \0. Using dep.url (e.g. "/__uno.css") in the
+      // generated import() fails in Vite 8 module runner with ERR_DENIED_ID
+      // because the URL looks like a nonexistent filesystem path.
+      //
+      // Instead, use dep.id (the resolved virtual module ID, e.g. \0virtual:uno.css)
+      // which wrapId() converts to /@id/__x00__virtual:uno.css — a safe form
+      // that Vite's /@id/ resolution plugin can resolve through the plugin pipeline.
+      // Real CSS files (dep.file is set) keep using dep.url as before.
+      styles[dep.id] = dep.file === null ? dep.id : dep.url;
     }
   }
 


### PR DESCRIPTION
## Description

Virtual CSS modules (e.g. UnoCSS `/__uno.css`) have `dep.file === null` and `dep.id` starting with `\0`. Using `dep.url` (e.g. `/__uno.css`) in the generated `import()` call fails in **Vite 8 module runner** with `ERR_DENIED_ID` because the URL looks like a nonexistent filesystem path.

## Root Cause

In `findStylesInModuleGraph`, the code stores `styles[dep.id] = dep.url` for all CSS modules. For virtual modules:

- `dep.url` = `/__uno.css` (the URL form, not resolvable as a real file)
- `dep.id` = `\0virtual:uno.css` (the resolved virtual module ID)

The generated code does `import("/__uno.css?inline")` — Vite 8's module runner rejects this ID because it's neither a real file path nor a `\0`-prefixed virtual module.

## Fix

For virtual modules (`dep.file === null`), use `dep.id` (the resolved ID) instead of `dep.url`. `wrapId()` converts `\0virtual:uno.css` to `/@id/__x00__virtual:uno.css` — a safe form that Vite's `/@id/` resolution plugin can resolve through the plugin pipeline.

Real CSS files (`dep.file` is set) keep using `dep.url` as before.

## Related

Fixes #2292