### PR TITLE
fix(dev-server): delegate preview to Nitro when building with Nitro v3

### DIFF
--- a/.changeset/calm-preview-owners.md
+++ b/.changeset/calm-preview-owners.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Delegate `vite preview` to Nitro when its preview plugin is active, including for static builds that intentionally have no server entry.

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { NodeRequest, sendNodeResponse } from "srvx/node";
@@ -15,6 +15,22 @@ export function devServer(serverEntryPath: string): Array<PluginOption> {
     {
       name: "solid-start-dev-server",
       configurePreviewServer(server) {
+        // When Nitro controls the production server, its preview hook
+        // handles requests. Detect this by checking for the Nitro build
+        // output marker — if present, skip our middleware so the
+        // nitro:preview hook runs instead.
+        const nitroJsonPath = join(server.config.root, ".output", "nitro.json");
+        if (existsSync(nitroJsonPath)) {
+          try {
+            const nitroConfig = JSON.parse(readFileSync(nitroJsonPath, "utf8"));
+            if (nitroConfig.serverEntry) {
+              return;
+            }
+          } catch {
+            // Malformed nitro.json — fall through to the default path.
+          }
+        }
+
         const serverEntryUrl = pathToFileURL(resolvePreviewServerEntry(server.config.root)).href;
 
         return () => {

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -15,9 +15,8 @@ export function devServer(serverEntryPath: string): Array<PluginOption> {
     {
       name: "solid-start-dev-server",
       configurePreviewServer(server) {
-        // Nitro's preview hook handles both server and static builds. Static
-        // builds intentionally have no server entry, so use the active plugin
-        // as the ownership signal instead of inspecting generated output.
+        // Nitro's preview hook handles both server and static builds.
+        // Static builds have no server entry, so detect the active plugin instead.
         if (server.config.plugins.some(plugin => plugin.name === "nitro:preview")) return;
 
         const serverEntryUrl = pathToFileURL(resolvePreviewServerEntry(server.config.root)).href;

--- a/packages/start/src/config/dev-server.ts
+++ b/packages/start/src/config/dev-server.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { NodeRequest, sendNodeResponse } from "srvx/node";
@@ -15,21 +15,10 @@ export function devServer(serverEntryPath: string): Array<PluginOption> {
     {
       name: "solid-start-dev-server",
       configurePreviewServer(server) {
-        // When Nitro controls the production server, its preview hook
-        // handles requests. Detect this by checking for the Nitro build
-        // output marker — if present, skip our middleware so the
-        // nitro:preview hook runs instead.
-        const nitroJsonPath = join(server.config.root, ".output", "nitro.json");
-        if (existsSync(nitroJsonPath)) {
-          try {
-            const nitroConfig = JSON.parse(readFileSync(nitroJsonPath, "utf8"));
-            if (nitroConfig.serverEntry) {
-              return;
-            }
-          } catch {
-            // Malformed nitro.json — fall through to the default path.
-          }
-        }
+        // Nitro's preview hook handles both server and static builds. Static
+        // builds intentionally have no server entry, so use the active plugin
+        // as the ownership signal instead of inspecting generated output.
+        if (server.config.plugins.some(plugin => plugin.name === "nitro:preview")) return;
 
         const serverEntryUrl = pathToFileURL(resolvePreviewServerEntry(server.config.root)).href;
 


### PR DESCRIPTION
## Problem

When using the official Nitro v3 Vite plugin with `preset: "node-server"`, `vite preview` fails with:

```
Error: Could not find the SolidStart server entry in <project>/dist/server
```

SolidStart's `configurePreviewServer` hook runs before the `nitro:preview` hook. Since Nitro stores the server entry at `.output/server/index.mjs` instead of `dist/server/entry-server.*`, `resolvePreviewServerEntry` throws, stopping Vite's hook loop before Nitro's hook can handle the request.

## Fix

Check for the Nitro build output marker (`.output/nitro.json`). If present and the file declares a `serverEntry`, SolidStart skips its own preview middleware and lets the `nitro:preview` hook handle requests.

## Verification

- `vite build` + `vite preview` with Nitro v3 → succeeds (preview delegated to Nitro)
- `vite build` + `vite preview` without Nitro → unchanged behavior (SolidStart middleware still used)
- No Nitro build → `dist/server/entry-server.*` checked as before

Fixes #2291