### PR TITLE
fix: set explicit Content-Type on seroval stream server function responses

### DIFF
--- a/.changeset/tidy-planes-brush.md
+++ b/.changeset/tidy-planes-brush.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Declare an explicit `Content-Type: text/plain; charset=utf-8` on seroval-stream server function responses (success and error paths) so intermediaries cannot content-sniff a type onto them

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ tsconfig.tsbuildinfo
 apps/tests/**/test-results
 .solid-start
 .pnpm-store
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,3 @@ tsconfig.tsbuildinfo
 apps/tests/**/test-results
 .solid-start
 .pnpm-store
-
-
-#Ignore vscode AI rules
-.github/instructions/codacy.instructions.md

--- a/packages/start/src/fns/handler.spec.ts
+++ b/packages/start/src/fns/handler.spec.ts
@@ -282,3 +282,57 @@ describe("the configured server function error handler", () => {
     expect(h3Event.res.headers.get("X-Error")).toBe("boom");
   });
 });
+
+describe("seroval stream response headers", () => {
+  const callReturning = async (value: unknown) => {
+    const request = new Request("http://localhost/_server", {
+      method: "POST",
+      headers: { "X-Server-Id": "fn", "X-Server-Instance": "server-fn:1" },
+    });
+    const h3Event = { res: { headers: new Headers(), status: 200 } };
+    vi.mocked(getFetchEvent).mockReturnValue({
+      request,
+      response: { headers: { getSetCookie: () => [] } },
+      nativeEvent: h3Event,
+      locals: {},
+    } as unknown as FetchEvent);
+    vi.mocked(getServerFunction).mockReturnValue(() => value);
+    const { handleServerFunction } = await import("./handler.ts");
+    await handleServerFunction(h3Event as never);
+    return h3Event;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configuredErrorHandler.current = undefined;
+  });
+
+  it("sets an explicit content type on serialized results so intermediaries cannot sniff one", async () => {
+    const h3Event = await callReturning({ some: "value" });
+
+    expect(h3Event.res.headers.get("X-Start-Type")).toBe("0");
+    expect(h3Event.res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+  });
+
+  it("sets an explicit content type on serialized errors", async () => {
+    const request = new Request("http://localhost/_server", {
+      method: "POST",
+      headers: { "X-Server-Id": "fn", "X-Server-Instance": "server-fn:1" },
+    });
+    const h3Event = { res: { headers: new Headers(), status: 200 } };
+    vi.mocked(getFetchEvent).mockReturnValue({
+      request,
+      response: { headers: { getSetCookie: () => [] } },
+      nativeEvent: h3Event,
+      locals: {},
+    } as unknown as FetchEvent);
+    vi.mocked(getServerFunction).mockReturnValue(() => {
+      throw new Error("boom");
+    });
+    const { handleServerFunction } = await import("./handler.ts");
+    await handleServerFunction(h3Event as never);
+
+    expect(h3Event.res.headers.get("X-Start-Type")).toBe("0");
+    expect(h3Event.res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+  });
+});

--- a/packages/start/src/fns/handler.ts
+++ b/packages/start/src/fns/handler.ts
@@ -125,6 +125,8 @@ export async function handleServerFunction(h3Event: H3Event) {
       h3Event.res.headers.set("content-type", "text/javascript");
       return serializeToJSStream(instance, result);
     }
+    // explicit type keeps intermediaries (e.g. Go proxies) from sniffing one onto the stream
+    h3Event.res.headers.set("content-type", "text/plain; charset=utf-8");
     return serializeToJSONStream(result);
   } catch (x) {
     x = await applyServerFunctionErrorHandler(x);
@@ -165,6 +167,7 @@ export async function handleServerFunction(h3Event: H3Event) {
         h3Event.res.headers.set("content-type", "text/javascript");
         return serializeToJSStream(instance, x);
       }
+      h3Event.res.headers.set("content-type", "text/plain; charset=utf-8");
       return serializeToJSONStream(x);
     }
     return x;


### PR DESCRIPTION
Fixes #2295.

JSON-mode seroval-stream server function responses shipped without a `Content-Type` header, so intermediaries that content-sniff header-less responses (e.g. Go `net/http`-based reverse proxies like kamal-proxy) injected their own guess. This made the transport deployment-dependent and, on v1's client dispatch order, caused silent client-side navigation hangs.

As discussed in #2295, this sets `Content-Type: text/plain; charset=utf-8` — matching the 1.x fix in #2092 — next to the existing `X-Start-Type` header, in both the success and the error serialization paths of `handleServerFunction`. The v2 client dispatches on `X-Start-Type`, so this changes no client behavior; it only makes the wire format explicit.

Changes:

- `packages/start/src/fns/handler.ts`: set the header in both seroval JSON-stream paths (js mode already sets `text/javascript`)
- `packages/start/src/fns/handler.spec.ts`: regression tests for the success and error paths (assert `X-Start-Type` and `content-type`)
- patch changeset

`vitest run` in `packages/start`: 98/98 passing.
