### PR TITLE
fix: defer hydration until suspense stream is parsed

### DIFF
--- a/.changeset/calm-streams-hydrate.md
+++ b/.changeset/calm-streams-hydrate.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Defer client hydration until streamed Suspense content has been parsed to prevent stale route DOM after history navigation

--- a/apps/tests/src/app.tsx
+++ b/apps/tests/src/app.tsx
@@ -2,9 +2,11 @@ import { MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { Suspense } from "solid-js";
+import { getRequestEvent, isServer } from "solid-js/web";
 import "./app.css";
+import Repro2297App from "./repro-2297-app";
 
-export default function App() {
+function OriginalApp() {
   return (
     <Router
       root={props => (
@@ -69,4 +71,12 @@ export default function App() {
       <FileRoutes />
     </Router>
   );
+}
+
+export default function App() {
+  const pathname = isServer
+    ? new URL(getRequestEvent()!.request.url).pathname
+    : window.location.pathname;
+
+  return pathname.startsWith("/suspense-back") ? <Repro2297App /> : <OriginalApp />;
 }

--- a/apps/tests/src/e2e/suspense-back.test.ts
+++ b/apps/tests/src/e2e/suspense-back.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("does not retain the current route when going back after reloads", async ({ page }) => {
+  await page.goto("/suspense-back");
+  await expect(page.getByRole("heading", { name: "root video" })).toBeVisible();
+
+  await page.getByRole("link", { name: /root video/ }).click();
+  await expect(page.getByText("detail video")).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText("detail video")).toBeVisible();
+  await page.reload();
+  await expect(page.getByText("detail video")).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/suspense-back$/);
+  await expect(page.getByRole("heading", { name: "root video" })).toBeVisible();
+  await expect(page.getByText("detail video")).toHaveCount(0);
+  await expect(page.getByAltText("root video")).toHaveCount(1);
+});

--- a/apps/tests/src/repro-2297-app.tsx
+++ b/apps/tests/src/repro-2297-app.tsx
@@ -1,0 +1,51 @@
+import { createAsync, query, Route, Router } from "@solidjs/router";
+import { For, Suspense } from "solid-js";
+
+const getVideos = query(async () => {
+  "use server";
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return [{ title: "root video", thumb: "/favicon.ico" }];
+}, "suspense-back-videos");
+
+const getVideo = query(async () => {
+  "use server";
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return { title: "detail video", thumb: "/favicon.ico" };
+}, "suspense-back-video");
+
+export default function Repro2297App() {
+  return (
+    <Router>
+      <Route
+        path="/suspense-back"
+        component={() => {
+          const videos = createAsync(() => getVideos());
+          return (
+            <Suspense fallback={<p>Loading root...</p>}>
+              <For each={videos()}>
+                {video => (
+                  <a href="/suspense-back/video">
+                    <h1>{video.title}</h1>
+                    <img alt="root video" src={video.thumb} />
+                  </a>
+                )}
+              </For>
+            </Suspense>
+          );
+        }}
+      />
+      <Route
+        path="/suspense-back/video"
+        component={() => {
+          const video = createAsync(() => getVideo());
+          return (
+            <Suspense fallback={<p>Loading detail...</p>}>
+              {video()?.title}
+              <img alt="detail video" src={video()?.thumb} />
+            </Suspense>
+          );
+        }}
+      />
+    </Router>
+  );
+}

--- a/packages/start/src/server/StartServer.tsx
+++ b/packages/start/src/server/StartServer.tsx
@@ -34,7 +34,6 @@ export function StartServer(props: { document: Component<DocumentComponentProps>
               <script
                 type="module"
                 nonce={nonce}
-                async
                 src={getSsrManifest("client").path(import.meta.env.START_CLIENT_ENTRY_URL)}
               />
             </>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2297
- [x] Tests for the changes have been added (for bug fixes / features)

## What is the current behavior?

The client entry module is marked `async`, so it can hydrate while the HTML parser is still waiting for streamed Suspense content. Hydration can retain references to fallback route DOM that the stream later replaces. After reloading a detail route and navigating back, both the stale detail route and the new root route can remain rendered.

## What is the new behavior?

The client module now uses the default deferred execution of module scripts. It is still discovered and fetched when the parser encounters it, but hydration waits until the streamed document has been parsed.

A Playwright regression reproduces the reload-and-back sequence from #2297 and verifies that only the root route remains.

## Other information

Validation completed:

- `pnpm --filter @solidjs/start typecheck`
- `pnpm --filter @solidjs/start test:ci` (98 tests)
- `pnpm --filter tests build`
- `pnpm --filter tests unit:ci` (5 tests)
- Playwright Chromium e2e suite (38 tests)
- Focused regression in standard and bundled-dev configurations
