### PR TITLE
fix: suppress route reload events during the initial route scan

### DIFF
--- a/.changeset/quiet-initial-route-scan.md
+++ b/.changeset/quiet-initial-route-scan.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Don't emit route "reload" events during the initial file-system route scan. The scan runs on the first dev request, and the events invalidated the just-served routes manifest ~200ms later, pushing a spurious HMR update of the app/router module chain that raced hydration — intermittently duplicating pages, breaking client-side navigation, and detaching actions in dev.

--- a/packages/start/src/config/fs-routes/router.ts
+++ b/packages/start/src/config/fs-routes/router.ts
@@ -55,8 +55,13 @@ export class BaseFileSystemRouter extends EventTarget {
   }
 
   async buildRoutes(): Promise<any[]> {
-    for (var src of glob(this.glob())) {
-      await this.addRoute(src);
+    this.initialScan = true;
+    try {
+      for (var src of glob(this.glob())) {
+        await this.addRoute(src);
+      }
+    } finally {
+      this.initialScan = false;
     }
 
     return this.routes;
@@ -119,7 +124,15 @@ export class BaseFileSystemRouter extends EventTarget {
     }
   }
 
+  // "reload" listeners invalidate the routes manifest module, so the events
+  // must stay quiet while buildRoutes first discovers the existing files:
+  // a manifest already served to the browser would otherwise be invalidated
+  // ~200ms into the first request, racing hydration with an HMR update of
+  // the app/router module chain.
+  private initialScan = false;
+
   reload(route: string, type: "update" | "remove" | "add") {
+    if (this.initialScan) return;
     this.dispatchEvent(
       new CustomEvent("reload", {
         detail: {


### PR DESCRIPTION
## What

`BaseFileSystemRouter.buildRoutes()` runs on the first dev request and emitted a `reload` event for every existing route file it discovered. The fs-watcher's debounced handlers then invalidated (ssr) / `reloadModule`d (client) the `solid-start:routes` manifest ~200ms later — after the manifest had already been served — pushing a spurious HMR update that re-imported `solid-start:routes`, `@solidjs/start`'s `router.jsx`, and the user's `app.tsx` as fresh `?t=`-stamped module instances while hydration was still in flight.

This PR keeps the `reload` events quiet during the initial scan. Edits, additions, and removals of route files after the scan still emit as before.

## Symptoms

Depending on where the update landed relative to hydration, dev sessions intermittently saw:

- two pages rendered simultaneously (#2297)
- client-side navigation updating the URL but not the content
- `action`/`onSubmit` handlers never firing (the handler lives in the stale module instance while the DOM belongs to the new one)

The race is nondeterministic twice over: server-side, if the debounced handler fires before the manifest module exists in the graph, the event degrades to a harmless `full-reload` sent to zero connected clients — so cold starts only misbehaved ~50% of the time; client-side, damage depends on whether the HMR update lands before or after hydration completes, so heavier apps fail much more often than small ones. This matches an A/B on a real site where 16/20 cold dev runs broke client-side navigation.

## Verification

Against the published `@solidjs/start@2.0.0` with this change patched into `dist`, driving cold dev starts with Playwright (fresh `node_modules/.vite` + fresh server per run):

- before: 3/6 cold loads received a spurious `hot updated: /src/app.tsx` push ~420ms after the first request, with the browser re-importing `app.tsx?t=…` and `solid-start:routes?t=…`
- after: 0/6, across repeated batches
- editing an existing route file still hot-updates just that module; adding a new route file still reloads the manifest and the new route navigates correctly

`pnpm typecheck` and the fs-routes unit tests (28) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)