### PR TITLE
chore: update Solid to 1.9.15

### DIFF
--- a/.changeset/update-solid-1-9-15.md
+++ b/.changeset/update-solid-1-9-15.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/start": patch
+---
+
+Update Solid to 1.9.15 to include the latest lazy loading and hydration fixes

--- a/apps/fixtures/bare-js/package.json
+++ b/apps/fixtures/bare-js/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "engines": {

--- a/apps/fixtures/bare/package.json
+++ b/apps/fixtures/bare/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "engines": {

--- a/apps/fixtures/basic/package.json
+++ b/apps/fixtures/basic/package.json
@@ -11,7 +11,7 @@
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "engines": {

--- a/apps/fixtures/css/package.json
+++ b/apps/fixtures/css/package.json
@@ -12,7 +12,7 @@
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "devDependencies": {

--- a/apps/fixtures/experiments/package.json
+++ b/apps/fixtures/experiments/package.json
@@ -11,7 +11,7 @@
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "engines": {

--- a/apps/fixtures/hackernews/package.json
+++ b/apps/fixtures/hackernews/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5"
   },
   "engines": {

--- a/apps/fixtures/notes/package.json
+++ b/apps/fixtures/notes/package.json
@@ -12,7 +12,7 @@
     "date-fns": "^4.4.0",
     "marked": "^18.0.7",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "unstorage": "1.17.5",
     "vite": "^8.1.5"
   },

--- a/apps/fixtures/todomvc/package.json
+++ b/apps/fixtures/todomvc/package.json
@@ -11,7 +11,7 @@
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "workspace:*",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "unstorage": "1.17.5",
     "vite": "^8.1.5"
   },

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -14,7 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "solid-motionone": "^1.0.4",
     "solid-transition-group": "^0.3.0"
   },

--- a/apps/tests/package.json
+++ b/apps/tests/package.json
@@ -25,7 +25,7 @@
     "jsdom": "^29.1.1",
     "lodash": "^4.18.1",
     "nitro": "^3.0.260610-beta",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "vite": "^8.1.5",
     "vite-plugin-solid": "^2.11.13",
     "vitest": "^4.1.10"

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -75,7 +75,7 @@
     "seroval": "^1.6.0",
     "seroval-plugins": "^1.6.0",
     "shiki": "^4.3.1",
-    "solid-js": "^1.9.14",
+    "solid-js": "^1.9.15",
     "source-map-js": "^1.2.1",
     "srvx": "^0.12.4",
     "terracotta": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -51,8 +51,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -61,10 +61,10 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -72,8 +72,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -82,10 +82,10 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -93,8 +93,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -121,8 +121,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -131,13 +131,13 @@ importers:
     dependencies:
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
@@ -146,7 +146,7 @@ importers:
     dependencies:
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -160,8 +160,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       unstorage:
         specifier: 1.17.5
         version: 1.17.5(db0@0.3.4)(ioredis@5.10.0)
@@ -173,7 +173,7 @@ importers:
     dependencies:
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -181,8 +181,8 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       unstorage:
         specifier: 1.17.5
         version: 1.17.5(db0@0.3.4)(ioredis@5.10.0)
@@ -194,10 +194,10 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../packages/start
@@ -211,21 +211,21 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       solid-motionone:
         specifier: ^1.0.4
-        version: 1.0.4(solid-js@1.9.14)
+        version: 1.0.4(solid-js@1.9.15)
       solid-transition-group:
         specifier: ^0.3.0
-        version: 0.3.0(solid-js@1.9.14)
+        version: 0.3.0(solid-js@1.9.15)
     devDependencies:
       '@kobalte/core':
         specifier: ^0.13.12
-        version: 0.13.12(solid-js@1.9.14)
+        version: 0.13.12(solid-js@1.9.15)
       '@kobalte/utils':
         specifier: ^0.9.2
-        version: 0.9.2(solid-js@1.9.14)
+        version: 0.9.2(solid-js@1.9.15)
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
@@ -252,16 +252,16 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: ^1.0.0
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@solidjs/start':
         specifier: workspace:*
         version: link:../../packages/start
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@1.0.0(solid-js@1.9.14))(solid-js@1.9.14)
+        version: 0.8.10(@solidjs/router@1.0.0(solid-js@1.9.15))(solid-js@1.9.15)
       '@testing-library/jest-dom':
         specifier: ^6.10.0
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -281,14 +281,14 @@ importers:
         specifier: ^3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(ioredis@5.10.0)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
       vite-plugin-solid:
         specifier: ^2.11.13
-        version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
+        version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.15)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
@@ -322,10 +322,10 @@ importers:
         version: 7.29.7
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.9.14)
+        version: 0.29.4(solid-js@1.9.15)
       '@solidjs/router':
         specifier: '>=0.16.0 <2.0.0-0'
-        version: 1.0.0(solid-js@1.9.14)
+        version: 1.0.0(solid-js@1.9.15)
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
@@ -375,8 +375,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       solid-js:
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.9.15
+        version: 1.9.15
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1
@@ -385,10 +385,10 @@ importers:
         version: 0.12.4
       terracotta:
         specifier: ^1.1.1
-        version: 1.1.1(solid-js@1.9.14)
+        version: 1.1.1(solid-js@1.9.15)
       vite-plugin-solid:
         specifier: ^2.11.13
-        version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
+        version: 2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.15)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
     devDependencies:
       '@types/babel__core':
         specifier: ^7.20.5
@@ -2880,8 +2880,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  solid-js@1.9.14:
-    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
+  solid-js@1.9.15:
+    resolution: {integrity: sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==}
 
   solid-motionone@1.0.4:
     resolution: {integrity: sha512-aqEjgecoO9raDFznu/dEci7ORSmA26Kjj9J4Cn1Gyr0GZuOVdvsNxdxClTL9J40Aq/uYFx4GLwC8n70fMLHiuA==}
@@ -3683,10 +3683,10 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@corvu/utils@0.4.2(solid-js@1.9.14)':
+  '@corvu/utils@0.4.2(solid-js@1.9.15)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -3869,27 +3869,27 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kobalte/core@0.13.12(solid-js@1.9.14)':
+  '@kobalte/core@0.13.12(solid-js@1.9.15)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@internationalized/number': 3.6.7
-      '@kobalte/utils': 0.9.2(solid-js@1.9.14)
-      '@solid-primitives/props': 3.2.4(solid-js@1.9.14)
-      '@solid-primitives/resize-observer': 2.2.0(solid-js@1.9.14)
-      solid-js: 1.9.14
-      solid-presence: 0.1.8(solid-js@1.9.14)
-      solid-prevent-scroll: 0.1.10(solid-js@1.9.14)
+      '@kobalte/utils': 0.9.2(solid-js@1.9.15)
+      '@solid-primitives/props': 3.2.4(solid-js@1.9.15)
+      '@solid-primitives/resize-observer': 2.2.0(solid-js@1.9.15)
+      solid-js: 1.9.15
+      solid-presence: 0.1.8(solid-js@1.9.15)
+      solid-prevent-scroll: 0.1.10(solid-js@1.9.15)
 
-  '@kobalte/utils@0.9.2(solid-js@1.9.14)':
+  '@kobalte/utils@0.9.2(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/keyed': 1.5.3(solid-js@1.9.14)
-      '@solid-primitives/map': 0.4.13(solid-js@1.9.14)
-      '@solid-primitives/media': 2.3.6(solid-js@1.9.14)
-      '@solid-primitives/props': 3.2.4(solid-js@1.9.14)
-      '@solid-primitives/refs': 1.1.4(solid-js@1.9.14)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.15)
+      '@solid-primitives/keyed': 1.5.3(solid-js@1.9.15)
+      '@solid-primitives/map': 0.4.13(solid-js@1.9.15)
+      '@solid-primitives/media': 2.3.6(solid-js@1.9.15)
+      '@solid-primitives/props': 3.2.4(solid-js@1.9.15)
+      '@solid-primitives/refs': 1.1.4(solid-js@1.9.15)
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4243,83 +4243,83 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@solid-primitives/event-listener@2.4.6(solid-js@1.9.14)':
+  '@solid-primitives/event-listener@2.4.6(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/keyed@1.5.3(solid-js@1.9.14)':
+  '@solid-primitives/keyed@1.5.3(solid-js@1.9.15)':
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  '@solid-primitives/map@0.4.13(solid-js@1.9.14)':
+  '@solid-primitives/map@0.4.13(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/trigger': 1.2.4(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/trigger': 1.2.4(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/media@2.3.6(solid-js@1.9.14)':
+  '@solid-primitives/media@2.3.6(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
-      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.14)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.15)
+      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.15)
+      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.15)
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/props@3.2.4(solid-js@1.9.14)':
+  '@solid-primitives/props@3.2.4(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/refs@1.1.4(solid-js@1.9.14)':
+  '@solid-primitives/refs@1.1.4(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/resize-observer@2.2.0(solid-js@1.9.14)':
+  '@solid-primitives/resize-observer@2.2.0(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
-      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.14)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.15)
+      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.15)
+      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.15)
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/rootless@1.5.4(solid-js@1.9.14)':
+  '@solid-primitives/rootless@1.5.4(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/static-store@0.1.4(solid-js@1.9.14)':
+  '@solid-primitives/static-store@0.1.4(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/transition-group@1.1.2(solid-js@1.9.14)':
+  '@solid-primitives/transition-group@1.1.2(solid-js@1.9.15)':
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  '@solid-primitives/trigger@1.2.4(solid-js@1.9.14)':
+  '@solid-primitives/trigger@1.2.4(solid-js@1.9.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  '@solid-primitives/utils@6.4.1(solid-js@1.9.14)':
+  '@solid-primitives/utils@6.4.1(solid-js@1.9.15)':
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  '@solidjs/meta@0.29.4(solid-js@1.9.14)':
+  '@solidjs/meta@0.29.4(solid-js@1.9.15)':
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  '@solidjs/router@1.0.0(solid-js@1.9.14)':
+  '@solidjs/router@1.0.0(solid-js@1.9.15)':
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  '@solidjs/testing-library@0.8.10(@solidjs/router@1.0.0(solid-js@1.9.14))(solid-js@1.9.14)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@1.0.0(solid-js@1.9.15))(solid-js@1.9.15)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      solid-js: 1.9.14
+      solid-js: 1.9.15
     optionalDependencies:
-      '@solidjs/router': 1.0.0(solid-js@1.9.14)
+      '@solidjs/router': 1.0.0(solid-js@1.9.15)
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4664,12 +4664,12 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.7)(solid-js@1.9.14):
+  babel-preset-solid@1.9.12(@babel/core@7.29.7)(solid-js@1.9.15):
     dependencies:
       '@babel/core': 7.29.7
       babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.7)
     optionalDependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
   baseline-browser-mapping@2.11.1: {}
 
@@ -5661,50 +5661,50 @@ snapshots:
 
   slash@3.0.0: {}
 
-  solid-js@1.9.14:
+  solid-js@1.9.15:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
 
-  solid-motionone@1.0.4(solid-js@1.9.14):
+  solid-motionone@1.0.4(solid-js@1.9.15):
     dependencies:
       '@motionone/dom': 10.18.0
       '@motionone/utils': 10.18.0
-      '@solid-primitives/props': 3.2.4(solid-js@1.9.14)
-      '@solid-primitives/refs': 1.1.4(solid-js@1.9.14)
-      '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.14)
+      '@solid-primitives/props': 3.2.4(solid-js@1.9.15)
+      '@solid-primitives/refs': 1.1.4(solid-js@1.9.15)
+      '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.15)
       csstype: 3.2.3
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
-  solid-presence@0.1.8(solid-js@1.9.14):
+  solid-presence@0.1.8(solid-js@1.9.15):
     dependencies:
-      '@corvu/utils': 0.4.2(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@corvu/utils': 0.4.2(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  solid-prevent-scroll@0.1.10(solid-js@1.9.14):
+  solid-prevent-scroll@0.1.10(solid-js@1.9.15):
     dependencies:
-      '@corvu/utils': 0.4.2(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@corvu/utils': 0.4.2(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  solid-refresh@0.6.3(solid-js@1.9.14):
+  solid-refresh@0.6.3(solid-js@1.9.15):
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/types': 7.29.7
-      solid-js: 1.9.14
+      solid-js: 1.9.15
     transitivePeerDependencies:
       - supports-color
 
-  solid-transition-group@0.3.0(solid-js@1.9.14):
+  solid-transition-group@0.3.0(solid-js@1.9.15):
     dependencies:
-      '@solid-primitives/refs': 1.1.4(solid-js@1.9.14)
-      '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.14)
-      solid-js: 1.9.14
+      '@solid-primitives/refs': 1.1.4(solid-js@1.9.15)
+      '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.15)
+      solid-js: 1.9.15
 
-  solid-use@0.9.1(solid-js@1.9.14):
+  solid-use@0.9.1(solid-js@1.9.15):
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.15
 
   source-map-js@1.2.1: {}
 
@@ -5768,10 +5768,10 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terracotta@1.1.1(solid-js@1.9.14):
+  terracotta@1.1.1(solid-js@1.9.15):
     dependencies:
-      solid-js: 1.9.14
-      solid-use: 0.9.1(solid-js@1.9.14)
+      solid-js: 1.9.15
+      solid-use: 0.9.1(solid-js@1.9.15)
 
   terser@5.46.0:
     dependencies:
@@ -5920,14 +5920,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)):
+  vite-plugin-solid@2.11.13(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@1.9.15)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.15)
       merge-anything: 5.1.7
-      solid-js: 1.9.14
-      solid-refresh: 0.6.3(solid-js@1.9.14)
+      solid-js: 1.9.15
+      solid-refresh: 0.6.3(solid-js@1.9.15)
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)
       vitefu: 1.1.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0))
     optionalDependencies:


### PR DESCRIPTION
## Summary

- update SolidStart and workspace apps to `solid-js` 1.9.15
- refresh the lockfile to resolve Solid and its peers against 1.9.15
- add a patch changeset for the updated minimum version

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @solidjs/start typecheck`
- `pnpm --filter @solidjs/start test:ci`
- `pnpm --filter @solidjs/start build`
- `pnpm --filter tests build`
- `pnpm --filter tests unit:ci`
- `pnpm --filter tests e2e`
- `pnpm --filter tests e2e:bundled-dev`